### PR TITLE
Fix: DO-1902 fix default pandas.Timestamp encoder & build 1.2.2

### DIFF
--- a/borg.toml
+++ b/borg.toml
@@ -1,1 +1,1 @@
-version = "1.2.1"
+version = "1.2.2"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "pnpm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "packages": [
     "packages/*"
   ],

--- a/packages/create-dara-app/pyproject.toml
+++ b/packages/create-dara-app/pyproject.toml
@@ -27,7 +27,7 @@ license = "Apache-2.0"
 name = "create-dara-app"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.2.1"
+version = "1.2.2"
 
 [tool.poetry.dependencies]
 click = "=8.1.3"

--- a/packages/dara-components/package.json
+++ b/packages/dara-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darajs/components",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Components for the Dara framework",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@bokeh/bokehjs": "~3.1.1",
-    "@darajs/core": "1.2.1",
+    "@darajs/core": "1.2.2",
     "@darajs/styled-components": "~1.2.0",
     "@darajs/ui-causal-graph-editor": "~1.2.0",
     "@darajs/ui-code-editor": "~1.2.0",

--- a/packages/dara-components/pyproject.toml
+++ b/packages/dara-components/pyproject.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0"
 name = "dara-components"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.2.1"
+version = "1.2.2"
 
 [[tool.poetry.packages]]
 include = "dara"
@@ -33,7 +33,7 @@ include = "dara"
 [tool.poetry.dependencies]
 bokeh = ">=3.1.0, <3.2.0"
 cai-causal-graph = ">=0.1.0"
-dara-core = "=1.2.1"
+dara-core = "=1.2.2"
 dill = ">=0.3.0, <0.4.0"
 matplotlib = ">=2.0.0"
 pandas = ">=1.1.0, <3.0.0"

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## 1.2.2
+
+-   Fixed an issue where the default encoders for `pandas.Timeseries`, `numpy.complex64` and `numpy.complex128` would output unserializable values
+
 ## 1.2.1
 
 -   Fixed an issue where `DataVariable` would fail to initialize with data when created within a synchronous handler function

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## 1.2.2
 
--   Fixed an issue where the default encoders for `pandas.Timeseries`, `numpy.complex64` and `numpy.complex128` would output unserializable values
+-   Fixed an issue where the default encoders for certain types such as `pandas.Timeseries`, `numpy.complex64` and `numpy.complex128` would output unserializable values
 
 ## 1.2.1
 

--- a/packages/dara-core/dara/core/interactivity/data_variable.py
+++ b/packages/dara-core/dara/core/interactivity/data_variable.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 import asyncio
 from typing import Optional, Union
 
-from anyio.abc import TaskGroup
 from anyio import from_thread
+from anyio.abc import TaskGroup
 from pandas import DataFrame
 from pydantic import BaseModel
 
@@ -121,7 +121,6 @@ class DataVariable(AnyDataVariable):
                     # Fallback - we're in an external thread without an event loop, so we need to use a blocking portal
                     with from_thread.start_blocking_portal() as portal:
                         portal.call(self._update, var_entry, store, data)
-
 
     @staticmethod
     def _get_cache_key(uid: str) -> str:

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=unnecessary-lambda
-from typing import Any, Callable, MutableMapping, Optional, Type
+from typing import Any, Callable, MutableMapping, Type
 
 import numpy
 import pandas
@@ -46,7 +46,7 @@ def _get_numpy_str_encoder(typ: Type[Any]):
     """
     return Encoder(serialize=lambda x: str(x), deserialize=lambda x: typ(x))
 
-def _get_pandas_array_encoder(array_type: Type[Any], dtype: Type[Any], raise_: bool = False):
+def _get_pandas_array_encoder(array_type: Type[Any], dtype: Any, raise_: bool = False):
     return Encoder(
         serialize=lambda x: x.astype(str).tolist(),
         deserialize=lambda x: pandas.array(x, dtype=dtype) if not raise_ else _not_implemented(x, dtype)

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=unnecessary-lambda
-from typing import Any, Callable, MutableMapping, Type
+from typing import Any, Callable, MutableMapping, Optional, Type
 
 import numpy
 import pandas
@@ -27,6 +27,8 @@ class Encoder(TypedDict):
     serialize: Callable
     deserialize: Callable
 
+def _not_implemented(x):
+    raise NotImplementedError(f'No deserialization implementation for item {x}')
 
 def _get_numpy_dtypes_encoder(typ: Type[Any]):
     """
