### PR TITLE
Feat: DO-1708 Expose DynamicComponent as a class

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,6 +4,20 @@ title: Changelog
 
 ## NEXT
 
+-   Exposed `DynamicComponent` as a Python class. Normally used under-the-hood by `@darajs/core` to render dynamic components, it can now be used directly in advanced use cases to serialize components and render them dynamically.
+
+```python
+from dara.core.visual.components import DynamicComponent
+from dara.components import Text, DerivedVariable
+
+derived_text = DerivedVariable(lambda: 'Hello World', variables=[])
+text_cmp = Text(text=derived_text).dict()
+
+config.add_page(name='Dynamic Render', content=DynamicComponent(component=text_cmp))
+```
+
+## 1.1.0
+
 -   Internal asset build system refactor, the generated build cache file now stores complete information required to run an asset build.
 -   Fixed an issue where static assets were only being copied once when the output (e.g. `dist`) folder is created. They are now copied over at each server start.
 -   Static assets are no longer copied over to the `static` folder before being copied into the output folder. The migration process now copies assets from each static folder directly into the output folder in the order the static folders were added.

--- a/packages/dara-core/dara/core/defaults.py
+++ b/packages/dara-core/dara/core/defaults.py
@@ -45,6 +45,8 @@ from dara.core.interactivity.actions import (
 from dara.core.internal.store import Store
 from dara.core.visual.components import (
     DefaultFallbackDef,
+    DynamicComponent,
+    DynamicComponentDef,
     Fallback,
     For,
     ForDef,
@@ -74,6 +76,7 @@ INITIAL_CORE_INTERNALS = {'Store': _store}
 
 # These components are provided by the core JS of this module
 CORE_COMPONENTS: Dict[str, ComponentTypeAnnotation] = {
+    DynamicComponent.__name__: DynamicComponentDef,
     Menu.__name__: MenuDef,
     ProgressTracker.__name__: ProgressTrackerDef,
     RouterContent.__name__: RouterContentDef,

--- a/packages/dara-core/dara/core/visual/components/__init__.py
+++ b/packages/dara-core/dara/core/visual/components/__init__.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+from dara.core.visual.components.dynamic_component import DynamicComponent, DynamicComponentDef
 from dara.core.visual.components.fallback import (
     DefaultFallbackDef,
     Fallback,
@@ -33,6 +33,8 @@ from dara.core.visual.components.sidebar_frame import SideBarFrame, SideBarFrame
 from dara.core.visual.components.topbar_frame import TopBarFrame, TopBarFrameDef
 
 __all__ = [
+    'DynamicComponent',
+    'DynamicComponentDef',
     'InvalidComponent',
     'ProgressTracker',
     'ProgressTrackerDef',

--- a/packages/dara-core/dara/core/visual/components/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/components/dynamic_component.py
@@ -1,0 +1,14 @@
+from typing import Union
+from dara.core.definitions import ComponentInstance, JsComponentDef
+
+DynamicComponentDef = JsComponentDef(name='DynamicComponent', js_module='@darajs/core', py_module='dara.core')
+
+class DynamicComponent(ComponentInstance):
+    """
+    DynamicComponent allows dynamically rendering an arbitrary Dara component. It is used under the hood
+    to recursively render Dara components on each page. It can be used directly in advanced use cases where a component can be
+    serialized and passed around as a dictionary.
+
+    :param component: A Dara component instance or a dictionary representing a Dara component.
+    """
+    component: Union[ComponentInstance, dict]


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Exposed `DynamicComponent` as a Python class. Normally it is used under-the-hood by `@darajs/core` to render component trees. It can now be used directly in advanced use cases to serialize components and render them dynamically.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Note that using DynamicComponent in this way under the hood ends up rendering two instance of DynamicComponent (since it is used to resolve DynamicComponent itself first).

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a local app

```python

select = Select(items=DerivedVariable(...), value=...).dict()


config.add_page(name='dynamic render', content=DynamicComponent(component=select))

```

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->