### PR TITLE
Fix: DO-1862 custsup table search does not show up

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -1,7 +1,9 @@
 ---
 title: Changelog
 ---
+## NETX
 
+-   Fixed an issue where `Table` search bar was hidden by the table itself
 ## 1.1.8
 
 -   Fixed an issue where `Table` did not return the correct index row when sorted

--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -1,7 +1,7 @@
 ---
 title: Changelog
 ---
-## NETX
+## NEXT
 
 -   Fixed an issue where `Table` search bar was hidden by the table itself
 ## 1.1.8

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -110,7 +110,7 @@ const columnSortTypes: Record<ColumnProps['type'], (a: any, b: any, id: string) 
 const TableSearch = styled.div`
     display: flex;
     justify-content: flex-end;
-    padding: 1rem 1rem 0rem 1rem;
+    padding: 0rem 1rem;
 `;
 
 function getCellRenderer(formatter: { [k: string]: any }): any {
@@ -541,7 +541,7 @@ function Table(props: TableProps): JSX.Element {
                 flex: '1 1 auto',
                 flexDirection: 'column',
                 // Set a min height so at the very least Table shows header and one row
-                minHeight: '96px',
+                minHeight: props.searchable ? '8.5rem' : '6rem',
                 overflow: 'auto',
                 position: 'relative',
                 ...style,
@@ -557,12 +557,12 @@ function Table(props: TableProps): JSX.Element {
                 <div
                     style={{
                         bottom: 0,
-                        height: '100%',
+                        height: props.searchable ? 'calc(100% - 2.5rem)' : '100%',
                         left: 0,
                         padding: props.searchable ? '0.5rem 1rem 1rem 1rem' : '1rem',
                         position: 'absolute',
                         right: 0,
-                        top: 0,
+                        top: props.searchable ? '2.5rem' : 0,
                     }}
                 >
                     <UiTable

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -110,7 +110,6 @@ const columnSortTypes: Record<ColumnProps['type'], (a: any, b: any, id: string) 
 const TableSearch = styled.div`
     display: flex;
     justify-content: flex-end;
-    padding: 0rem 1rem;
 `;
 
 function getCellRenderer(formatter: { [k: string]: any }): any {
@@ -541,7 +540,7 @@ function Table(props: TableProps): JSX.Element {
                 flex: '1 1 auto',
                 flexDirection: 'column',
                 // Set a min height so at the very least Table shows header and one row
-                minHeight: props.searchable ? '8.5rem' : '6rem',
+                minHeight: props.searchable ? '9rem' : '6rem',
                 overflow: 'auto',
                 position: 'relative',
                 ...style,
@@ -552,17 +551,17 @@ function Table(props: TableProps): JSX.Element {
                     <Input onChange={onSearchChange} placeholder="Search Table..." />
                 </TableSearch>
             )}
-            {/* Padding is moved to the wrapper otherwise the autosizer calculates the size wrong in some cases */}
+            {/* paddingBottom is needed due to an issue with AutoSizer constantly recalculating the height */}
             {resolvedColumns && (
                 <div
                     style={{
                         bottom: 0,
-                        height: props.searchable ? 'calc(100% - 2.5rem)' : '100%',
+                        height: props.searchable ? 'calc(100% - 3rem)' : '100%',
                         left: 0,
-                        padding: props.searchable ? '0.5rem 1rem 1rem 1rem' : '1rem',
+                        paddingBottom: '1.1rem',
                         position: 'absolute',
                         right: 0,
-                        top: props.searchable ? '2.5rem' : 0,
+                        top: props.searchable ? '3rem' : 0,
                     }}
                 >
                     <UiTable


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Even with `searchable` set to True the search box did not appear over the Table component.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue was found due to Table's inset to be defaulted to zero. That meant that the Table was on top of the search bar. The inset is needed as a hack around some resizing issues we had in the past however it did not account for the bar being present. To fix this I have added a condition on searchable set, where if true adds some space for it.

Table unlike other components also had some padding set around it, this has been removed.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by rendering a Table with and without searchable flag
On safari, firefox and chrome

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
![table scroll](https://github.com/causalens/dara/assets/104359539/ed59fa05-85c3-4bfd-8722-ead67726ff65)
