### PR TITLE
Feat: DO-1543 Support to lookup entry in external registry 

### DIFF
--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -42,6 +42,7 @@ from dara.core.internal.import_discovery import (
     create_component_definition,
     run_discovery,
 )
+from dara.core.internal.registry_lookup import CustomRegistryLookup
 from dara.core.internal.scheduler import ScheduledJob, ScheduledJobFactory
 from dara.core.logging import dev_logger
 from dara.core.visual.components import RawString
@@ -52,7 +53,7 @@ class Configuration(GenericModel):
     """Definition of the main framework configuration"""
 
     auth_config: BaseAuthConfig
-    registry_lookup: Dict[str, Callable]
+    registry_lookup: CustomRegistryLookup
     actions: List[ActionDef]
     endpoint_configurations: List[EndpointConfiguration]
     components: List[ComponentTypeAnnotation]

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -110,7 +110,7 @@ class ConfigurationBuilder:
     """
 
     auth_config: BaseAuthConfig
-    registry_lookup: Dict[str, Callable]
+    registry_lookup: CustomRegistryLookup
     _actions: List[ActionDef]
     _components: List[ComponentTypeAnnotation]
     _errors: List[str]
@@ -371,7 +371,7 @@ class ConfigurationBuilder:
 
         return auth
 
-    def add_registry_lookup(self, registry_lookup: Dict[str, Callable[[str], Coroutine]]):
+    def add_registry_lookup(self, registry_lookup: CustomRegistryLookup):
         """
         Register custom external registry lookup handlers, which will be called when a uid its not in the server registry
         Example:

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -18,7 +18,7 @@ limitations under the License.
 import os
 import pathlib
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, Coroutine, Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
 from pydantic.generics import GenericModel
 
@@ -370,7 +370,28 @@ class ConfigurationBuilder:
 
         return auth
 
-    def add_registry_lookup(self, registry_lookup: Dict):
+    def add_registry_lookup(self, registry_lookup: Dict[str, Callable[[str], Coroutine]]):
+        """
+        Register custom external registry lookup handlers, which will be called when a uid its not in the server registry
+        Example:
+
+        ```python
+        from dara.core import ConfigurationBuilder
+        config = ConfigurationBuilder()
+
+        def get_derived_variable(uid)-> DerivedVariableRegistryEntry:
+            # return derived variable
+
+        def get_action(uid)-> Callable:
+            # return action
+
+        config.add_registry_lookup(
+                    {
+                        'DerivedVariable': get_derived_variable,
+                        'Action Handler': get_action,
+                    }
+                )
+        """
         self.registry_lookup = registry_lookup
 
         return registry_lookup

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -18,7 +18,7 @@ limitations under the License.
 import os
 import pathlib
 from types import ModuleType
-from typing import Any, Callable, Coroutine, Dict, List, Literal, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
 from pydantic.generics import GenericModel
 

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -52,6 +52,7 @@ class Configuration(GenericModel):
     """Definition of the main framework configuration"""
 
     auth_config: BaseAuthConfig
+    registry_lookup: Dict[str, Callable]
     actions: List[ActionDef]
     endpoint_configurations: List[EndpointConfiguration]
     components: List[ComponentTypeAnnotation]
