### PR TITLE
Fix: DO-1543 Dataframe update action

### DIFF
--- a/packages/dara-core/dara/core/interactivity/actions.py
+++ b/packages/dara-core/dara/core/interactivity/actions.py
@@ -315,10 +315,16 @@ class UpdateVariable(ActionInstance):
             store = utils_registry.get('Store')
 
             async def data_resolver(ctx):
-                registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
-                var_entry = await registry_mgr.get(data_variable_registry, str(variable.uid))
-                resolved_value = await run_user_handler(resolver, (ctx,))
-                DataVariable.update_value(var_entry, store, resolved_value)
+                if utils_registry.has('RegistryLookup'):
+                    registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
+                    var_entry = await registry_mgr.get(data_variable_registry, str(variable.uid))
+                    resolved_value = await run_user_handler(resolver, (ctx,))
+                    DataVariable.update_value(var_entry, store, resolved_value)
+                else:
+                    var_entry = data_variable_registry.get(str(variable.uid))
+                    resolved_value = await run_user_handler(resolver, (ctx,))
+                    DataVariable._update(var_entry, store, resolved_value)
+                    return (var_entry,resolved_value)
 
             self.register_resolver(uid, data_resolver)
         else:

--- a/packages/dara-core/dara/core/interactivity/actions.py
+++ b/packages/dara-core/dara/core/interactivity/actions.py
@@ -312,10 +312,10 @@ class UpdateVariable(ActionInstance):
                 utils_registry,
             )
 
-            registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
             store = utils_registry.get('Store')
 
             async def data_resolver(ctx):
+                registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
                 var_entry = await registry_mgr.get(data_variable_registry, str(variable.uid))
                 resolved_value = await run_user_handler(resolver, (ctx,))
                 DataVariable.update_value(var_entry, store, resolved_value)


### PR DESCRIPTION
## Motivation and Context
1.UpdateVariable `__init__()` function executed before `utils_registry.set('RegistryLookup')`, which introduced a KeyError.
2. Edge case: utils_registry not having RegistryLookup/WebsocketManager/TaskGroup

## Implementation Description
1. Call `utils_registry.get('RegistryLookup')` in the data resolver function
2. If utils_registry has RegistryLookup, call `DataVariable.update_value()`, which will start broadcast; otherwise call `DataVariable._update()` and return the value
## Any new dependencies Introduced
No

## How Has This Been Tested?
Local tested

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->