### PR TITLE
Feat: DO-1785 Add serialization support

### DIFF
--- a/docs/best-practices/retaining-correct-variable-types.md
+++ b/docs/best-practices/retaining-correct-variable-types.md
@@ -2,12 +2,17 @@
 title: Retaining Correct Variable Types
 ---
 ### Adding Type Annotations to Your Resolver
-`dara.core.interactivity.plain_variable.Variable`s are stored in the browser and `dara.core.interactivity.derived_variable.DerivedVariable`s and `py_component`s are calculated on the server. When a `Variable` is passed to one of these, it is serialized into a format that FastApi can handle and becomes a python basic type format on the server side. Eg, a  `numpy.array` will became a  `list`, a `numpy.int8` will become a `int`.
+`dara.core.interactivity.plain_variable.Variable`s are stored in the browser and `dara.core.interactivity.derived_variable.DerivedVariable`s and `py_component`s are calculated on the server. This means that there are times when Dara needs to be able to serialize and deserialize your values.
 
+Static values or `Variable` default values need to be serialized to JSON as part of the component tree - either when included directly in the page or when returned from a `py_component`.
 
-By default, Dara supports to serialize all the generic data types in Numpy. See [default data types supported](https://github.com/causalens/dara/blob/master/packages/dara-core/dara/core/internal/encoder_registry.py).
+When a user-defined resolver (for `DerivedVariable`s, `py_component`s or action) is called, Dara receives the `Variable` values from the frontend as the serialized JSON. This means your data structures would be turned into primitive types, a `numpy.array` will became a `list`, a `numpy.int8` will become a `int`.
 
-You can also add your custom encoder by using `ConfigurationBuilder.add_encoder()`. Notice, if a Variable is a type that can not be serialized by either default encoder handler or custom encoder handle, it will case a crush.
+To preserve your original types, Dara provides an encoder system which will attempt to turn the primitive types back into the original type, as long as you annotate your resolver with a type for which an encoder is defined.
+
+Out of the box, Dara comes with encoders for all generic data types in `pandas` and `numpy`. . See [default data types supported](https://github.com/causalens/dara/blob/master/packages/dara-core/dara/core/internal/encoder_registry.py).
+
+You can also add your custom encoder by using `ConfigurationBuilder.add_encoder()`. Notice, if a Variable is a type that can not be serialized by either default encoder handler or custom encoder handle, it can cause serialization to fail.
 ```python
 from dara.core import ConfigurationBuilder
 
@@ -34,7 +39,7 @@ def my_component(var: numpy.array):
     return Text(var.tobytes())
 my_component(my_var)
 ```
-Currently the serialize/deserialize handler does not work for action resolvers due to their different API shape, which we'll hopefully solve in the near future.
+Current limitation of the serialize/deserialize handler is that the automatic deserialization does not work for action resolvers due to their different API shape.
 
 ### Using pydantic
 `dara.core.interactivity.plain_variable.Variable`s are stored in the browser and `dara.core.interactivity.derived_variable.DerivedVariable`s and `py_component`s are calculated on the server. When a `Variable` is passed to one of these, it is serialized into a JSON format which becomes a plain `dict` on the server side.

--- a/packages/dara-components/dara/components/smart/data_slicer/extension/filter_status_button.py
+++ b/packages/dara-components/dara/components/smart/data_slicer/extension/filter_status_button.py
@@ -15,7 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Optional, TypedDict
+from typing import Optional
+from typing_extensions import TypedDict
 
 from dara.core.base_definitions import Action
 from dara.core.definitions import AnyVariable, ComponentInstance

--- a/packages/dara-components/dara/components/smart/data_slicer/utils/core.py
+++ b/packages/dara-components/dara/components/smart/data_slicer/utils/core.py
@@ -17,7 +17,8 @@ limitations under the License.
 
 import re
 from datetime import datetime, timezone
-from typing import Any, List, Optional, TypedDict, Union
+from typing import Any, List, Optional, Union
+from typing_extensions import TypedDict
 
 import numpy
 from pandas import DataFrame, Series

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Added serialize/deserialize support to numpy/pandas datatype
+-   Added custom encoder support. User can add encoder to handle serialization/deserialization of a type
 ## 1.1.6
 
 -   Internal: dedupe custom registry lookup calls

--- a/packages/dara-core/dara/core/auth/definitions.py
+++ b/packages/dara-core/dara/core/auth/definitions.py
@@ -17,9 +17,10 @@ limitations under the License.
 
 from contextvars import ContextVar
 from datetime import datetime
-from typing import List, Optional, TypedDict, Union
+from typing import List, Optional, Union
 
 from pydantic import BaseModel
+from typing_extensions import TypedDict
 
 
 class TokenData(BaseModel):

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -18,7 +18,19 @@ limitations under the License.
 import os
 import pathlib
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from pydantic.generics import GenericModel
 
@@ -304,7 +316,10 @@ class ConfigurationBuilder:
         return handler
 
     EncoderType = TypeVar('EncoderType')
-    def add_encoder(self,typ: Type[EncoderType],serialize: Callable[[EncoderType], Any],deserialize: Callable[[Any], EncoderType]):
+
+    def add_encoder(
+        self, typ: Type[EncoderType], serialize: Callable[[EncoderType], Any], deserialize: Callable[[Any], EncoderType]
+    ):
         """
         Register a custom encoder, which serialize and deserialize the type
 

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -18,7 +18,7 @@ limitations under the License.
 import os
 import pathlib
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, TypeVar, Union
 
 from pydantic.generics import GenericModel
 
@@ -303,7 +303,8 @@ class ConfigurationBuilder:
         self._custom_ws_handlers[kind] = handler
         return handler
 
-    def add_encoder(self, typ: Type[Any], serialize: Callable, deserialize: Callable):
+    EncoderType = TypeVar('EncoderType')
+    def add_encoder(self,typ: Type[EncoderType],serialize: Callable[[EncoderType], Any],deserialize: Callable[[Any], EncoderType]):
         """
         Register a custom encoder, which serialize and deserialize the type
 

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -18,7 +18,7 @@ limitations under the License.
 import os
 import pathlib
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, Union,MutableMapping
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, Union
 
 from pydantic.generics import GenericModel
 
@@ -37,6 +37,7 @@ from dara.core.definitions import (
     Page,
     Template,
 )
+from dara.core.internal.encoder_registry import Encoder
 from dara.core.internal.import_discovery import (
     create_action_definition,
     create_component_definition,
@@ -47,7 +48,7 @@ from dara.core.internal.scheduler import ScheduledJob, ScheduledJobFactory
 from dara.core.logging import dev_logger
 from dara.core.visual.components import RawString
 from dara.core.visual.themes import BaseTheme, ThemeDef
-from dara.core.internal.encoder_registry import Encoder
+
 
 class Configuration(GenericModel):
     """Definition of the main framework configuration"""
@@ -74,7 +75,7 @@ class Configuration(GenericModel):
     theme: Union[BaseTheme, str]
     title: str
     ws_handlers: Dict[str, Callable[[str, Any], Any]]
-    encoder:Dict[Type[Any],Encoder]
+    encoder: Dict[Type[Any], Encoder]
 
     class Config:
         extra = 'forbid'
@@ -124,7 +125,7 @@ class ConfigurationBuilder:
     _package_tags_processors: List[Callable[[Dict[str, List[str]]], Dict[str, List[str]]]]
     _template_extra_js: str
     _custom_ws_handlers: Dict[str, Callable[[str, Any], Any]]
-    _custom_encoder:Dict[Type[Any],Encoder]
+    _custom_encoder: Dict[Type[Any], Encoder]
     routes: Set[ApiRoute]
     static_files_dir: str
     scheduled_jobs: List[Tuple[Union[ScheduledJob, ScheduledJobFactory], Callable, Optional[List[Any]]]] = []
@@ -301,7 +302,8 @@ class ConfigurationBuilder:
         """
         self._custom_ws_handlers[kind] = handler
         return handler
-    def add_encoder(self,typ:Type[Any],serialize:Callable, deserialize:Callable):
+
+    def add_encoder(self, typ: Type[Any], serialize: Callable, deserialize: Callable):
         """
         Register a custom encoder, which serialize and deserialize the type
 
@@ -313,7 +315,7 @@ class ConfigurationBuilder:
         import numpy
         config.add_encoder(typ=np.array, serialize=lambda x: x.tolist(), deserialize=lambda y: np.array(y))
         """
-        encoder = Encoder(serialize=serialize,deserialize=deserialize)
+        encoder = Encoder(serialize=serialize, deserialize=deserialize)
         self._custom_encoder[typ] = encoder
         return encoder
 

--- a/packages/dara-core/dara/core/configuration.py
+++ b/packages/dara-core/dara/core/configuration.py
@@ -75,7 +75,7 @@ class Configuration(GenericModel):
     theme: Union[BaseTheme, str]
     title: str
     ws_handlers: Dict[str, Callable[[str, Any], Any]]
-    encoder: Dict[Type[Any], Encoder]
+    encoders: Dict[Type[Any], Encoder]
 
     class Config:
         extra = 'forbid'
@@ -125,7 +125,7 @@ class ConfigurationBuilder:
     _package_tags_processors: List[Callable[[Dict[str, List[str]]], Dict[str, List[str]]]]
     _template_extra_js: str
     _custom_ws_handlers: Dict[str, Callable[[str, Any], Any]]
-    _custom_encoder: Dict[Type[Any], Encoder]
+    _custom_encoders: Dict[Type[Any], Encoder]
     routes: Set[ApiRoute]
     static_files_dir: str
     scheduled_jobs: List[Tuple[Union[ScheduledJob, ScheduledJobFactory], Callable, Optional[List[Any]]]] = []
@@ -158,7 +158,7 @@ class ConfigurationBuilder:
         self.context_components = []
         self.task_module = None
         self._custom_ws_handlers = {}
-        self._custom_encoder = {}
+        self._custom_encoders = {}
 
         self.template = 'default'
         self.theme = BaseTheme(main='light')
@@ -316,7 +316,7 @@ class ConfigurationBuilder:
         config.add_encoder(typ=np.array, serialize=lambda x: x.tolist(), deserialize=lambda y: np.array(y))
         """
         encoder = Encoder(serialize=serialize, deserialize=deserialize)
-        self._custom_encoder[typ] = encoder
+        self._custom_encoders[typ] = encoder
         return encoder
 
     def add_package_tags_processor(self, processor: Callable[[Dict[str, List[str]]], Dict[str, List[str]]]):
@@ -505,5 +505,5 @@ class ConfigurationBuilder:
             theme=self.theme,
             title=self.title,
             ws_handlers=self._custom_ws_handlers,
-            encoder=self._custom_encoder,
+            encoders=self._custom_encoders,
         )

--- a/packages/dara-core/dara/core/interactivity/derived_variable.py
+++ b/packages/dara-core/dara/core/interactivity/derived_variable.py
@@ -20,19 +20,10 @@ from __future__ import annotations
 import json
 import uuid
 from inspect import Parameter, isclass, signature
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    TypedDict,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, validator
+from typing_extensions import TypedDict
 
 from dara.core.base_definitions import BaseTask, CacheType, PendingTask
 from dara.core.interactivity.actions import TriggerVariable

--- a/packages/dara-core/dara/core/interactivity/derived_variable.py
+++ b/packages/dara-core/dara/core/interactivity/derived_variable.py
@@ -38,6 +38,7 @@ from dara.core.base_definitions import BaseTask, CacheType, PendingTask
 from dara.core.interactivity.actions import TriggerVariable
 from dara.core.interactivity.any_variable import AnyVariable
 from dara.core.interactivity.non_data_variable import NonDataVariable
+from dara.core.internal.encoder_registry import encoder_registry
 from dara.core.internal.store import Store
 from dara.core.internal.tasks import MetaTask, Task, TaskManager
 from dara.core.internal.utils import CacheScope, get_cache_scope, run_user_handler
@@ -207,7 +208,9 @@ class DerivedVariable(NonDataVariable, Generic[VariableType]):
                 if typ is not None and isclass(typ) and issubclass(typ, BaseModel) and arg is not None:
                     parsed_args.append(typ(**arg))
                     continue
-                parsed_args.append(arg)
+                elif typ in encoder_registry:
+                    parsed_args.append(encoder_registry[typ]["deserialize"](arg))
+                    continue
             return parsed_args
 
         # If there is a *args argument then zip the signature and args up to that point, then spread the rest

--- a/packages/dara-core/dara/core/interactivity/derived_variable.py
+++ b/packages/dara-core/dara/core/interactivity/derived_variable.py
@@ -210,7 +210,7 @@ class DerivedVariable(NonDataVariable, Generic[VariableType]):
                 elif typ is not None and isclass(typ) and issubclass(typ, BaseModel) and arg is not None:
                     parsed_args.append(typ(**arg))
                 else:
-                    parsed_args.append(typ(**arg))
+                    parsed_args.append(arg)
             return parsed_args
 
         # If there is a *args argument then zip the signature and args up to that point, then spread the rest

--- a/packages/dara-core/dara/core/interactivity/derived_variable.py
+++ b/packages/dara-core/dara/core/interactivity/derived_variable.py
@@ -209,7 +209,7 @@ class DerivedVariable(NonDataVariable, Generic[VariableType]):
                     parsed_args.append(typ(**arg))
                     continue
                 elif typ in encoder_registry:
-                    parsed_args.append(encoder_registry[typ]["deserialize"](arg))
+                    parsed_args.append(encoder_registry[typ]['deserialize'](arg))
                     continue
             return parsed_args
 

--- a/packages/dara-core/dara/core/interactivity/derived_variable.py
+++ b/packages/dara-core/dara/core/interactivity/derived_variable.py
@@ -205,7 +205,7 @@ class DerivedVariable(NonDataVariable, Generic[VariableType]):
         if len(var_arg_idx) == 0:
             for param, arg in zip(parameters, args):
                 typ = param.annotation
-                if typ in encoder_registry:
+                if typ is not None and typ in encoder_registry:
                     parsed_args.append(encoder_registry[typ]['deserialize'](arg))
                 elif typ is not None and isclass(typ) and issubclass(typ, BaseModel) and arg is not None:
                     parsed_args.append(typ(**arg))

--- a/packages/dara-core/dara/core/interactivity/derived_variable.py
+++ b/packages/dara-core/dara/core/interactivity/derived_variable.py
@@ -205,12 +205,12 @@ class DerivedVariable(NonDataVariable, Generic[VariableType]):
         if len(var_arg_idx) == 0:
             for param, arg in zip(parameters, args):
                 typ = param.annotation
-                if typ is not None and isclass(typ) and issubclass(typ, BaseModel) and arg is not None:
-                    parsed_args.append(typ(**arg))
-                    continue
-                elif typ in encoder_registry:
+                if typ in encoder_registry:
                     parsed_args.append(encoder_registry[typ]['deserialize'](arg))
-                    continue
+                elif typ is not None and isclass(typ) and issubclass(typ, BaseModel) and arg is not None:
+                    parsed_args.append(typ(**arg))
+                else:
+                    parsed_args.append(typ(**arg))
             return parsed_args
 
         # If there is a *args argument then zip the signature and args up to that point, then spread the rest

--- a/packages/dara-core/dara/core/internal/dependency_resolution.py
+++ b/packages/dara-core/dara/core/internal/dependency_resolution.py
@@ -15,9 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, List, Literal, Optional, TypedDict, Union
+from typing import Any, List, Literal, Optional, Union
 
-from typing_extensions import TypeGuard
+from typing_extensions import TypedDict, TypeGuard
 
 from dara.core.interactivity import DataVariable, DerivedDataVariable, DerivedVariable
 from dara.core.interactivity.filtering import FilterQuery

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
+# pylint: disable=unnecessary-lambda
 from typing import Any, Callable, MutableMapping, Type, TypedDict
 
 import numpy

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -1,55 +1,69 @@
-from typing import Any, MutableMapping, TypedDict,Type,Callable
-import pandas
+"""
+Copyright 2023 Impulse Innovations Limited
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Any, Callable, MutableMapping, Type, TypedDict
+
 import numpy
+import pandas
 
 
 class Encoder(TypedDict):
     serialize: Callable
-    deserialize:Callable
+    deserialize: Callable
 
 
-def get_numpy_dtypes_encoder(typ:Type[Any]):
-    return Encoder(serialize=lambda x:x.item(),deserialize=lambda x:typ(x))
+def _get_numpy_dtypes_encoder(typ: Type[Any]):
+    """
+    Construct numpy generic datatype
 
+    :param typ: The numpy generic datatype class
+    """
+    return Encoder(serialize=lambda x: x.item(), deserialize=lambda x: typ(x))
+
+
+# A encoder_registry to handle serialization/deserialization for numpy/pandas type
 encoder_registry: MutableMapping[Type[Any], Encoder] = {
-    numpy.ndarray: Encoder(serialize=lambda x:x.tolist(),deserialize=lambda x:numpy.array(x)),
-
-    numpy.int8:get_numpy_dtypes_encoder(numpy.int8),
-    numpy.int16:get_numpy_dtypes_encoder(numpy.int16),
-    numpy.int32:get_numpy_dtypes_encoder(numpy.int32),
-    numpy.int64:get_numpy_dtypes_encoder(numpy.int64),
-    numpy.longlong:get_numpy_dtypes_encoder(numpy.longlong),
-    numpy.timedelta64:get_numpy_dtypes_encoder(numpy.timedelta64),
-
-    numpy.uint8:get_numpy_dtypes_encoder(numpy.uint8),
-    numpy.uint16:get_numpy_dtypes_encoder(numpy.uint16),
-    numpy.uint32:get_numpy_dtypes_encoder(numpy.uint32),
-    numpy.uint64:get_numpy_dtypes_encoder(numpy.uint64),
-    numpy.ulonglong:get_numpy_dtypes_encoder(numpy.ulonglong),
-
-    numpy.float16:get_numpy_dtypes_encoder(numpy.float16),
-    numpy.float32:get_numpy_dtypes_encoder(numpy.float32),
-    numpy.float64:get_numpy_dtypes_encoder(numpy.float64),
-    numpy.longdouble:get_numpy_dtypes_encoder(numpy.longdouble),
-
-    numpy.complex64:get_numpy_dtypes_encoder(numpy.complex64),
-    numpy.complex128:get_numpy_dtypes_encoder(numpy.complex128),
-    numpy.clongdouble:get_numpy_dtypes_encoder(numpy.clongdouble),
-
-    numpy.bytes_:get_numpy_dtypes_encoder(numpy.bytes_),
-    numpy.str_:get_numpy_dtypes_encoder(numpy.str_),
-
-    numpy.void:get_numpy_dtypes_encoder(numpy.void),
-    numpy.record:get_numpy_dtypes_encoder(numpy.record),
-
-    numpy.bool_:get_numpy_dtypes_encoder(numpy.bool_),
-    numpy.datetime64:get_numpy_dtypes_encoder(numpy.datetime64),
-
-    pandas.array: Encoder(serialize=lambda x:x.tolist(),deserialize=lambda x:pandas.array(x)),
-    pandas.Series: Encoder(serialize=lambda x:x.to_list(),deserialize=lambda x:pandas.Series(x)),
-    pandas.Index: Encoder(serialize=lambda x:x.to_list(),deserialize=lambda x:pandas.Index(x)),
-    pandas.Timestamp: Encoder(serialize=lambda x:x.date(),deserialize=lambda x:pandas.Timestamp(x)),
-
-
-
+    numpy.ndarray: Encoder(serialize=lambda x: x.tolist(), deserialize=lambda x: numpy.array(x)),
+    numpy.int8: _get_numpy_dtypes_encoder(numpy.int8),
+    numpy.int16: _get_numpy_dtypes_encoder(numpy.int16),
+    numpy.int32: _get_numpy_dtypes_encoder(numpy.int32),
+    numpy.int64: _get_numpy_dtypes_encoder(numpy.int64),
+    numpy.longlong: _get_numpy_dtypes_encoder(numpy.longlong),
+    numpy.timedelta64: _get_numpy_dtypes_encoder(numpy.timedelta64),
+    numpy.uint8: _get_numpy_dtypes_encoder(numpy.uint8),
+    numpy.uint16: _get_numpy_dtypes_encoder(numpy.uint16),
+    numpy.uint32: _get_numpy_dtypes_encoder(numpy.uint32),
+    numpy.uint64: _get_numpy_dtypes_encoder(numpy.uint64),
+    numpy.ulonglong: _get_numpy_dtypes_encoder(numpy.ulonglong),
+    numpy.float16: _get_numpy_dtypes_encoder(numpy.float16),
+    numpy.float32: _get_numpy_dtypes_encoder(numpy.float32),
+    numpy.float64: _get_numpy_dtypes_encoder(numpy.float64),
+    numpy.longdouble: _get_numpy_dtypes_encoder(numpy.longdouble),
+    numpy.complex64: _get_numpy_dtypes_encoder(numpy.complex64),
+    numpy.complex128: _get_numpy_dtypes_encoder(numpy.complex128),
+    numpy.clongdouble: _get_numpy_dtypes_encoder(numpy.clongdouble),
+    numpy.bytes_: _get_numpy_dtypes_encoder(numpy.bytes_),
+    numpy.str_: _get_numpy_dtypes_encoder(numpy.str_),
+    numpy.void: _get_numpy_dtypes_encoder(numpy.void),
+    numpy.record: _get_numpy_dtypes_encoder(numpy.record),
+    numpy.bool_: _get_numpy_dtypes_encoder(numpy.bool_),
+    numpy.datetime64: _get_numpy_dtypes_encoder(numpy.datetime64),
+    pandas.array: Encoder(serialize=lambda x: x.tolist(), deserialize=lambda x: pandas.array(x)),
+    pandas.Series: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Series(x)),
+    pandas.Index: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Index(x)),
+    pandas.Timestamp: Encoder(serialize=lambda x: x.date(), deserialize=lambda x: pandas.Timestamp(x)),
 }

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -15,10 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=unnecessary-lambda
-from typing import Any, Callable, MutableMapping, Type, TypedDict
+from typing import Any, Callable, MutableMapping, Type
 
 import numpy
 import pandas
+from typing_extensions import TypedDict
 
 
 class Encoder(TypedDict):

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -1,0 +1,55 @@
+from typing import Any, MutableMapping, TypedDict,Type,Callable
+import pandas
+import numpy
+
+
+class Encoder(TypedDict):
+    serialize: Callable
+    deserialize:Callable
+
+
+def get_numpy_dtypes_encoder(typ:Type[Any]):
+    return Encoder(serialize=lambda x:x.item(),deserialize=lambda x:typ(x))
+
+encoder_registry: MutableMapping[Type[Any], Encoder] = {
+    numpy.ndarray: Encoder(serialize=lambda x:x.tolist(),deserialize=lambda x:numpy.array(x)),
+
+    numpy.int8:get_numpy_dtypes_encoder(numpy.int8),
+    numpy.int16:get_numpy_dtypes_encoder(numpy.int16),
+    numpy.int32:get_numpy_dtypes_encoder(numpy.int32),
+    numpy.int64:get_numpy_dtypes_encoder(numpy.int64),
+    numpy.longlong:get_numpy_dtypes_encoder(numpy.longlong),
+    numpy.timedelta64:get_numpy_dtypes_encoder(numpy.timedelta64),
+
+    numpy.uint8:get_numpy_dtypes_encoder(numpy.uint8),
+    numpy.uint16:get_numpy_dtypes_encoder(numpy.uint16),
+    numpy.uint32:get_numpy_dtypes_encoder(numpy.uint32),
+    numpy.uint64:get_numpy_dtypes_encoder(numpy.uint64),
+    numpy.ulonglong:get_numpy_dtypes_encoder(numpy.ulonglong),
+
+    numpy.float16:get_numpy_dtypes_encoder(numpy.float16),
+    numpy.float32:get_numpy_dtypes_encoder(numpy.float32),
+    numpy.float64:get_numpy_dtypes_encoder(numpy.float64),
+    numpy.longdouble:get_numpy_dtypes_encoder(numpy.longdouble),
+
+    numpy.complex64:get_numpy_dtypes_encoder(numpy.complex64),
+    numpy.complex128:get_numpy_dtypes_encoder(numpy.complex128),
+    numpy.clongdouble:get_numpy_dtypes_encoder(numpy.clongdouble),
+
+    numpy.bytes_:get_numpy_dtypes_encoder(numpy.bytes_),
+    numpy.str_:get_numpy_dtypes_encoder(numpy.str_),
+
+    numpy.void:get_numpy_dtypes_encoder(numpy.void),
+    numpy.record:get_numpy_dtypes_encoder(numpy.record),
+
+    numpy.bool_:get_numpy_dtypes_encoder(numpy.bool_),
+    numpy.datetime64:get_numpy_dtypes_encoder(numpy.datetime64),
+
+    pandas.array: Encoder(serialize=lambda x:x.tolist(),deserialize=lambda x:pandas.array(x)),
+    pandas.Series: Encoder(serialize=lambda x:x.to_list(),deserialize=lambda x:pandas.Series(x)),
+    pandas.Index: Encoder(serialize=lambda x:x.to_list(),deserialize=lambda x:pandas.Index(x)),
+    pandas.Timestamp: Encoder(serialize=lambda x:x.date(),deserialize=lambda x:pandas.Timestamp(x)),
+
+
+
+}

--- a/packages/dara-core/dara/core/internal/normalization.py
+++ b/packages/dara-core/dara/core/internal/normalization.py
@@ -15,21 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import (
-    Any,
-    Generic,
-    List,
-    Mapping,
-    Tuple,
-    TypedDict,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Generic, List, Mapping, Tuple, TypeVar, Union, cast, overload
 
 from pydantic import BaseModel
-from typing_extensions import TypeGuard
+from typing_extensions import TypedDict, TypeGuard
 
 from dara.core.internal.hashing import hash_object
 

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -279,7 +279,7 @@ def create_router(config: Configuration):
                     body.cache_key,
                     store,
                     body.filters,
-                    Pagination(offset=offset, limit=limit, orderBy=order_by,  index=index),
+                    Pagination(offset=offset, limit=limit, orderBy=order_by, index=index),
                 )
                 if isinstance(data, BaseTask):
                     await task_mgr.run_task(data, body.ws_channel)

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -231,8 +231,7 @@ def _start_application(config: Configuration):
         custom_ws_handlers_registry.register(kind, handler)
 
     # update encoder registry
-    for typ, encoder in config.encoders.items():
-        encoder_registry[typ] = encoder
+    encoder_registry.update(config.encoders)
 
     # Inject the encoder to pydantic ENCODERS_BY_TYPE, which will be called in fastapi jsonable_encoder
     for key, value in encoder_registry.items():

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -71,10 +71,6 @@ from dara.core.js_tooling.js_utils import (
 )
 from dara.core.logging import LoggingMiddleware, dev_logger, eng_logger, http_logger
 
-# Inject the encoder to pydantic ENCODERS_BY_TYPE, which will be called in fastapi jsonable_encoder
-for key, value in encoder_registry.items():
-    ENCODERS_BY_TYPE[key] = value['serialize']
-
 
 def _start_application(config: Configuration):
     """
@@ -237,6 +233,10 @@ def _start_application(config: Configuration):
     # update encoder registry
     for typ, encoder in config.encoders.items():
         encoder_registry[typ] = encoder
+
+    # Inject the encoder to pydantic ENCODERS_BY_TYPE, which will be called in fastapi jsonable_encoder
+    for key, value in encoder_registry.items():
+        ENCODERS_BY_TYPE[key] = value['serialize']
 
     # Generate a new build_cache
     try:

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -235,7 +235,7 @@ def _start_application(config: Configuration):
         custom_ws_handlers_registry.register(kind, handler)
 
     # update encoder registry
-    for typ, encoder in config.encoder.items():
+    for typ, encoder in config.encoders.items():
         encoder_registry[typ] = encoder
 
     # Generate a new build_cache

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -29,6 +29,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from prometheus_client import start_http_server
+from pydantic.json import ENCODERS_BY_TYPE
 from starlette.templating import Jinja2Templates, _TemplateResponse
 
 from dara.core.auth import auth_router
@@ -41,6 +42,7 @@ from dara.core.defaults import (
 )
 from dara.core.internal.cgroup import get_cpu_count, set_memory_limit
 from dara.core.internal.devtools import send_error_for_session
+from dara.core.internal.encoder_registry import encoder_registry
 from dara.core.internal.pool import TaskPool
 from dara.core.internal.registries import (
     action_def_registry,
@@ -68,12 +70,11 @@ from dara.core.js_tooling.js_utils import (
     rebuild_js,
 )
 from dara.core.logging import LoggingMiddleware, dev_logger, eng_logger, http_logger
-from dara.core.internal.encoder_registry import encoder_registry
-from pydantic.json import ENCODERS_BY_TYPE
 
 # Inject the encoder to pydantic ENCODERS_BY_TYPE, which will be called in fastapi jsonable_encoder
-for key,value in encoder_registry.items():
+for key, value in encoder_registry.items():
     ENCODERS_BY_TYPE[key] = value['serialize']
+
 
 def _start_application(config: Configuration):
     """

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -254,7 +254,7 @@ async def render_component(
             # returned dict back into an instance of the BaseModel class
             val = value
             typ = annotations.get(key)
-            if typ in encoder_registry:
+            if typ is not None and typ in encoder_registry:
                 val = encoder_registry[typ]['deserialize'](val)
             elif typ is not None and isclass(typ) and issubclass(typ, BaseModel) and isinstance(value, dict):
                 val = typ(**value)

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -46,12 +46,12 @@ from dara.core.interactivity import (
     Variable,
 )
 from dara.core.internal.dependency_resolution import resolve_dependency
+from dara.core.internal.encoder_registry import encoder_registry
 from dara.core.internal.store import Store
 from dara.core.internal.tasks import MetaTask, TaskManager
 from dara.core.internal.utils import run_user_handler
 from dara.core.logging import dev_logger, eng_logger
 from dara.core.visual.components import InvalidComponent, RawString
-from dara.core.internal.encoder_registry import encoder_registry
 
 CURRENT_COMPONENT_ID = ContextVar('current_component_id', default='')
 

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -51,6 +51,7 @@ from dara.core.internal.tasks import MetaTask, TaskManager
 from dara.core.internal.utils import run_user_handler
 from dara.core.logging import dev_logger, eng_logger
 from dara.core.visual.components import InvalidComponent, RawString
+from dara.core.internal.encoder_registry import encoder_registry
 
 CURRENT_COMPONENT_ID = ContextVar('current_component_id', default='')
 
@@ -255,6 +256,8 @@ async def render_component(
             typ = annotations.get(key)
             if typ is not None and isclass(typ) and issubclass(typ, BaseModel) and isinstance(value, dict):
                 val = typ(**value)
+            elif typ in encoder_registry:
+                val = encoder_registry[typ]['deserialize'](val)
             resolved_dyn_kwargs[key] = val
 
         # Merge resolved dynamic kwargs with static kwargs received

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -254,10 +254,10 @@ async def render_component(
             # returned dict back into an instance of the BaseModel class
             val = value
             typ = annotations.get(key)
-            if typ is not None and isclass(typ) and issubclass(typ, BaseModel) and isinstance(value, dict):
-                val = typ(**value)
-            elif typ in encoder_registry:
+            if typ in encoder_registry:
                 val = encoder_registry[typ]['deserialize'](val)
+            elif typ is not None and isclass(typ) and issubclass(typ, BaseModel) and isinstance(value, dict):
+                val = typ(**value)
             resolved_dyn_kwargs[key] = val
 
         # Merge resolved dynamic kwargs with static kwargs received

--- a/packages/dara-core/tests/python/utils.py
+++ b/packages/dara-core/tests/python/utils.py
@@ -8,11 +8,11 @@ from typing import (
     List,
     Mapping,
     Tuple,
-    TypedDict,
     TypeVar,
     Union,
     cast,
 )
+from typing_extensions import TypedDict
 from unittest.mock import MagicMock
 
 import anyio


### PR DESCRIPTION
## Motivation and Context
Errors occur when the backend is trying to return a component json data to the frontend, which contains datatypes in pandas/numpy. The reason behind this is fastapi doesn't know how to handle serialisation of those datatypes.

Hence, an encoder registry is introduced to handle the serialisation and deserialisation.

## Implementation Description
Defined a global encoder dict registry, in which key is a class Type, and each type have two handlers, one for serialisation and one for serialisation.

User can add their custom encoder to the global encoder dict registry by calling config.add_encoder()

## Any new dependencies Introduced
None

## How Has This Been Tested?
Locally tested.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->