### PR TITLE
Fix: DO-1782 parallel registry lookup errors, build 1.1.6

### DIFF
--- a/borg.toml
+++ b/borg.toml
@@ -1,1 +1,1 @@
-version = "1.1.5"
+version = "1.1.6"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "pnpm",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "packages": [
     "packages/*"
   ],

--- a/packages/create-dara-app/pyproject.toml
+++ b/packages/create-dara-app/pyproject.toml
@@ -27,7 +27,7 @@ license = "Apache-2.0"
 name = "create-dara-app"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.1.5"
+version = "1.1.6"
 
 [tool.poetry.dependencies]
 click = "=8.1.3"

--- a/packages/dara-components/package.json
+++ b/packages/dara-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darajs/components",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Components for the Dara framework",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@bokeh/bokehjs": "~3.1.1",
-    "@darajs/core": "1.1.5",
+    "@darajs/core": "1.1.6",
     "@darajs/styled-components": "~1.0.0",
     "@darajs/ui-causal-graph-editor": "~1.0.0",
     "@darajs/ui-code-editor": "~1.0.0",

--- a/packages/dara-components/pyproject.toml
+++ b/packages/dara-components/pyproject.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0"
 name = "dara-components"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.1.5"
+version = "1.1.6"
 
 [[tool.poetry.packages]]
 include = "dara"
@@ -33,7 +33,7 @@ include = "dara"
 [tool.poetry.dependencies]
 bokeh = ">=3.1.0, <3.2.0"
 cai-causal-graph = ">=0.1.0"
-dara-core = "=1.1.5"
+dara-core = "=1.1.6"
 dill = ">=0.3.0, <0.4.0"
 matplotlib = ">=2.0.0"
 pandas = ">=1.1.0, <3.0.0"

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## 1.1.6
+
+-   Internal: dedupe custom registry lookup calls
+
 ## 1.1.5
 
 -   Lock `anyio` to `>=4.0.0`

--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -18,6 +18,7 @@ limitations under the License.
 from typing import Callable, Coroutine, Dict, Literal
 
 from dara.core.internal.registry import Registry, RegistryType
