### PR TITLE
Fix: DO-1724 `copy_js` param in `bundle_js` not working properly

### DIFF
--- a/packages/dara-core/dara/core/js_tooling/js_utils.py
+++ b/packages/dara-core/dara/core/js_tooling/js_utils.py
@@ -462,7 +462,11 @@ def bundle_js(build_cache: BuildCache, copy_js: bool = False):
         if os.path.isdir(build_cache.build_config.js_config.local_entry):
             if copy_js:
                 # Just move the directory to output
-                shutil.copytree(build_cache.build_config.js_config.local_entry, build_cache.static_files_dir)
+                js_folder_name = os.path.basename(build_cache.build_config.js_config.local_entry)
+                shutil.copytree(
+                    build_cache.build_config.js_config.local_entry,
+                    os.path.join(build_cache.static_files_dir, js_folder_name)
+                )
             else:
                 build_cache.symlink_js()
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Issue discovered when attempting to bundle JS in a project with custom JS. The `copy_js` option would copy contents of a local JS folder directly into the output folder, rather than placing them in a folder with the original name. E.g.

```
- project_name/
- js/
  - my_file.tsx
- output_folder/
  - my_file.tsx
```

whereas correct behaviour should be

```
- project_name/
- js/
  - my_file.tsx
- output_folder/
  - js/
    - my_file.tsx
```

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Fixed by appending the original directory basename to the destination path.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a local project

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->