### PR TITLE
Fix: DO-1452, DO-1713 fix table sort does not return the right index row

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BEARER_CONFIG := ./bearer.yml
 bearer:
 	@if [ ! -f "$(LOCAL_BEARER)" ]; then \
 		echo "Installing Bearer"; \
-		curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh; \
+		curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- v1.22.0; \
 	fi
 
 	@for package in $(shell ls packages) ; do \

--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Fixed an issue where `Table` did not return the correct index row when sorted
+-   Fixed an issue where `Table` selection was not persistent. This can now be achieved by passing a `Variable` to `selected_indices` with the `persist_value=True` flag 
 
 ## 1.0.1
 

--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `Table` did not return the correct index row when sorted
+
 ## 1.0.1
 
 -   Fixed an issue where `Switch` would not be aligned by default with other components

--- a/packages/dara-components/dara/components/common/table.py
+++ b/packages/dara-components/dara/components/common/table.py
@@ -725,7 +725,8 @@ class Table(ContentComponent):
     :param show_checkboxes: Whether to show or hide checkboxes column when onclick_row is set. Defaults to True
     :param onclick_row: An action handler for when a row is clicked on the table
     :param selected_indices: Optional variable to store the selected rows indices, must be a list of numbers. Note that these indices are
-    the sequential indices of the rows as accepted by `DataFrame.iloc`, not the `row.index` value.
+    the sequential indices of the rows as accepted by `DataFrame.iloc`, not the `row.index` value. If you would like the selection to persist over
+    page reloads, you must set `persist_value=True` on the variable.
     :param search_columns: Optional list defining the columns to be searched, only the columns passed are searchable
     :param searchable: Boolean, if True table can be searched via Input and will only render matching rows
     :param max_rows: if specified, table height will be fixed to accomodate the specified number of rows

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -373,12 +373,14 @@ function Table(props: TableProps): JSX.Element {
 
     const datetimeColumns = useMemo(() => getDatetimeColumns(resolvedColumns), [resolvedColumns]);
     const fetchData = useCallback(
-        async (startIndex: number, stopIndex: number) => {
+        async (startIndex: number, stopIndex: number, index?: number) => {
             const response = await getData(combineFilters('AND', [filtersToFilterQuery(filters), searchQuery]), {
+                index,
                 limit: stopIndex - startIndex,
-                offset: startIndex,
+                offset: sortingRules[0] ? startIndex + 5 : startIndex,
                 sort: sortingRules[0],
             });
+
             return {
                 data: response.data.map((row: DataRow) => {
                     for (const val of datetimeColumns) {
@@ -408,7 +410,7 @@ function Table(props: TableProps): JSX.Element {
     async function getRowByIndex(idx: number): Promise<DataRow> {
         // populate cache with a few rows around the index if row not in cache
         if (!extraDataCache.current[idx]) {
-            const { data } = await fetchData(idx - 5, idx + 5);
+            const { data } = await fetchData(idx - 5, idx + 5, idx);
             for (const row of data) {
                 extraDataCache.current[row[INDEX_COL]] = row;
             }

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -410,7 +410,7 @@ function Table(props: TableProps): JSX.Element {
     async function getRowByIndex(idx: number): Promise<DataRow> {
         // populate cache with a few rows around the index if row not in cache
         if (!extraDataCache.current[idx]) {
-            const { data } = await fetchData(idx);
+            const { data } = await fetchData(undefined, undefined, idx);
             for (const row of data) {
                 extraDataCache.current[row[INDEX_COL]] = row;
             }

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -373,9 +373,11 @@ function Table(props: TableProps): JSX.Element {
 
     const datetimeColumns = useMemo(() => getDatetimeColumns(resolvedColumns), [resolvedColumns]);
     const fetchData = useCallback(
-        async (index?: number) => {
+        async (startIndex?: number, stopIndex?: number, index?: number) => {
             const response = await getData(combineFilters('AND', [filtersToFilterQuery(filters), searchQuery]), {
                 index,
+                limit: stopIndex !== undefined && startIndex !== undefined ? stopIndex - startIndex : undefined,
+                offset: startIndex !== undefined ? startIndex : undefined,
                 sort: sortingRules[0],
             });
 

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -401,23 +401,11 @@ function Table(props: TableProps): JSX.Element {
 
     /**
      * Returns a row by index
-     * - first tries to retrieve it from the loader data
-     * - if not found, tries to retrieve it from the extraDataCache
-     * - if not found, fetches a few rows around the index and stores them in the extraDataCache
+     * Fetches a few rows around the index and stores them in the extraDataCache
      *
      * @param idx index of row to get
      */
     async function getRowByIndex(idx: number): Promise<DataRow> {
-        const loaderItem = getItem(idx);
-
-        // item available in current window
-        if (loaderItem) {
-            return loaderItem;
-        }
-
-        // This should only happen if user changes selectedRow from the outside
-        // and the row has not been loaded yet
-
         // populate cache with a few rows around the index if row not in cache
         if (!extraDataCache.current[idx]) {
             const { data } = await fetchData(idx - 5, idx + 5);

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -377,7 +377,7 @@ function Table(props: TableProps): JSX.Element {
             const response = await getData(combineFilters('AND', [filtersToFilterQuery(filters), searchQuery]), {
                 index,
                 limit: stopIndex - startIndex,
-                offset: sortingRules[0] ? startIndex + 5 : startIndex,
+                offset: startIndex,
                 sort: sortingRules[0],
             });
 

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -373,11 +373,9 @@ function Table(props: TableProps): JSX.Element {
 
     const datetimeColumns = useMemo(() => getDatetimeColumns(resolvedColumns), [resolvedColumns]);
     const fetchData = useCallback(
-        async (startIndex: number, stopIndex: number, index?: number) => {
+        async (index?: number) => {
             const response = await getData(combineFilters('AND', [filtersToFilterQuery(filters), searchQuery]), {
                 index,
-                limit: stopIndex - startIndex,
-                offset: startIndex,
                 sort: sortingRules[0],
             });
 
@@ -410,7 +408,7 @@ function Table(props: TableProps): JSX.Element {
     async function getRowByIndex(idx: number): Promise<DataRow> {
         // populate cache with a few rows around the index if row not in cache
         if (!extraDataCache.current[idx]) {
-            const { data } = await fetchData(idx - 5, idx + 5, idx);
+            const { data } = await fetchData(idx);
             for (const row of data) {
                 extraDataCache.current[row[INDEX_COL]] = row;
             }

--- a/packages/dara-core/dara/core/interactivity/filtering.py
+++ b/packages/dara-core/dara/core/interactivity/filtering.py
@@ -33,6 +33,7 @@ class Pagination(BaseModel):
     Model representing pagination to be applied to a dataset.
 
     Retrieves results [offset:offset+limit]
+    If index is defined, retrieves only the row of the specified index
     """
 
     offset: Optional[int] = None

--- a/packages/dara-core/dara/core/interactivity/filtering.py
+++ b/packages/dara-core/dara/core/interactivity/filtering.py
@@ -241,7 +241,6 @@ def apply_filters(
     """
     Apply filtering and pagination to a DataFrame.
     """
-
     if data is None:
         return None, 0
 

--- a/packages/dara-core/dara/core/interactivity/filtering.py
+++ b/packages/dara-core/dara/core/interactivity/filtering.py
@@ -38,6 +38,7 @@ class Pagination(BaseModel):
     offset: Optional[int] = None
     limit: Optional[int] = None
     orderBy: Optional[str] = None
+    index: Optional[str] = None
 
 
 class QueryCombinator(str, Enum):
@@ -240,19 +241,26 @@ def apply_filters(
     """
     Apply filtering and pagination to a DataFrame.
     """
+
     if data is None:
         return None, 0
+
+    new_data = data
 
     # FILTER
     if filters is not None:
         resolved_query = _resolve_filter_query(data, filters)
         if resolved_query is not None:
-            data = data[resolved_query]
+            new_data = new_data[resolved_query]
 
     # Count before paginating
-    total_count = len(data.index)
+    total_count = len(new_data.index)
 
     if pagination is not None:
+        # ON FETCHING SPECIFIC ROW
+        if pagination.index is not None:
+            return data[int(pagination.index) : int(pagination.index) + 1], total_count
+
         # SORT
         if pagination.orderBy is not None:
             order_by = pagination.orderBy
@@ -263,12 +271,12 @@ def apply_filters(
                 order_by = order_by[1:]
                 ascending = False
 
-            data = data.sort_values(by=order_by, ascending=ascending, inplace=False)
+            new_data = new_data.sort_values(by=order_by, ascending=ascending, inplace=False)
 
         # PAGINATE
         start_index = pagination.offset if pagination.offset is not None else 0
         stop_index = start_index + pagination.limit if pagination.limit is not None else total_count
 
-        data = data[start_index:stop_index]
+        new_data = new_data[start_index:stop_index]
 
-    return data, total_count
+    return new_data, total_count

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -254,6 +254,7 @@ def create_router(config: Configuration):
         offset: Optional[int] = None,
         limit: Optional[int] = None,
         order_by: Optional[str] = None,
+        index: Optional[str] = None,
     ):   # pylint: disable=unused-variable
         try:
             store: Store = utils_registry.get('Store')
@@ -277,14 +278,14 @@ def create_router(config: Configuration):
                     body.cache_key,
                     store,
                     body.filters,
-                    Pagination(offset=offset, limit=limit, orderBy=order_by),
+                    Pagination(offset=offset, limit=limit, orderBy=order_by,  index=index),
                 )
                 if isinstance(data, BaseTask):
                     await task_mgr.run_task(data, body.ws_channel)
                     return {'task_id': data.task_id}
             elif variable.type == 'plain':
                 data = DataVariable.get_value(
-                    variable, store, body.filters, Pagination(offset=offset, limit=limit, orderBy=order_by)
+                    variable, store, body.filters, Pagination(offset=offset, limit=limit, orderBy=order_by, index=index)
                 )
 
             dev_logger.debug(

--- a/packages/dara-core/js/shared/interactivity/data-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/data-variable.tsx
@@ -48,6 +48,10 @@ function createDataUrl(path: string, pagination?: Pagination): URL {
         url.searchParams.set('order_by', (pagination.sort.desc ? '-' : '') + pagination.sort.id);
     }
 
+    if (pagination?.index) {
+        url.searchParams.set('index', String(pagination.index));
+    }
+
     return url;
 }
 

--- a/packages/dara-core/js/types/core.tsx
+++ b/packages/dara-core/js/types/core.tsx
@@ -49,6 +49,7 @@ export interface Pagination {
     limit?: number;
     offset?: number;
     sort?: SortingRule;
+    index?: number;
 }
 
 type CacheType = 'session' | 'global' | 'user';


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
A bug was found where if table was sorted then the wrong chosen role was passed to the backend.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue turned out to be an issue with getting the value within the getItem which created a discrepancy when data was sorted from initial index to the one chosen by the user. This was also an issue for if the table selected value was changed from outside the component. The easier fix was to simply remove that part of the logic. We do need to fetch the data more often, but in this way we guarantee that regardless if selection is done in a sorted table or changed from outside that the correct index is still passed to both `onclick_row` action context and `selected_indices` Variables.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by single and multi selecting table rows, sorted and unsorted and checking corresponding Variables were updated as expected.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->