+from dara.core.internal.utils import async_dedupe
 
 RegistryLookupKey = Literal[
     RegistryType.ACTION,
@@ -37,6 +38,7 @@ class RegistryLookup:
     def __init__(self, handlers: CustomRegistryLookup = {}):
         self.handlers = handlers
 
+    @async_dedupe
     async def get(self, registry: Registry, uid: str):
         """
         Get the entry from registry by uid.

--- a/packages/dara-core/dara/core/internal/utils.py
+++ b/packages/dara-core/dara/core/internal/utils.py
@@ -18,12 +18,23 @@ limitations under the License.
 from __future__ import annotations
 
 import inspect
+from functools import wraps
 from importlib import import_module
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable, Literal, Optional, Sequence, Tuple, Union
-import anyio
-from functools import wraps
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    Literal,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
+import anyio
 from starlette.concurrency import run_in_threadpool
 
 from dara.core.auth.definitions import SESSION_ID, USER
@@ -112,7 +123,7 @@ def enforce_sso(conf: ConfigurationBuilder):
         )
 
 
-def async_dedupe(fn):
+def async_dedupe(fn: Callable[..., Awaitable]):
     """
     Decorator to deduplicate concurrent calls to asynchronous functions based on their arguments.
 
@@ -123,9 +134,9 @@ def async_dedupe(fn):
     This decorator is useful for operations that might be triggered multiple times in parallel
     but should be executed only once to prevent redundant work or data fetches.
     """
-    locks = {}
-    results = {}
-    wait_counts = {}
+    locks: Dict[Tuple, anyio.Lock] = {}
+    results: Dict[Tuple, Any] = {}
+    wait_counts: Dict[Tuple, int] = {}
 
     is_method = 'self' in inspect.signature(fn).parameters
 

--- a/packages/dara-core/package.json
+++ b/packages/dara-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darajs/core",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Dara Framework core",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/dara-core/pyproject.toml
+++ b/packages/dara-core/pyproject.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0"
 name = "dara-core"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.1.5"
+version = "1.1.6"
 
 [[tool.poetry.packages]]
 include = "dara"
@@ -62,11 +62,11 @@ xlrd = "*"
 
 [tool.poetry.dependencies.create-dara-app]
 optional = true
-version = "=1.1.5"
+version = "=1.1.6"
 
 [tool.poetry.dependencies.dara-components]
 optional = true
-version = "=1.1.5"
+version = "=1.1.6"
 
 [tool.poetry.dependencies.uvicorn]
 extras = ["standard"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
   packages/dara-components:
     specifiers:
       '@bokeh/bokehjs': ~3.1.1
-      '@darajs/core': 1.1.5
+      '@darajs/core': 1.1.6
       '@darajs/eslint-config': ~1.0.0
       '@darajs/prettier-config': ~1.0.0
       '@darajs/styled-components': ~1.0.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -522,7 +522,7 @@ rich = "*"
 
 [[package]]
 name = "create-dara-app"
-version = "1.1.5"
+version = "1.1.6"
 description = "CLI to quickly bootstrap a Dara app"
 category = "main"
 optional = false
@@ -613,7 +613,7 @@ files = [
 
 [[package]]
 name = "dara-components"
-version = "1.1.5"
+version = "1.1.6"
 description = "Components for the Dara Framework"
 category = "main"
 optional = false
@@ -624,7 +624,7 @@ develop = true
 [package.dependencies]
 bokeh = ">=3.1.0, <3.2.0"
 cai-causal-graph = ">=0.1.0"
-dara-core = "=1.1.5"
+dara-core = "=1.1.6"
 dill = ">=0.3.0, <0.4.0"
 matplotlib = ">=2.0.0"
 pandas = ">=1.1.0, <3.0.0"
@@ -638,7 +638,7 @@ url = "packages/dara-components"
 
 [[package]]
 name = "dara-core"
-version = "1.1.5"
+version = "1.1.6"
 description = "Dara Framework Core"
 category = "main"
 optional = false
@@ -677,7 +677,7 @@ uvicorn = {version = "^0.22.0", extras = ["standard"]}
 xlrd = "*"
 
 [package.extras]
-all = ["dara-components (==1.1.5)"]
+all = ["dara-components (==1.1.6)"]
 
 [package.source]
 type = "directory"
@@ -2993,4 +2993,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0, <3.12.0"
-content-hash = "e0c3fd88565bfa538690304eee734380dacbb1d588389502b3a8ab84f5877e93"
+content-hash = "2e9b768e1da2af01c9bc9179a06c0e208ff1f76547d4d5531e8e5bea52b516bd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,71 +2,71 @@
 requires = ["poetry"]
 [tool.poetry]
 name = "borg-meta-package"
-version = "1.1.5"
+version = "1.1.6"
 description = "Borg Meta Package"
 authors = ["borg"]
 
 [tool.poetry.dependencies]
-toml = "^0.10.2"
-python = ">=3.8.0, <3.12.0"
-matplotlib = ">=2.0.0"
-seaborn = ">=0.11.0"
-cai-causal-graph = ">=0.1.0"
-responses = "^0.18.0"
-async-asgi-testclient = "^1.4.11"
-scipy = "*"
-prometheus-client = "^0.14.1"
-dill = ">=0.3.0, <0.4.0"
-openpyxl = "*"
-pyarrow = "*"
-croniter = "^1.0.15"
-typing-extensions = ">=4.0.0, <4.6.0"
-pandas = ">=1.1.0, <3.0.0"
-dara-core = "=1.1.5"
-pydantic = ">=1.8.1, <2.0.0"
-httpx = ">=0.23.0"
-jinja2 = ">=2.1.1, <3.1.0"
-odfpy = "*"
-fastapi = ">=0.95.1, <0.96.0"
-python-dotenv = "^0.19.2"
-plotly = ">=5.14.0, <5.15.0"
-pyxlsb = "*"
 exceptiongroup = "^1.1.3"
-colorama = "^0.4.6"
-cryptography = ">=41.0.3"
-tblib = "^1.7.0"
-packaging = "^23.1"
+bokeh = ">=3.1.0, <3.2.0"
+anyio = ">=4.0.0"
+toml = "^0.10.2"
+croniter = "^1.0.15"
+odfpy = "*"
+pyjwt = ">=2.0.1, <3.0.0"
+prometheus-client = "^0.14.1"
+pandas = ">=1.1.0, <3.0.0"
 click = "=8.1.3"
 fastapi-vite = "^0.3.1"
+python-dotenv = "^0.19.2"
+cai-causal-graph = ">=0.1.0"
+pyxlsb = "*"
+scipy = "*"
+cryptography = ">=41.0.3"
+plotly = ">=5.14.0, <5.15.0"
+pydantic = ">=1.8.1, <2.0.0"
 xlrd = "*"
+httpx = ">=0.23.0"
+openpyxl = "*"
+fastapi = ">=0.95.1, <0.96.0"
+dara-core = "=1.1.6"
+async-asgi-testclient = "^1.4.11"
+colorama = "^0.4.6"
+typing-extensions = ">=4.0.0, <4.6.0"
+pyarrow = "*"
+matplotlib = ">=2.0.0"
+python = ">=3.8.0, <3.12.0"
 cookiecutter = "^2.1.1"
-bokeh = ">=3.1.0, <3.2.0"
-pyjwt = ">=2.0.1, <3.0.0"
-anyio = ">=4.0.0"
+packaging = "^23.1"
+responses = "^0.18.0"
+jinja2 = ">=2.1.1, <3.1.0"
+seaborn = ">=0.11.0"
+tblib = "^1.7.0"
 python-multipart = "^0.0.5"
-
-[tool.poetry.dependencies.create-dara-app]
-version = "=1.1.5"
-optional = true
-
-[tool.poetry.dependencies.dara-components]
-version = "=1.1.5"
-optional = true
+dill = ">=0.3.0, <0.4.0"
 
 [tool.poetry.dependencies.uvicorn]
 version = "^0.22.0"
 
+[tool.poetry.dependencies.dara-components]
+version = "=1.1.6"
+optional = true
+
+[tool.poetry.dependencies.create-dara-app]
+version = "=1.1.6"
+optional = true
+
 [tool.poetry.dev-dependencies]
-types-requests = "^2.28.1"
-pylint = ">=2.6.0, <3.0.0"
-types-croniter = "^1.0.10"
-blue = "^0.9.0"
-mypy = "^0.991.0"
-pytest = "^7.0.0"
-pytest-timeout = "^2.1.0"
 bandit = "^1.7.5"
+pytest-timeout = "^2.1.0"
 requests = ">=2.25.1, <3.0.0"
 isort = "^5.10.1"
+blue = "^0.9.0"
+pytest = "^7.0.0"
+types-croniter = "^1.0.10"
+types-requests = "^2.28.1"
+pylint = ">=2.6.0, <3.0.0"
+mypy = "^0.991.0"
 
 [tool.poetry.dev-dependencies.create-dara-app]
 path = "packages/create-dara-app"


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

This PR fixes cases where now the asynchronous nature of registry lookup can cause issues when multiple requests come in at the same time, requesting the same registry key. In those cases the custom handlers can be invoked multiple times with the same value, which results in the same registry key being attempted to be registered and errors out.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

The issue is fixed by implementing an `async_dedupe` decorator, which keeps track of args/kwargs that the function is being called with; invoking the method with the same set of arguments instead awaits the lock.

Including build changes for 1.1.6

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in a local project utilising custom registry handlers, this PR fixes the issue

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->