### PR TITLE
Fix: DO-1658 prefix zipped docs files with __docs/

### DIFF
--- a/tooling/scripts/docs-upload.py
+++ b/tooling/scripts/docs-upload.py
@@ -32,7 +32,7 @@ with ZipFile('docs.zip', 'w') as archive:
     for file_path in directory.rglob("*"):
         archive.write(
             file_path,
-            arcname=file_path.relative_to(directory)
+            arcname=directory.name / file_path.relative_to(directory)
         )
 
 # Upload to Artifactory


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

The zip format expected by our docs system includes a top-level `__docs` folder within the zip. The previous implementation here included just the `__docs` contents instead.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

The zipping script now prefixes each file with `__docs/` which makes it include a `__docs` folder within the zip.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By running the script locally, verifying the resulting structure

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->

See contents of the zip now including a __docs folder:
![Screenshot 2023-08-15 at 09 48 12](https://github.com/causalens/dara/assets/87647189/fa02323d-67ff-4c28-b06e-c930d3201013)
