### PR TITLE
Fix: DO-1584 label switch not centred vertically

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,9 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `Switch` would not be aligned by default with other components
 ## 1.0.0-a.1
 
 -   Initial release

--- a/packages/dara-components/js/common/switch/switch.tsx
+++ b/packages/dara-components/js/common/switch/switch.tsx
@@ -9,6 +9,7 @@ const _SwitchDiv = styled.div`
     display: flex;
     flex-direction: row;
     align-items: center;
+    margin: 0.5rem 0;
 `;
 const SwitchDiv = injectCss(_SwitchDiv);
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
When `Switch` was used with a horizontal` Label` it did not appear centered by default.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue was due Switch being narrower than all our other interactive components. So that it would behave similarly I have added some margins so that its total height is the same of input and select.

This has been added on Dara instead of Dara-UI as it goes against our components structure. They do not have margins in the design. For Dara for ease of use it makes sense to have the margin, but for other libraries that depend on it, e.g. platform it may not be desirable. 

The down side of this approach is that for vertical labels the spacing might end up being too great, although still would be in line with other components. Users can always override the margin or gap between label if that is not desirable behaviour for them.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running an app locally 
Also by locally running linting and tests

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->