@@ -108,6 +109,7 @@ class ConfigurationBuilder:
     """
 
     auth_config: BaseAuthConfig
+    registry_lookup: Dict[str, Callable]
     _actions: List[ActionDef]
     _components: List[ComponentTypeAnnotation]
     _errors: List[str]
@@ -132,6 +134,7 @@ class ConfigurationBuilder:
 
     def __init__(self):
         self.auth_config = DefaultAuthConfig()
+        self.registry_lookup = {}
         self._actions = []
         self._components = []
         self._errors = []
@@ -367,6 +370,11 @@ class ConfigurationBuilder:
 
         return auth
 
+    def add_registry_lookup(self, registry_lookup: Dict):
+        self.registry_lookup = registry_lookup
+
+        return registry_lookup
+
     def set_theme(
         self,
         main_theme: Optional[Union[ThemeDef, Literal['light'], Literal['dark']]] = None,
@@ -435,6 +443,7 @@ class ConfigurationBuilder:
         return Configuration(
             actions=self._actions,
             auth_config=self.auth_config,
+            registry_lookup = self.registry_lookup,
             components=self._components,
             context_components=self.context_components,
             endpoint_configurations=self._endpoint_configurations,

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -443,7 +443,7 @@ class ConfigurationBuilder:
         return Configuration(
             actions=self._actions,
             auth_config=self.auth_config,
-            registry_lookup = self.registry_lookup,
+            registry_lookup=self.registry_lookup,
             components=self._components,
             context_components=self.context_components,
             endpoint_configurations=self._endpoint_configurations,

--- a/packages/dara-core/dara/core/definitions.py
+++ b/packages/dara-core/dara/core/definitions.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 from __future__ import annotations
 
+import json
 import uuid
 from enum import Enum
 from typing import (
@@ -204,6 +205,9 @@ class ComponentInstance(DaraBaseModel):
             kwargs = {**kwargs, 'uid': uid}
 
         super().__init__(*args, **kwargs)
+
+    def __repr__(self):
+        return '__dara__' + json.dumps(self.dict())
 
     @validator('raw_css', pre=True)
     @classmethod

--- a/packages/dara-core/dara/core/interactivity/actions.py
+++ b/packages/dara-core/dara/core/interactivity/actions.py
@@ -36,6 +36,7 @@ from pydantic import BaseModel
 from dara.core.base_definitions import ActionDef, ActionInstance, TemplateMarker
 from dara.core.interactivity.data_variable import DataVariable
 from dara.core.internal.download import generate_download_code
+from dara.core.internal.registry_lookup import RegistryLookup
 from dara.core.internal.utils import run_user_handler
 
 # Type-only imports
@@ -311,10 +312,11 @@ class UpdateVariable(ActionInstance):
                 utils_registry,
             )
 
-            var_entry = data_variable_registry.get(str(variable.uid))
+            registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
             store = utils_registry.get('Store')
 
             async def data_resolver(ctx):
+                var_entry = await registry_mgr.get(data_variable_registry, str(variable.uid))
                 resolved_value = await run_user_handler(resolver, (ctx,))
                 DataVariable.update_value(var_entry, store, resolved_value)
 

--- a/packages/dara-core/dara/core/internal/dependency_resolution.py
+++ b/packages/dara-core/dara/core/internal/dependency_resolution.py
@@ -22,9 +22,10 @@ from typing_extensions import TypeGuard
 from dara.core.interactivity import DataVariable, DerivedDataVariable, DerivedVariable
 from dara.core.interactivity.filtering import FilterQuery
 from dara.core.internal.pandas_utils import remove_index
+from dara.core.internal.registry_lookup import RegistryLookup
 from dara.core.internal.store import Store
 from dara.core.internal.tasks import TaskManager
-from dara.core.internal.registry_lookup import RegistryLookup
+
 
 class ResolvedDerivedVariable(TypedDict):
     deps: List[int]
@@ -97,11 +98,11 @@ async def _resolve_derived_data_var(entry: ResolvedDerivedDataVariable, store: S
     from dara.core.internal.registries import (
         data_variable_registry,
         derived_variable_registry,
-        utils_registry
+        utils_registry,
     )
 
     registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-    dv_var = await registry_mgr.get(derived_variable_registry,str(entry.get('uid')))
+    dv_var = await registry_mgr.get(derived_variable_registry, str(entry.get('uid')))
     data_var = data_variable_registry.get(str(entry.get('uid')))
 
     input_values: List[Any] = entry.get('values', [])
@@ -121,10 +122,10 @@ async def _resolve_derived_var(derived_variable_entry: ResolvedDerivedVariable, 
     :param store: store instance to use for caching
     :param task_mgr: task manager instance
     """
-    from dara.core.internal.registries import utils_registry,derived_variable_registry
+    from dara.core.internal.registries import derived_variable_registry, utils_registry
 
     registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-    var = await registry_mgr.get(derived_variable_registry,str(derived_variable_entry.get('uid')))