@@ -36,6 +38,19 @@ def _get_numpy_dtypes_encoder(typ: Type[Any]):
     """
     return Encoder(serialize=lambda x: x.item(), deserialize=lambda x: typ(x))
 
+def _get_numpy_str_encoder(typ: Type[Any]):
+    """
+    Construct numpy str datatype
+
+    :param typ: The numpy datatype class
+    """
+    return Encoder(serialize=lambda x: str(x), deserialize=lambda x: typ(x))
+
+def _get_pandas_array_encoder(array_type: Type[Any], dtype: Optional[Type[Any]]):
+    return Encoder(
+        serialize=lambda x: x.astype(str).tolist(),
+        deserialize=lambda x: pandas.array(x, dtype=dtype) if dtype else _not_implemented(x)
+    )
 
 # A encoder_registry to handle serialization/deserialization for numpy/pandas type
 encoder_registry: MutableMapping[Type[Any], Encoder] = {
@@ -45,7 +60,7 @@ encoder_registry: MutableMapping[Type[Any], Encoder] = {
     numpy.int32: _get_numpy_dtypes_encoder(numpy.int32),
     numpy.int64: _get_numpy_dtypes_encoder(numpy.int64),
     numpy.longlong: _get_numpy_dtypes_encoder(numpy.longlong),
-    numpy.timedelta64: _get_numpy_dtypes_encoder(numpy.timedelta64),
+    numpy.timedelta64:  Encoder(serialize=lambda x: x.astype('timedelta64[ns]').item(), deserialize=lambda x: numpy.timedelta64(int(x), 'ns')),
     numpy.uint8: _get_numpy_dtypes_encoder(numpy.uint8),
     numpy.uint16: _get_numpy_dtypes_encoder(numpy.uint16),
     numpy.uint32: _get_numpy_dtypes_encoder(numpy.uint32),
@@ -54,17 +69,23 @@ encoder_registry: MutableMapping[Type[Any], Encoder] = {
     numpy.float16: _get_numpy_dtypes_encoder(numpy.float16),
     numpy.float32: _get_numpy_dtypes_encoder(numpy.float32),
     numpy.float64: _get_numpy_dtypes_encoder(numpy.float64),
-    numpy.longdouble: _get_numpy_dtypes_encoder(numpy.longdouble),
-    numpy.complex64: Encoder(serialize=lambda x: str(x), deserialize=lambda x: numpy.complex64(x)),
-    numpy.complex128: Encoder(serialize=lambda x: str(x), deserialize=lambda x: numpy.complex128(x)),
-    numpy.clongdouble: _get_numpy_dtypes_encoder(numpy.clongdouble),
-    numpy.bytes_: _get_numpy_dtypes_encoder(numpy.bytes_),
+    numpy.longdouble: _get_numpy_str_encoder(numpy.longdouble),
+    numpy.complex64: _get_numpy_str_encoder(numpy.complex64),
+    numpy.complex128: _get_numpy_str_encoder(numpy.complex128),
+    numpy.clongdouble: _get_numpy_str_encoder(numpy.clongdouble),
+    numpy.bytes_: Encoder(serialize=lambda x: x.decode('utf-8'), deserialize=lambda x: numpy.bytes_(x)),
     numpy.str_: _get_numpy_dtypes_encoder(numpy.str_),
-    numpy.void: _get_numpy_dtypes_encoder(numpy.void),
-    numpy.record: _get_numpy_dtypes_encoder(numpy.record),
+    numpy.void: Encoder(serialize=lambda x: x.tobytes().decode(), deserialize=lambda x: numpy.void(x.encode())),
     numpy.bool_: _get_numpy_dtypes_encoder(numpy.bool_),
-    numpy.datetime64: _get_numpy_dtypes_encoder(numpy.datetime64),
+    numpy.datetime64: Encoder(serialize=lambda x: x.item().isoformat(), deserialize=lambda x: numpy.datetime64(x)),
     ExtensionArray: Encoder(serialize=lambda x: x.tolist(), deserialize=lambda x: pandas.array(x)),
+    pandas.arrays.IntervalArray: _get_pandas_array_encoder(pandas.arrays.IntervalArray, pandas.Interval),
+    pandas.arrays.PeriodArray: _get_pandas_array_encoder(pandas.arrays.PeriodArray, None),
+    pandas.arrays.DatetimeArray: _get_pandas_array_encoder(pandas.arrays.DatetimeArray, numpy.dtype('datetime64[ns]')),
+    pandas.arrays.IntegerArray: _get_pandas_array_encoder(pandas.arrays.IntegerArray, numpy.dtype('int')),
+    pandas.arrays.FloatingArray: _get_pandas_array_encoder(pandas.arrays.FloatingArray, numpy.dtype('float')),
+    pandas.arrays.StringArray: _get_pandas_array_encoder(pandas.arrays.StringArray, str),
+    pandas.arrays.BooleanArray: _get_pandas_array_encoder(pandas.arrays.BooleanArray, numpy.dtype('bool')),
     pandas.Series: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Series(x)),
     pandas.Index: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Index(x)),
     pandas.Timestamp: Encoder(serialize=lambda x: x.isoformat(), deserialize=lambda x: pandas.Timestamp(x)),

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, MutableMapping, Type
 
 import numpy
 import pandas
+from pandas.core.arrays.base import ExtensionArray
 from typing_extensions import TypedDict
 
 
@@ -54,8 +55,8 @@ encoder_registry: MutableMapping[Type[Any], Encoder] = {
     numpy.float32: _get_numpy_dtypes_encoder(numpy.float32),
     numpy.float64: _get_numpy_dtypes_encoder(numpy.float64),
     numpy.longdouble: _get_numpy_dtypes_encoder(numpy.longdouble),
-    numpy.complex64: _get_numpy_dtypes_encoder(numpy.complex64),
-    numpy.complex128: _get_numpy_dtypes_encoder(numpy.complex128),
+    numpy.complex64: Encoder(serialize=lambda x: str(x), deserialize=lambda x: numpy.complex64(x)),
+    numpy.complex128: Encoder(serialize=lambda x: str(x), deserialize=lambda x: numpy.complex128(x)),
     numpy.clongdouble: _get_numpy_dtypes_encoder(numpy.clongdouble),
     numpy.bytes_: _get_numpy_dtypes_encoder(numpy.bytes_),
     numpy.str_: _get_numpy_dtypes_encoder(numpy.str_),
@@ -63,8 +64,8 @@ encoder_registry: MutableMapping[Type[Any], Encoder] = {
     numpy.record: _get_numpy_dtypes_encoder(numpy.record),
     numpy.bool_: _get_numpy_dtypes_encoder(numpy.bool_),
     numpy.datetime64: _get_numpy_dtypes_encoder(numpy.datetime64),
-    pandas.array: Encoder(serialize=lambda x: x.tolist(), deserialize=lambda x: pandas.array(x)),
+    ExtensionArray: Encoder(serialize=lambda x: x.tolist(), deserialize=lambda x: pandas.array(x)),
     pandas.Series: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Series(x)),
     pandas.Index: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Index(x)),
-    pandas.Timestamp: Encoder(serialize=lambda x: x.date(), deserialize=lambda x: pandas.Timestamp(x)),
+    pandas.Timestamp: Encoder(serialize=lambda x: x.isoformat(), deserialize=lambda x: pandas.Timestamp(x)),
 }

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -85,7 +85,7 @@ encoder_registry: MutableMapping[Type[Any], Encoder] = {
     pandas.arrays.IntegerArray: _get_pandas_array_encoder(pandas.arrays.IntegerArray, numpy.dtype('int')),
     pandas.arrays.FloatingArray: _get_pandas_array_encoder(pandas.arrays.FloatingArray, numpy.dtype('float')),
     pandas.arrays.StringArray: _get_pandas_array_encoder(pandas.arrays.StringArray, str),
-    pandas.arrays.BooleanArray: _get_pandas_array_encoder(pandas.arrays.BooleanArray, numpy.dtype('bool')),
+    pandas.arrays.BooleanArray: Encoder(serialize=lambda x: x.tolist(), deserialize=lambda x: pandas.array(x, dtype='boolean')),
     pandas.Series: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Series(x)),
     pandas.Index: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Index(x)),
     pandas.Timestamp: Encoder(serialize=lambda x: x.isoformat(), deserialize=lambda x: pandas.Timestamp(x)),

--- a/packages/dara-core/package.json
+++ b/packages/dara-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darajs/core",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Dara Framework core",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/dara-core/pyproject.toml
+++ b/packages/dara-core/pyproject.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0"
 name = "dara-core"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.2.1"
+version = "1.2.2"
 
 [[tool.poetry.packages]]
 include = "dara"
@@ -62,11 +62,11 @@ xlrd = "*"
 
 [tool.poetry.dependencies.create-dara-app]
 optional = true
-version = "=1.2.1"
+version = "=1.2.2"
 
 [tool.poetry.dependencies.dara-components]
 optional = true
-version = "=1.2.1"
+version = "=1.2.2"
 
 [tool.poetry.dependencies.uvicorn]
 extras = ["standard"]

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -32,7 +32,7 @@ from dara.core.internal.encoder_registry import encoder_registry
     (numpy.void, numpy.void(b'test'), False),
     (numpy.bool_, numpy.bool_(True), False),
     (numpy.datetime64, numpy.datetime64('2023-10-04'), False),
-    (pandas.arrays.IntervalArray, pandas.arrays.IntervalArray.from_tuples([(0, 1), (2, 3)]), False),
+    (pandas.arrays.IntervalArray, pandas.arrays.IntervalArray.from_tuples([(0, 1), (2, 3)]), True),
     (pandas.arrays.PeriodArray, pandas.period_range(start='2000Q1', end='2000Q2', freq='Q').array, True),
     (pandas.arrays.DatetimeArray, pandas.to_datetime(['2000-01-01', '2000-01-02']).array, False),
     (pandas.arrays.IntegerArray, pandas.array([1, 2, 3], dtype='Int32'), False),

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -1,0 +1,64 @@
+import json
+import numpy
+import pandas
+from pandas.core.arrays.base import ExtensionArray
+import pytest
+
+from dara.core.internal.encoder_registry import encoder_registry
+
+
+@pytest.mark.parametrize('type_, value, raise_', [
+    (numpy.ndarray, numpy.array([1, 2, 3]), False),
+    (numpy.int8, numpy.int8(1), False),
+    (numpy.int16, numpy.int16(1), False),
+    (numpy.int32, numpy.int32(1), False),
+    (numpy.int64, numpy.int64(1), False),
+    (numpy.longlong, numpy.longlong(1), False),
+    (numpy.timedelta64, numpy.timedelta64(1, 'D'), False),
+    (numpy.uint8, numpy.uint8(1), False),
+    (numpy.uint16, numpy.uint16(1), False),
+    (numpy.uint32, numpy.uint32(1), False),
+    (numpy.uint64, numpy.uint64(1), False),
+    (numpy.ulonglong, numpy.ulonglong(1), False),
+    (numpy.float16, numpy.float16(1.0), False),
+    (numpy.float32, numpy.float32(1.0), False),
+    (numpy.float64, numpy.float64(1.0), False),
+    (numpy.longdouble, numpy.longdouble(1.0), False),
+    (numpy.complex64, numpy.complex64(1 + 2j), False),
+    (numpy.complex128, numpy.complex128(1 + 2j), False),
+    (numpy.clongdouble, numpy.clongdouble(1 + 2j), False),
+    (numpy.bytes_, numpy.bytes_('test', encoding='utf-8'), False),
+    (numpy.str_, numpy.str_('test'), False),
+    (numpy.void, numpy.void(b'test'), False),
+    (numpy.bool_, numpy.bool_(True), False),
+    (numpy.datetime64, numpy.datetime64('2023-10-04'), False),
+    (pandas.arrays.IntervalArray, pandas.arrays.IntervalArray.from_tuples([(0, 1), (2, 3)]), False),
+    (pandas.arrays.PeriodArray, pandas.period_range(start='2000Q1', end='2000Q2', freq='Q').array, True),
+    (pandas.arrays.DatetimeArray, pandas.to_datetime(['2000-01-01', '2000-01-02']).array, False),
+    (pandas.arrays.IntegerArray, pandas.array([1, 2, 3], dtype='Int32'), False),
+    (pandas.arrays.FloatingArray, pandas.array([1.0, 2.0, 3.0], dtype='Float64'), False),
+    (pandas.arrays.StringArray, pandas.array(['a', 'b', 'c']), False),
+    (pandas.arrays.BooleanArray, pandas.array([True, False, True]), False),
+    (pandas.Series, pandas.Series([1, 2, 3]), False),
+    (pandas.Index, pandas.Index([1, 2, 3]), False),
+    (pandas.Timestamp, pandas.Timestamp('2023-10-04'), False)
+])
+def test_serialization_deserialization(type_, value, raise_):
+    encoder = encoder_registry[type_]
+    serialized = json.dumps(encoder['serialize'](value))
+
+    if raise_:
+        with pytest.raises(NotImplementedError):
+            encoder['deserialize'](json.loads(serialized))
+        return
+
+    deserialized = encoder['deserialize'](json.loads(serialized))
+
+    # If it's a pandas type use built-in equality
+    if isinstance(value, pandas.Series) or isinstance(value, pandas.Index):
+        assert value.equals(deserialized)
+    # Handle pandas arrays
+    elif isinstance(value, ExtensionArray):
+        assert numpy.array_equal(value, deserialized)
+    else:
+        assert numpy.array_equal(value, deserialized) or value == deserialized

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
   packages/dara-components:
     specifiers:
       '@bokeh/bokehjs': ~3.1.1
-      '@darajs/core': 1.2.1
+      '@darajs/core': 1.2.2
       '@darajs/eslint-config': ~1.2.0
       '@darajs/prettier-config': ~1.2.0
       '@darajs/styled-components': ~1.2.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -216,14 +216,14 @@ xyzservices = ">=2021.09.1"
 
 [[package]]
 name = "cai-causal-graph"
-version = "0.2.4"
+version = "0.2.5"
 description = "A Causal AI package for causal graphs."
 category = "main"
 optional = false
 python-versions = ">=3.8.0,<3.12.0"
 files = [
-    {file = "cai_causal_graph-0.2.4-py3-none-any.whl", hash = "sha256:fc267e8cfb30c4b6622af9f955fa2410d058e34806d52dc9f78d6791b7250f91"},
-    {file = "cai_causal_graph-0.2.4.tar.gz", hash = "sha256:3c76cae8ae1f7b0012ce9053634b0ad575da6efa1ba2d7758865bc2ccccda280"},
+    {file = "cai_causal_graph-0.2.5-py3-none-any.whl", hash = "sha256:991269e24c8b8a33059927b60e2f2bc006a6bd9f6864f2b18c18974f7bdbda35"},
+    {file = "cai_causal_graph-0.2.5.tar.gz", hash = "sha256:8ac10d5e761937757c4ffd67fd8cd32072d2259bc9773dda8d15c56deb9cc707"},
 ]
 
 [package.dependencies]
@@ -543,7 +543,7 @@ rich = "*"
 
 [[package]]
 name = "create-dara-app"
-version = "1.2.1"
+version = "1.2.2"
 description = "CLI to quickly bootstrap a Dara app"
 category = "main"
 optional = false
@@ -638,7 +638,7 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "dara-components"
-version = "1.2.1"
+version = "1.2.2"
 description = "Components for the Dara Framework"
 category = "main"
 optional = false
@@ -649,7 +649,7 @@ develop = true
 [package.dependencies]
 bokeh = ">=3.1.0, <3.2.0"
 cai-causal-graph = ">=0.1.0"
-dara-core = "=1.2.1"
+dara-core = "=1.2.2"
 dill = ">=0.3.0, <0.4.0"
 matplotlib = ">=2.0.0"
 pandas = ">=1.1.0, <3.0.0"
@@ -663,7 +663,7 @@ url = "packages/dara-components"
 
 [[package]]
 name = "dara-core"
-version = "1.2.1"
+version = "1.2.2"
 description = "Dara Framework Core"
 category = "main"
 optional = false
@@ -702,7 +702,7 @@ uvicorn = {version = "^0.22.0", extras = ["standard"]}
 xlrd = "*"
 
 [package.extras]
-all = ["dara-components (==1.2.1)"]
+all = ["dara-components (==1.2.2)"]
 
 [package.source]
 type = "directory"
@@ -3075,4 +3075,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0, <3.12.0"
-content-hash = "13b400f6340014dfcd98bea779ab1cbea8d0ef38fab89702bfd3a0e0c84ea5df"
+content-hash = "9e9ed9455e9986961243c2cde9aec8b4c5b3ac32186007d60026aa1a6bfa86b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,73 +2,77 @@
 requires = ["poetry"]
 [tool.poetry]
 name = "borg-meta-package"
-version = "1.2.1"
+version = "1.2.2"
 description = "Borg Meta Package"
 authors = ["borg"]
 
 [tool.poetry.dependencies]
-cryptography = ">=41.0.3"
 pyjwt = ">=2.0.1, <3.0.0"
-pandas = ">=1.1.0, <3.0.0"
-dill = ">=0.3.0, <0.4.0"
-scipy = "*"
-dara-core = "=1.2.1"
-matplotlib = ">=2.0.0"
-cookiecutter = "^2.1.1"
-colorama = "^0.4.6"
-odfpy = "*"
-fastapi-vite = "^0.3.1"
-seaborn = ">=0.11.0"
-plotly = ">=5.14.0, <5.15.0"
-exceptiongroup = "^1.1.3"
-bokeh = ">=3.1.0, <3.2.0"
-python = ">=3.8.0, <3.12.0"
-openpyxl = "*"
-tblib = "^1.7.0"
-async-asgi-testclient = "^1.4.11"
-pydantic = ">=1.8.1, <2.0.0"
-xlrd = "*"
-python-dotenv = "^0.19.2"
-typing-extensions = ">=4.0.0, <4.6.0"
-httpx = ">=0.23.0"
-python-multipart = "^0.0.5"
-croniter = "^1.0.15"
-toml = "^0.10.2"
-packaging = "^23.1"
-pyarrow = "*"
-jinja2 = ">=2.1.1, <3.1.0"
-anyio = ">=4.0.0"
-prometheus-client = "^0.14.1"
 responses = "^0.18.0"
-click = "=8.1.3"
-fastapi = ">=0.95.1, <0.96.0"
+exceptiongroup = "^1.1.3"
+anyio = ">=4.0.0"
+python-dotenv = "^0.19.2"
+tblib = "^1.7.0"
 cai-causal-graph = ">=0.1.0"
+click = "=8.1.3"
+pandas = ">=1.1.0, <3.0.0"
 pyxlsb = "*"
-
-[tool.poetry.dependencies.create-dara-app]
-version = "=1.2.1"
-optional = true
+async-asgi-testclient = "^1.4.11"
+jinja2 = ">=2.1.1, <3.1.0"
+openpyxl = "*"
+colorama = "^0.4.6"
+xlrd = "*"
+python-multipart = "^0.0.5"
+pyarrow = "*"
+fastapi = ">=0.95.1, <0.96.0"
+prometheus-client = "^0.14.1"
+httpx = ">=0.23.0"
+cookiecutter = "^2.1.1"
+matplotlib = ">=2.0.0"
+croniter = "^1.0.15"
+python = ">=3.8.0, <3.12.0"
+packaging = "^23.1"
+scipy = "*"
+cryptography = ">=41.0.3"
+seaborn = ">=0.11.0"
+toml = "^0.10.2"
+fastapi-vite = "^0.3.1"
+pydantic = ">=1.8.1, <2.0.0"
+odfpy = "*"
+dill = ">=0.3.0, <0.4.0"
+typing-extensions = ">=4.0.0, <4.6.0"
+dara-core = "=1.2.2"
+bokeh = ">=3.1.0, <3.2.0"
+plotly = ">=5.14.0, <5.15.0"
 
 [tool.poetry.dependencies.uvicorn]
 version = "^0.22.0"
 
+[tool.poetry.dependencies.create-dara-app]
+version = "=1.2.2"
+optional = true
+
 [tool.poetry.dependencies.dara-components]
-version = "=1.2.1"
+version = "=1.2.2"
 optional = true
 
 [tool.poetry.dev-dependencies]
+pytest-timeout = "^2.1.0"
+types-croniter = "^1.0.10"
+freezegun = "^1.2.2"
 blue = "^0.9.0"
-bandit = "^1.7.5"
-requests = ">=2.25.1, <3.0.0"
 pytest = "^7.0.0"
 isort = "^5.10.1"
-pylint-print = "^1.0.1"
 types-requests = "^2.28.1"
-freezegun = "^1.2.2"
-pytest-timeout = "^2.1.0"
 mypy = "^0.991.0"
-types-croniter = "^1.0.10"
+requests = ">=2.25.1, <3.0.0"
 pylint = ">=2.6.0, <3.0.0"
+bandit = "^1.7.5"
+pylint-print = "^1.0.1"
+
+[tool.poetry.dev-dependencies.create-dara-app]
+path = "packages/create-dara-app"
+develop = true
 
 [tool.poetry.dev-dependencies.dara-components]
 path = "packages/dara-components"
@@ -76,9 +80,5 @@ develop = true
 
 [tool.poetry.dev-dependencies.dara-core]
 path = "packages/dara-core"
-develop = true
-
-[tool.poetry.dev-dependencies.create-dara-app]
-path = "packages/create-dara-app"
 develop = true
 [tool.borg.scripts]


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Issue found when testing out new 1.2 changes, the default encoder for pandas.Timestamp was previously outputting a datetime object which was unserializable. Fixed by using the same isoformat method as the native datetime object uses.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by modifying code directly in the project where the issue was spotted

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->