### PR TITLE
Fix: DO-1913: table has a weird scrollbar in dara 1 2

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `Table` would always overflow
+
 ## 1.1.10
 
 -   Internal: `parseLayoutDefinition` and `GraphLayoutDefinition` are now exposed on js side `CausalGraph` object can now accept extras.  

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -558,6 +558,7 @@ function Table(props: TableProps): JSX.Element {
                 </TableSearch>
             )}
             {/* paddingBottom is needed due to an issue with AutoSizer constantly recalculating the height */}
+            {/* width is needed due to an issue with AutoSizer miscalculating the width to be a value greater than it should be */}
             {resolvedColumns && (
                 <div
                     style={{

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -568,6 +568,7 @@ function Table(props: TableProps): JSX.Element {
                         position: 'absolute',
                         right: 0,
                         top: props.searchable ? '3rem' : 0,
+                        width: 'calc(100% - 1px)',
                     }}
                 >
                     <UiTable


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
After 1.2 release a horizontal scrollbar would always appear in Table component

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
This seems to be an issue with the AutoSizer calculating a width just slightly larger than it should.  This does not seem to happen if the component has left/right paddings above a certain threshold. While playing with it I noticed we could alternative set the width to 100% - 1px, it seems that in some cases defining a width to a parent component helps the AutoSizer. This seems to allow the AutoSizer to get the size just right. 

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested locally with a layered structure of tables. In Chrome, Safari and Firefox on different screen sizes

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
<img width="1440" alt="Screenshot 2023-10-09 at 16 42 42" src="https://github.com/causalens/dara/assets/104359539/e0e85e93-a37a-462a-bdd2-ad1815ee014d">