+    var = await registry_mgr.get(derived_variable_registry, str(derived_variable_entry.get('uid')))
     input_values: List[Any] = derived_variable_entry.get('values', [])
     result = await DerivedVariable.get_value(
         var, store, task_mgr, input_values, derived_variable_entry.get('force', False)

--- a/packages/dara-core/dara/core/internal/dependency_resolution.py
+++ b/packages/dara-core/dara/core/internal/dependency_resolution.py
@@ -24,7 +24,7 @@ from dara.core.interactivity.filtering import FilterQuery
 from dara.core.internal.pandas_utils import remove_index
 from dara.core.internal.store import Store
 from dara.core.internal.tasks import TaskManager
-
+from dara.core.internal.registry_lookup import RegistryLookup
 
 class ResolvedDerivedVariable(TypedDict):
     deps: List[int]
@@ -97,9 +97,11 @@ async def _resolve_derived_data_var(entry: ResolvedDerivedDataVariable, store: S
     from dara.core.internal.registries import (
         data_variable_registry,
         derived_variable_registry,
+        utils_registry
     )
 
-    dv_var = derived_variable_registry.get(str(entry.get('uid')))
+    registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+    dv_var = await registry_mgr.get(derived_variable_registry,str(entry.get('uid')))
     data_var = data_variable_registry.get(str(entry.get('uid')))
 
     input_values: List[Any] = entry.get('values', [])
@@ -119,9 +121,10 @@ async def _resolve_derived_var(derived_variable_entry: ResolvedDerivedVariable, 
     :param store: store instance to use for caching
     :param task_mgr: task manager instance
     """
-    from dara.core.internal.registries import derived_variable_registry
+    from dara.core.internal.registries import utils_registry,derived_variable_registry
 
-    var = derived_variable_registry.get(str(derived_variable_entry.get('uid')))
+    registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+    var = await registry_mgr.get(derived_variable_registry,str(derived_variable_entry.get('uid')))
     input_values: List[Any] = derived_variable_entry.get('values', [])
     result = await DerivedVariable.get_value(
         var, store, task_mgr, input_values, derived_variable_entry.get('force', False)

--- a/packages/dara-core/dara/core/internal/dependency_resolution.py
+++ b/packages/dara-core/dara/core/internal/dependency_resolution.py
@@ -141,9 +141,9 @@ async def _resolve_data_var(data_variable_entry: ResolvedDataVariable, store: St
     :param data_variable_entry: data var entry
     :param store: the store instance to use for caching
     """
-    from dara.core.internal.registries import data_variable_registry,utils_registry
+    from dara.core.internal.registries import data_variable_registry, utils_registry
 
     registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-    var = await registry_mgr.get(data_variable_registry,str(data_variable_entry.get('uid')))
+    var = await registry_mgr.get(data_variable_registry, str(data_variable_entry.get('uid')))
     result = DataVariable.get_value(var, store, data_variable_entry.get('filters', None))
     return remove_index(result)

--- a/packages/dara-core/dara/core/internal/dependency_resolution.py
+++ b/packages/dara-core/dara/core/internal/dependency_resolution.py
@@ -82,7 +82,7 @@ async def resolve_dependency(
         return await _resolve_derived_var(entry, store, task_mgr)
 
     if is_resolved_data_variable(entry):
-        return _resolve_data_var(entry, store)
+        return await _resolve_data_var(entry, store)
 
     return entry
 
@@ -103,7 +103,7 @@ async def _resolve_derived_data_var(entry: ResolvedDerivedDataVariable, store: S
 
     registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
     dv_var = await registry_mgr.get(derived_variable_registry, str(entry.get('uid')))
-    data_var = data_variable_registry.get(str(entry.get('uid')))
+    data_var = await registry_mgr.get(data_variable_registry, str(entry.get('uid')))
 
     input_values: List[Any] = entry.get('values', [])
 
@@ -133,7 +133,7 @@ async def _resolve_derived_var(derived_variable_entry: ResolvedDerivedVariable, 
     return result['value']
 
 
-def _resolve_data_var(data_variable_entry: ResolvedDataVariable, store: Store):
+async def _resolve_data_var(data_variable_entry: ResolvedDataVariable, store: Store):
     """
     Resolve a data variable from the registry and get it's new value based on the dynamic variable mapping passed
     in.
@@ -141,8 +141,9 @@ def _resolve_data_var(data_variable_entry: ResolvedDataVariable, store: Store):
     :param data_variable_entry: data var entry
     :param store: the store instance to use for caching
     """
-    from dara.core.internal.registries import data_variable_registry
+    from dara.core.internal.registries import data_variable_registry,utils_registry
 
-    var = data_variable_registry.get(str(data_variable_entry.get('uid')))
+    registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+    var = await registry_mgr.get(data_variable_registry,str(data_variable_entry.get('uid')))
     result = DataVariable.get_value(var, store, data_variable_entry.get('filters', None))
     return remove_index(result)

--- a/packages/dara-core/dara/core/internal/registries.py
+++ b/packages/dara-core/dara/core/internal/registries.py
@@ -31,29 +31,29 @@ from dara.core.interactivity.derived_variable import (
     DerivedVariableRegistryEntry,
     LatestValueRegistryEntry,
 )
-from dara.core.internal.registry import Registry
+from dara.core.internal.registry import Registry, RegistryType
 from dara.core.internal.websocket import CustomClientMessagePayload
 
-action_def_registry = Registry[ActionDef]('Action Definition', CORE_ACTIONS)   # all registered actions
-action_registry = Registry[Callable[..., Any]]('Action Handler')   # functions for actions requiring backend calls
-component_registry = Registry[ComponentTypeAnnotation]('Components', CORE_COMPONENTS)
-config_registry = Registry[EndpointConfiguration]('Endpoint Configuration')
-data_variable_registry = Registry[DataVariableRegistryEntry]('DataVariable', allow_duplicates=False)
-derived_variable_registry = Registry[DerivedVariableRegistryEntry]('DerivedVariable', allow_duplicates=False)
-latest_value_registry = Registry[LatestValueRegistryEntry]('LatestValue', allow_duplicates=False)
-template_registry = Registry[Template]('Template')
-auth_registry = Registry[BaseAuthConfig]('Auth Config')
-utils_registry = Registry[Any]('Utils', INITIAL_CORE_INTERNALS)
-static_kwargs_registry = Registry[Mapping[str, Any]]('Static kwargs')
+action_def_registry = Registry[ActionDef](RegistryType.ACTION_DEF, CORE_ACTIONS)   # all registered actions
+action_registry = Registry[Callable[..., Any]](RegistryType.ACTION)   # functions for actions requiring backend calls
+component_registry = Registry[ComponentTypeAnnotation](RegistryType.COMPONENTS, CORE_COMPONENTS)
+config_registry = Registry[EndpointConfiguration](RegistryType.ENDPOINT_CONFIG)
+data_variable_registry = Registry[DataVariableRegistryEntry](RegistryType.DATA_VARIABLE, allow_duplicates=False)
+derived_variable_registry = Registry[DerivedVariableRegistryEntry](RegistryType.DERIVED_VARIABLE, allow_duplicates=False)
+latest_value_registry = Registry[LatestValueRegistryEntry](RegistryType.LAST_VALUE, allow_duplicates=False)
+template_registry = Registry[Template](RegistryType.TEMPLATE)
+auth_registry = Registry[BaseAuthConfig](RegistryType.AUTH_CONFIG)
+utils_registry = Registry[Any](RegistryType.UTILS, INITIAL_CORE_INTERNALS)
+static_kwargs_registry = Registry[Mapping[str, Any]](RegistryType.STATIC_KWARGS)
 
-websocket_registry = Registry[str]('Websocket Channels')
+websocket_registry = Registry[str](RegistryType.WEBSOCKET_CHANNELS)
 """maps session_id -> WS channel"""
 
-sessions_registry = Registry[Set[str]]('User session')
+sessions_registry = Registry[Set[str]](RegistryType.USER_SESSION)
 """maps user_identifier -> session_ids """
 
-pending_tokens_registry = Registry[datetime]('Pending tokens')
+pending_tokens_registry = Registry[datetime](RegistryType.PENDING_TOKENS)
 """map of token -> expiry, for tokens pending connection"""
 
-custom_ws_handlers_registry = Registry[Callable[[str, CustomClientMessagePayload], Any]]('Custom WS handlers')
+custom_ws_handlers_registry = Registry[Callable[[str, CustomClientMessagePayload], Any]](RegistryType.CUSTOM_WS_HANDLERS)
 """map of custom kind name -> handler function(channel: str, message: CustomClientMessagePayload)"""

--- a/packages/dara-core/dara/core/internal/registries.py
+++ b/packages/dara-core/dara/core/internal/registries.py
@@ -39,7 +39,9 @@ action_registry = Registry[Callable[..., Any]](RegistryType.ACTION)   # function
 component_registry = Registry[ComponentTypeAnnotation](RegistryType.COMPONENTS, CORE_COMPONENTS)
 config_registry = Registry[EndpointConfiguration](RegistryType.ENDPOINT_CONFIG)
 data_variable_registry = Registry[DataVariableRegistryEntry](RegistryType.DATA_VARIABLE, allow_duplicates=False)
-derived_variable_registry = Registry[DerivedVariableRegistryEntry](RegistryType.DERIVED_VARIABLE, allow_duplicates=False)
+derived_variable_registry = Registry[DerivedVariableRegistryEntry](
+    RegistryType.DERIVED_VARIABLE, allow_duplicates=False
+)
 latest_value_registry = Registry[LatestValueRegistryEntry](RegistryType.LAST_VALUE, allow_duplicates=False)
 template_registry = Registry[Template](RegistryType.TEMPLATE)
 auth_registry = Registry[BaseAuthConfig](RegistryType.AUTH_CONFIG)
@@ -55,5 +57,7 @@ sessions_registry = Registry[Set[str]](RegistryType.USER_SESSION)
 pending_tokens_registry = Registry[datetime](RegistryType.PENDING_TOKENS)
 """map of token -> expiry, for tokens pending connection"""
 
-custom_ws_handlers_registry = Registry[Callable[[str, CustomClientMessagePayload], Any]](RegistryType.CUSTOM_WS_HANDLERS)
+custom_ws_handlers_registry = Registry[Callable[[str, CustomClientMessagePayload], Any]](
+    RegistryType.CUSTOM_WS_HANDLERS
+)
 """map of custom kind name -> handler function(channel: str, message: CustomClientMessagePayload)"""

--- a/packages/dara-core/dara/core/internal/registry.py
+++ b/packages/dara-core/dara/core/internal/registry.py
@@ -23,6 +23,7 @@ from dara.core.metrics import CACHE_METRICS_TRACKER, total_size
 
 T = TypeVar('T')
 
+
 class RegistryType(str, Enum):
     ACTION_DEF = 'Action Definition'
     ACTION = 'Action Handler'
@@ -39,6 +40,7 @@ class RegistryType(str, Enum):
     USER_SESSION = 'User session'
     PENDING_TOKENS = 'Pending tokens'
     CUSTOM_WS_HANDLERS = 'Custom WS handlers'
+
 
 class Registry(Generic[T]):
     """

--- a/packages/dara-core/dara/core/internal/registry.py
+++ b/packages/dara-core/dara/core/internal/registry.py
@@ -16,12 +16,29 @@ limitations under the License.
 """
 
 import copy
+from enum import Enum
 from typing import Generic, MutableMapping, Optional, TypeVar
 
 from dara.core.metrics import CACHE_METRICS_TRACKER, total_size
 
 T = TypeVar('T')
 
+class RegistryType(str, Enum):
+    ACTION_DEF = 'Action Definition'
+    ACTION = 'Action Handler'
+    COMPONENTS = 'Components'
+    ENDPOINT_CONFIG = 'Endpoint Configuration'
+    DATA_VARIABLE = 'DataVariable'
+    DERIVED_VARIABLE = 'DerivedVariable'
+    LAST_VALUE = 'LatestValue'
+    TEMPLATE = 'Template'
+    AUTH_CONFIG = 'Auth Config'
+    UTILS = 'Utils'
+    STATIC_KWARGS = 'Static kwargs'
+    WEBSOCKET_CHANNELS = 'Websocket Channels'
+    USER_SESSION = 'User session'
+    PENDING_TOKENS = 'Pending tokens'
+    CUSTOM_WS_HANDLERS = 'Custom WS handlers'
 
 class Registry(Generic[T]):
     """
@@ -32,7 +49,7 @@ class Registry(Generic[T]):
 
     def __init__(
         self,
-        name: str,
+        name: RegistryType,
         initial_registry: Optional[MutableMapping[str, T]] = None,
         allow_duplicates: Optional[bool] = True,
     ):

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -19,15 +19,22 @@ from typing import Callable, Coroutine, Dict, Literal
 
 from dara.core.internal.registry import Registry, RegistryType
 
-RegistryLookupKey = Literal[RegistryType.ACTION, RegistryType.COMPONENTS, RegistryType.DATA_VARIABLE, RegistryType.DERIVED_VARIABLE, RegistryType.STATIC_KWARGS]
-CustomRegistryLookup = Dict[RegistryLookupKey, Callable[[str],Coroutine]]
+RegistryLookupKey = Literal[
+    RegistryType.ACTION,
+    RegistryType.COMPONENTS,
+    RegistryType.DATA_VARIABLE,
+    RegistryType.DERIVED_VARIABLE,
+    RegistryType.STATIC_KWARGS,
+]
+CustomRegistryLookup = Dict[RegistryLookupKey, Callable[[str], Coroutine]]
+
 
 class RegistryLookup:
     """
     Manages registry Lookup.
     """
 
-    def __init__(self, handlers:CustomRegistryLookup={}):
+    def __init__(self, handlers: CustomRegistryLookup = {}):
         self.handlers = handlers
 
     async def get(self, registry: Registry, uid: str):

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional,Dict
+from typing import Dict, Optional
 
 from dara.core.internal.registry import Registry
 
@@ -24,17 +24,18 @@ class RegistryLookup:
     """
     Manages registry Lookup.
     """
-    def __init__(self,handlers:Optional[Dict]={}):
+
+    def __init__(self, handlers: Optional[Dict] = {}):
         self.handlers = handlers
 
-    async def get(self,registry:Registry,uid:str):
+    async def get(self, registry: Registry, uid: str):
         try:
             return registry.get(uid)
         except KeyError as e:
             if registry.name in self.handlers:
                 func = self.handlers[registry.name]
                 entry = await func(uid)
-                registry.register(uid,entry)
+                registry.register(uid, entry)
                 return entry
             raise ValueError(
                 f'Could not find uid {uid} in {registry.name} registry, did you register it before the app was initialized?'

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -1,0 +1,41 @@
+"""
+Copyright 2023 Impulse Innovations Limited
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Optional,Dict
+
+from dara.core.internal.registry import Registry
+
+
+class RegistryLookup:
+    """
+    Manages registry Lookup.
+    """
+    def __init__(self,handlers:Optional[Dict]={}):
+        self.handlers = handlers
+
+    async def get(self,registry:Registry,uid:str):
+        try:
+            return registry.get(uid)
+        except KeyError as e:
+            if registry.name in self.handlers:
+                func = self.handlers[registry.name]
+                entry = await func(uid)
+                registry.register(uid,entry)
+                return entry
+            raise ValueError(
+                f'Could not find uid {uid} in {registry.name} registry, did you register it before the app was initialized?'
+            ).with_traceback(e.__traceback__)

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 from dara.core.internal.registry import Registry
 
@@ -25,7 +25,7 @@ class RegistryLookup:
     Manages registry Lookup.
     """
 
-    def __init__(self, handlers: Optional[Dict] = {}):
+    def __init__(self, handlers: Dict[str,Callable]={}):
         self.handlers = handlers
 
     async def get(self, registry: Registry, uid: str):

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Callable, Dict
+from typing import Callable, Coroutine, Dict
 
 from dara.core.internal.registry import Registry
 
@@ -25,10 +25,17 @@ class RegistryLookup:
     Manages registry Lookup.
     """
 
-    def __init__(self, handlers: Dict[str,Callable]={}):
+    def __init__(self, handlers: Dict[str,Callable[[str],Coroutine]]={}):
         self.handlers = handlers
 
     async def get(self, registry: Registry, uid: str):
+        """
+        Get the entry from registry by uid.
+        If uid is not in registry and it has a external handler that defined, will execute the handler
+
+        :param registry: target registry
+        :param uid: entry id
+        """
         try:
             return registry.get(uid)
         except KeyError as e:

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -15,17 +15,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Callable, Coroutine, Dict
+from typing import Callable, Coroutine, Dict, Literal
 
-from dara.core.internal.registry import Registry
+from dara.core.internal.registry import Registry, RegistryType
 
+RegistryLookupKey = Literal[RegistryType.ACTION, RegistryType.COMPONENTS, RegistryType.DATA_VARIABLE, RegistryType.DERIVED_VARIABLE, RegistryType.STATIC_KWARGS]
+CustomRegistryLookup = Dict[RegistryLookupKey, Callable[[str],Coroutine]]
 
 class RegistryLookup:
     """
     Manages registry Lookup.
     """
 
-    def __init__(self, handlers: Dict[str,Callable[[str],Coroutine]]={}):
+    def __init__(self, handlers:CustomRegistryLookup={}):
         self.handlers = handlers
 
     async def get(self, registry: Registry, uid: str):
@@ -40,7 +42,7 @@ class RegistryLookup:
             return registry.get(uid)
         except KeyError as e:
             if registry.name in self.handlers:
-                func = self.handlers[registry.name]
+                func = self.handlers[registry.name]  # type: ignore
                 entry = await func(uid)
                 registry.register(uid, entry)
                 return entry

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict
 
 from dara.core.internal.registry import Registry
 

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -118,7 +118,7 @@ def create_router(config: Configuration):
         store: Store = utils_registry.get('Store')
         task_mgr: TaskManager = utils_registry.get('TaskManager')
         registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-        action = await registry_mgr.get(action_registry,uid)
+        action = await registry_mgr.get(action_registry, uid)
         extras = None
 
         # If extras was provided, it was normalized
@@ -183,10 +183,10 @@ def create_router(config: Configuration):
         store: Store = utils_registry.get('Store')
         task_mgr: TaskManager = utils_registry.get('TaskManager')
         registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-        comp = await registry_mgr.get(component_registry,component)
+        comp = await registry_mgr.get(component_registry, component)
 
         if isinstance(comp, PyComponentDef):
-            static_kwargs = await registry_mgr.get(static_kwargs_registry,body.uid)
+            static_kwargs = await registry_mgr.get(static_kwargs_registry, body.uid)
             values = denormalize(body.values.data, body.values.lookup)
 
             response = await render_component(comp, store, task_mgr, values, static_kwargs)
@@ -376,7 +376,7 @@ def create_router(config: Configuration):
         task_mgr: TaskManager = utils_registry.get('TaskManager')
         store: Store = utils_registry.get('Store')
         registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-        variable = await registry_mgr.get(derived_variable_registry,uid)
+        variable = await registry_mgr.get(derived_variable_registry, uid)
 
         values = denormalize(body.values.data, body.values.lookup)
 

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -167,7 +167,17 @@ def create_router(config: Configuration):
         return config.auth_config.component_config
 
     @core_api_router.get('/components', dependencies=[Depends(verify_session)])
-    async def get_components():  # pylint: disable=unused-variable
+    async def get_components(name: Optional[str]=None):  # pylint: disable=unused-variable
+        """
+        If name is passed, will only return the specific component
+
+        :param name: the name of component
+        """
+        if name is not None:
+            registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+            comp = await registry_mgr.get(component_registry, name)
+            return {'name': comp.dict(exclude={'func'})}
+
         return {k: comp.dict(exclude={'func'}) for k, comp in component_registry.get_all().items()}
 
     class ComponentRequestBody(BaseModel):

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -167,7 +167,7 @@ def create_router(config: Configuration):
         return config.auth_config.component_config
 
     @core_api_router.get('/components', dependencies=[Depends(verify_session)])
-    async def get_components(name: Optional[str]=None):  # pylint: disable=unused-variable
+    async def get_components(name: Optional[str] = None):  # pylint: disable=unused-variable
         """
         If name is passed, will try to register the component
 

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -169,14 +169,13 @@ def create_router(config: Configuration):
     @core_api_router.get('/components', dependencies=[Depends(verify_session)])
     async def get_components(name: Optional[str]=None):  # pylint: disable=unused-variable
         """
-        If name is passed, will only return the specific component
+        If name is passed, will try to register the component
 
         :param name: the name of component
         """
         if name is not None:
             registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-            comp = await registry_mgr.get(component_registry, name)
-            return {'name': comp.dict(exclude={'func'})}
+            await registry_mgr.get(component_registry, name)
 
         return {k: comp.dict(exclude={'func'}) for k, comp in component_registry.get_all().items()}
 
@@ -254,7 +253,8 @@ def create_router(config: Configuration):
         try:
             store: Store = utils_registry.get('Store')
             task_mgr: TaskManager = utils_registry.get('TaskManager')
-            variable = data_variable_registry.get(uid)
+            registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+            variable = await registry_mgr.get(data_variable_registry, uid)
 
             data = None
 
@@ -305,7 +305,8 @@ def create_router(config: Configuration):
     async def get_data_variable_count(uid: str, body: Optional[DataVariableCountRequestBody] = None):
         try:
             store: Store = utils_registry.get('Store')
-            variable = data_variable_registry.get(uid)
+            registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+            variable = await registry_mgr.get(data_variable_registry, uid)
 
             if variable.type == 'plain':
                 return DataVariable.get_total_count(variable, store, body.filters if body is not None else None)
@@ -344,7 +345,8 @@ def create_router(config: Configuration):
 
             if data_uid is not None:
                 try:
-                    variable = data_variable_registry.get(data_uid)
+                    registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+                    variable = await registry_mgr.get(data_variable_registry, data_uid)
                 except KeyError:
                     raise ValueError(f'Data Variable {data_uid} does not exist')
 

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -54,6 +54,7 @@ from dara.core.internal.registries import (
     utils_registry,
     websocket_registry,
 )
+from dara.core.internal.registry_lookup import RegistryLookup
 from dara.core.internal.routing import create_router, error_decorator
 from dara.core.internal.settings import get_settings
 from dara.core.internal.store import Store
@@ -122,6 +123,7 @@ def _start_application(config: Configuration):
         # Store must exist before the app starts as instantiating e.g. Variables
         # requires a store existing
         store: Store = utils_registry.get('Store')
+        utils_registry.set('RegistryLookup', RegistryLookup(config.registry_lookup))
 
         # Create a task group for the application so we can kick off tasks in the background
         async with create_task_group() as task_group:

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -314,7 +314,7 @@ def _make_render_safe(handler: Callable):
             return None
         elif isinstance(result, (str, float, int, bool)):
             # If it is ComponentInstance string(string start with '__dara__')
-            if result.startswith('__dara__'):
+            if isinstance(result,str) and result.startswith('__dara__'):
                 return json.loads(result[8:])
 
             # Handle primitives being returned by just displaying the value as a string

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 from __future__ import annotations
 
+import json
 import uuid
 from functools import wraps
 from inspect import Parameter, Signature, isclass, signature
@@ -312,6 +313,10 @@ def _make_render_safe(handler: Callable):
         if result is None:
             return None
         elif isinstance(result, (str, float, int, bool)):
+            # If it is ComponentInstance string(string start with '__dara__')
+            if result.startswith('__dara__'):
+                return json.loads(result[8:])
+
             # Handle primitives being returned by just displaying the value as a string
             return RawString(content=str(result))
         elif not isinstance(result, ComponentInstance):

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -314,7 +314,7 @@ def _make_render_safe(handler: Callable):
             return None
         elif isinstance(result, (str, float, int, bool)):
             # If it is ComponentInstance string(string start with '__dara__')
-            if isinstance(result,str) and result.startswith('__dara__'):
+            if isinstance(result, str) and result.startswith('__dara__'):
                 return json.loads(result[8:])
 
             # Handle primitives being returned by just displaying the value as a string

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -321,11 +321,10 @@ function PythonWrapper(props: PythonWrapperProps): JSX.Element {
     }
 
     if (isRawString(component)) {
-        let res = component.props.content
-        if(res.startsWith('__dara__')){
+        let res = component.props.content;
+        if (res.startsWith('__dara__')) {
             res = res.slice(8);
             const resJson = JSON.parse(res);
-            console.log(resJson);
             return <DynamicComponent component={resJson} key={component.uid} />;
         }
         return <>{component.props.content}</>;

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -321,12 +321,6 @@ function PythonWrapper(props: PythonWrapperProps): JSX.Element {
     }
 
     if (isRawString(component)) {
-        let res = component.props.content;
-        if (res.startsWith('__dara__')) {
-            res = res.slice(8);
-            const resJson = JSON.parse(res);
-            return <DynamicComponent component={resJson} key={component.uid} />;
-        }
         return <>{component.props.content}</>;
     }
 

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -321,6 +321,13 @@ function PythonWrapper(props: PythonWrapperProps): JSX.Element {
     }
 
     if (isRawString(component)) {
+        let res = component.props.content
+        if(res.startsWith('__dara__')){
+            res = res.slice(8);
+            const resJson = JSON.parse(res);
+            console.log(resJson);
+            return <DynamicComponent component={resJson} key={component.uid} />;
+        }
         return <>{component.props.content}</>;
     }
 

--- a/packages/dara-core/js/shared/utils/use-component-registry.tsx
+++ b/packages/dara-core/js/shared/utils/use-component-registry.tsx
@@ -5,7 +5,7 @@ import { HTTP_METHOD, validateResponse } from '@darajs/ui-utils';
 
 import { request } from '@/api';
 import { handleAuthErrors } from '@/auth/auth';
-import { useSessionToken } from '@/auth';
+import { useSessionToken } from '@/auth/auth-context';
 import { RegistriesCtx } from '@/shared/context';
 import { Component, ComponentInstance } from '@/types/core';
 

--- a/packages/dara-core/js/shared/utils/use-component-registry.tsx
+++ b/packages/dara-core/js/shared/utils/use-component-registry.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable no-await-in-loop */
 import { useCallback, useContext } from 'react';
 
-import { HTTP_METHOD } from '@darajs/ui-utils';
+import { HTTP_METHOD, validateResponse } from '@darajs/ui-utils';
 
 import { request } from '@/api';
+import { handleAuthErrors } from '@/auth/auth';
 import { useSessionToken } from '@/auth';
 import { RegistriesCtx } from '@/shared/context';
 import { Component, ComponentInstance } from '@/types/core';
@@ -35,6 +36,8 @@ function useComponentRegistry(maxRetries = 5): ComponentRegistryInterface {
                         { method: HTTP_METHOD.GET },
                         token
                     );
+                    await handleAuthErrors(res, true);
+                    await validateResponse(res, 'Failed to fetch the config for this app');
                     registry = await res.json();
                 } else {
                     // If component has not been found, it could be a nested py_component, so we refetch the registry


### PR DESCRIPTION
## Motivation and Context
Currently when render actions/derived variable/pycomponent, server will look for entry in the corresponding registry. If it doesn’t exist, will raise a KeyError.

This PR is adding a new feature: when catch a KeyError, server will check if user identified their own handler, if so, the customised handler will return the entry. 

## Implementation Description
1. Implement an `add_registry_lookup()` in the ConfigurationBuilder, user can add their own handlers.
```
from dara.core import ConfigurationBuilder

config = ConfigurationBuilder()

def get_derived_variable(uid)-> DerivedVariableRegistryEntry:
     # get external derived variable

def get_action(uid)-> Callable:
     # get external get_action

config.add_registry_lookup(
            {
                'DerivedVariable': get_derived_variable,
                'Action Handler': get_action,
            }
        )
```
2. Implement a RegistryLookup class, its take the user defined handlers when initialise and has a get function, which takes a registry and a uid as params. When the uid is not in the registry, it will call the lookup handler customised by user. 
```
from dara.core.internal.registry_lookup import RegistryLookup
from dara.core.internal.registries import derived_variable_registry

registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
variable = await registry_mgr.get(derived_variable_registry, uid)
```
## Any new dependencies Introduced
None

## How Has This Been Tested?
Manually tested

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->