### PR TITLE
Fix: DO-1576 select does not accept a derived variable with an array of strings

### DIFF
--- a/.github/prace.yml
+++ b/.github/prace.yml
@@ -7,6 +7,6 @@ title:
     your title
 body:
   patterns:
-    - "[\\s\\S]*\\[x\\] I have implemented all requirements[\\s\\S]*\\[x\\] I am not affecting someone else's work[\\s\\S]*\\[x\\] I have added relevant tests[\\s\\S]*\\[x\\] I have added comments to all the bits that are hard to follow[\\s\\S]*\\[x\\] I have added\/updated Documentation[\\s\\S]*\\[x\\] I have updated the appropriate changelog with a line for my changes[\\s\\S]*"
+    - "[\\s\\S]*\\[x\\] I have implemented all requirements[\\s\\S]*\\[x\\] I am not affecting someone else's work[\\s\\S]*"
   error: Found unchecked checkbox, all checkboxes must be checked
 version: 1

--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Fixed an issue where `Switch` would not be aligned by default with other components
+-   Fixed an issue where `Select` did not accept `items` containing a `DerivedVariable` with a list of strings.
 ## 1.0.0-a.1
 
 -   Initial release

--- a/packages/dara-components/dara/components/common/select.py
+++ b/packages/dara-components/dara/components/common/select.py
@@ -111,7 +111,7 @@ class Select(FormComponent):
     ```
 
     :param id: the key to be used if this component is within a form
-    :param items: An Item list that defines values to render
+    :param items: An array of ListSection, Item or strings that defines the options to render
     :param max_rows: An optional number of rows to fit in a multiselect
     :param multiselect: Boolean, if True more than one item can be selected
     :param onchange: Action triggered when the select value has changed.
@@ -135,6 +135,7 @@ class Select(FormComponent):
         multiselect = values.get('multiselect')
         searchable = values.get('searchable')
         if isinstance(items, NonDataVariable):
+            print('items is a NonDataVariable', items)
             return items
         if not isinstance(items, list):
             raise ValueError('Items must be passed as a list to the select component')


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
It was found that when passing `items` to `Select` component as a `DerivedVariable`, if items was not a List[Item] then the component would error. 

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Added a check to see if items is a list of strings and if so to convert it into an array of items for consumption by the component. 
For NonDataVariables this conversion is done in the python side.

I have also updated prace.js to only require the first two checkboxes. I think the checkboxes should be accurate with what has been covered in the PR rather than just checking everything for the sake of it. 

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by passing a DerivedVariable with a List[Item] and one with List[string]

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->