### PR TITLE
Fix: DO-1952 `resource` package usage on Windows installations & build 1.3.1

### DIFF
--- a/borg.toml
+++ b/borg.toml
@@ -1,1 +1,1 @@
-version = "1.3.0"
+version = "1.3.1"

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "npmClient": "pnpm",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "packages": [
     "packages/*"
   ],

--- a/packages/create-dara-app/pyproject.toml
+++ b/packages/create-dara-app/pyproject.toml
@@ -27,7 +27,7 @@ license = "Apache-2.0"
 name = "create-dara-app"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.3.0"
+version = "1.3.1"
 
 [tool.poetry.dependencies]
 click = "=8.1.3"

--- a/packages/dara-components/package.json
+++ b/packages/dara-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darajs/components",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Components for the Dara framework",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@bokeh/bokehjs": "~3.1.1",
-    "@darajs/core": "1.3.0",
+    "@darajs/core": "1.3.1",
     "@darajs/styled-components": "~1.2.0",
     "@darajs/ui-causal-graph-editor": "~1.2.0",
     "@darajs/ui-code-editor": "~1.2.0",

--- a/packages/dara-components/pyproject.toml
+++ b/packages/dara-components/pyproject.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0"
 name = "dara-components"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.3.0"
+version = "1.3.1"
 
 [[tool.poetry.packages]]
 include = "dara"
@@ -33,7 +33,7 @@ include = "dara"
 [tool.poetry.dependencies]
 bokeh = ">=3.1.0, <3.2.0"
 cai-causal-graph = ">=0.1.0"
-dara-core = "=1.3.0"
+dara-core = "=1.3.1"
 dill = ">=0.3.0, <0.4.0"
 matplotlib = ">=2.0.0"
 pandas = ">=1.1.0, <3.0.0"

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## 1.3.1
+
+-   Fixed usage of `resource` package which is not supported on Windows. Attempting to use `CGROUP_MEMORY_LIMIT_ENABLED` on Windows is now a noop and emits a warning.
+
 ## 1.3.0
 
 -   Internal: allow handler implementation substitution for variables, `py_component`, upload resolver and action resolver on a registry entry level

--- a/packages/dara-core/dara/core/internal/cgroup.py
+++ b/packages/dara-core/dara/core/internal/cgroup.py
@@ -18,9 +18,9 @@ limitations under the License.
 from __future__ import annotations
 
 import os
-import resource
+import sys
 
-from dara.core.logging import eng_logger
+from dara.core.logging import dev_logger, eng_logger
 
 CGROUP_V2_INDICATOR_PATH = '/sys/fs/cgroup/cgroup.controllers'   # Used to determine whether we're using cgroupv2
 
@@ -37,6 +37,12 @@ def set_memory_limit():
     Set memory limit for Python to limits defined in the cgroup.
     Works with both cgroupv1 and cgroupv2.
     """
+    if sys.platform == "win32":
+        dev_logger.warning('Memory limit is not supported on Windows platforms')
+        return
+
+    import resource
+
     # Get current limits
     soft, hard = resource.getrlimit(resource.RLIMIT_AS)
 

--- a/packages/dara-core/package.json
+++ b/packages/dara-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@darajs/core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Dara Framework core",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/dara-core/pyproject.toml
+++ b/packages/dara-core/pyproject.toml
@@ -25,7 +25,7 @@ license = "Apache-2.0"
 name = "dara-core"
 readme = "README.md"
 repository = "https://github.com/causalens/dara"
-version = "1.3.0"
+version = "1.3.1"
 
 [[tool.poetry.packages]]
 include = "dara"
@@ -62,11 +62,11 @@ xlrd = "*"
 
 [tool.poetry.dependencies.create-dara-app]
 optional = true
-version = "=1.3.0"
+version = "=1.3.1"
 
 [tool.poetry.dependencies.dara-components]
 optional = true
-version = "=1.3.0"
+version = "=1.3.1"
 
 [tool.poetry.dependencies.uvicorn]
 extras = ["standard"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
   packages/dara-components:
     specifiers:
       '@bokeh/bokehjs': ~3.1.1
-      '@darajs/core': 1.3.0
+      '@darajs/core': 1.3.1
       '@darajs/eslint-config': ~1.2.0
       '@darajs/prettier-config': ~1.2.0
       '@darajs/styled-components': ~1.2.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -216,14 +216,14 @@ xyzservices = ">=2021.09.1"
 
 [[package]]
 name = "cai-causal-graph"
-version = "0.2.6"
+version = "0.2.8"
 description = "A Causal AI package for causal graphs."
 category = "main"
 optional = false
 python-versions = ">=3.8.0,<3.12.0"
 files = [
-    {file = "cai_causal_graph-0.2.6-py3-none-any.whl", hash = "sha256:a6733ee5057d7fd36241021ed735a8e6f290480175fb8bddc1801807a0e102b6"},
-    {file = "cai_causal_graph-0.2.6.tar.gz", hash = "sha256:620dcbef64c0746507c98126a3f88224881c52841d42ef8d56cc363fffce2d1e"},
+    {file = "cai_causal_graph-0.2.8-py3-none-any.whl", hash = "sha256:7629408386c7cfebe51d447d91ecb4e3e7379dc210e47fd36cf2ddb0991e0aac"},
+    {file = "cai_causal_graph-0.2.8.tar.gz", hash = "sha256:cd6294754b9ea33bc086f392c43fbf30ebb5c15259df074f92fe3d9085ad1d18"},
 ]
 
 [package.dependencies]
@@ -543,7 +543,7 @@ rich = "*"
 
 [[package]]
 name = "create-dara-app"
-version = "1.3.0"
+version = "1.3.1"
 description = "CLI to quickly bootstrap a Dara app"
 category = "main"
 optional = false
@@ -622,14 +622,14 @@ test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "cycler"
-version = "0.12.0"
+version = "0.12.1"
 description = "Composable style cycles"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "cycler-0.12.0-py3-none-any.whl", hash = "sha256:7896994252d006771357777d0251f3e34d266f4fa5f2c572247a80ab01440947"},
-    {file = "cycler-0.12.0.tar.gz", hash = "sha256:8cc3a7b4861f91b1095157f9916f748549a617046e67eb7619abed9b34d2c94a"},
+    {file = "cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30"},
+    {file = "cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"},
 ]
 
 [package.extras]
@@ -638,7 +638,7 @@ tests = ["pytest", "pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "dara-components"
-version = "1.3.0"
+version = "1.3.1"
 description = "Components for the Dara Framework"
 category = "main"
 optional = false
@@ -649,7 +649,7 @@ develop = true
 [package.dependencies]
 bokeh = ">=3.1.0, <3.2.0"
 cai-causal-graph = ">=0.1.0"
-dara-core = "=1.3.0"
+dara-core = "=1.3.1"
 dill = ">=0.3.0, <0.4.0"
 matplotlib = ">=2.0.0"
 pandas = ">=1.1.0, <3.0.0"
@@ -663,7 +663,7 @@ url = "packages/dara-components"
 
 [[package]]
 name = "dara-core"
-version = "1.3.0"
+version = "1.3.1"
 description = "Dara Framework Core"
 category = "main"
 optional = false
@@ -702,7 +702,7 @@ uvicorn = {version = "^0.22.0", extras = ["standard"]}
 xlrd = "*"
 
 [package.extras]
-all = ["dara-components (==1.3.0)"]
+all = ["dara-components (==1.3.1)"]
 
 [package.source]
 type = "directory"
@@ -2188,14 +2188,14 @@ testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "no
 
 [[package]]
 name = "pytest-timeout"
-version = "2.1.0"
+version = "2.2.0"
 description = "pytest plugin to abort hanging tests"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
-    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
+    {file = "pytest-timeout-2.2.0.tar.gz", hash = "sha256:3b0b95dabf3cb50bac9ef5ca912fa0cfc286526af17afc806824df20c2f72c90"},
+    {file = "pytest_timeout-2.2.0-py3-none-any.whl", hash = "sha256:bde531e096466f49398a59f2dde76fa78429a09a12411466f88a07213e220de2"},
 ]
 
 [package.dependencies]
@@ -3075,4 +3075,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.0, <3.12.0"
-content-hash = "bebcd6d5a13194070134ca7b4023acb2294b7a9ba0c780c73efb7c40479521b5"
+content-hash = "c8f170c5ff1c093269b7a188925187cf18c401528d10d5526ffbf35e7f2f27d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,73 +2,77 @@
 requires = ["poetry"]
 [tool.poetry]
 name = "borg-meta-package"
-version = "1.3.0"
+version = "1.3.1"
 description = "Borg Meta Package"
 authors = ["borg"]
 
 [tool.poetry.dependencies]
+packaging = "^23.1"
+python = ">=3.8.0, <3.12.0"
+pydantic = ">=1.8.1, <2.0.0"
+scipy = "*"
+plotly = ">=5.14.0, <5.15.0"
+dill = ">=0.3.0, <0.4.0"
+cryptography = ">=41.0.3"
+odfpy = "*"
+pyarrow = "*"
+pandas = ">=1.1.0, <3.0.0"
+xlrd = "*"
+seaborn = ">=0.11.0"
+python-dotenv = "^0.19.2"
+tblib = "^1.7.0"
+cai-causal-graph = ">=0.1.0"
+httpx = ">=0.23.0"
+exceptiongroup = "^1.1.3"
+matplotlib = ">=2.0.0"
+openpyxl = "*"
 anyio = ">=4.0.0"
 croniter = "^1.0.15"
-python-multipart = "^0.0.5"
+async-asgi-testclient = "^1.4.11"
 toml = "^0.10.2"
 bokeh = ">=3.1.0, <3.2.0"
-fastapi = ">=0.95.1, <0.96.0"
-matplotlib = ">=2.0.0"
-pyjwt = ">=2.0.1, <3.0.0"
-async-asgi-testclient = "^1.4.11"
-openpyxl = "*"
-scipy = "*"
-responses = "^0.18.0"
-pandas = ">=1.1.0, <3.0.0"
+python-multipart = "^0.0.5"
 typing-extensions = ">=4.0.0, <4.6.0"
-pydantic = ">=1.8.1, <2.0.0"
-pyxlsb = "*"
-exceptiongroup = "^1.1.3"
-python-dotenv = "^0.19.2"
-plotly = ">=5.14.0, <5.15.0"
-seaborn = ">=0.11.0"
-httpx = ">=0.23.0"
-odfpy = "*"
-cookiecutter = "^2.1.1"
-prometheus-client = "^0.14.1"
-python = ">=3.8.0, <3.12.0"
-click = "=8.1.3"
-packaging = "^23.1"
-fastapi-vite = "^0.3.1"
-pyarrow = "*"
-xlrd = "*"
-tblib = "^1.7.0"
-dill = ">=0.3.0, <0.4.0"
-cai-causal-graph = ">=0.1.0"
-colorama = "^0.4.6"
-dara-core = "=1.3.0"
 jinja2 = ">=2.1.1, <3.1.0"
-cryptography = ">=41.0.3"
-
-[tool.poetry.dependencies.create-dara-app]
-version = "=1.3.0"
-optional = true
-
-[tool.poetry.dependencies.dara-components]
-version = "=1.3.0"
-optional = true
+fastapi-vite = "^0.3.1"
+responses = "^0.18.0"
+prometheus-client = "^0.14.1"
+click = "=8.1.3"
+colorama = "^0.4.6"
+pyxlsb = "*"
+cookiecutter = "^2.1.1"
+fastapi = ">=0.95.1, <0.96.0"
+dara-core = "=1.3.1"
+pyjwt = ">=2.0.1, <3.0.0"
 
 [tool.poetry.dependencies.uvicorn]
 version = "^0.22.0"
 
+[tool.poetry.dependencies.create-dara-app]
+version = "=1.3.1"
+optional = true
+
+[tool.poetry.dependencies.dara-components]
+version = "=1.3.1"
+optional = true
+
 [tool.poetry.dev-dependencies]
-blue = "^0.9.0"
-types-croniter = "^1.0.10"
-mypy = "^0.991.0"
-isort = "^5.10.1"
-pylint = ">=2.6.0, <3.0.0"
-requests = ">=2.25.1, <3.0.0"
-freezegun = "^1.2.2"
-pytest-timeout = "^2.1.0"
-pytest = "^7.0.0"
-bandit = "^1.7.5"
-pylint-print = "^1.0.1"
 types-requests = "^2.28.1"
+isort = "^5.10.1"
+bandit = "^1.7.5"
+types-croniter = "^1.0.10"
+requests = ">=2.25.1, <3.0.0"
+pylint = ">=2.6.0, <3.0.0"
+mypy = "^0.991.0"
+freezegun = "^1.2.2"
+pytest = "^7.0.0"
+pylint-print = "^1.0.1"
+blue = "^0.9.0"
+pytest-timeout = "^2.1.0"
+
+[tool.poetry.dev-dependencies.dara-components]
+path = "packages/dara-components"
+develop = true
 
 [tool.poetry.dev-dependencies.create-dara-app]
 path = "packages/create-dara-app"
@@ -76,9 +80,5 @@ develop = true
 
 [tool.poetry.dev-dependencies.dara-core]
 path = "packages/dara-core"
-develop = true
-
-[tool.poetry.dev-dependencies.dara-components]
-path = "packages/dara-components"
 develop = true
 [tool.borg.scripts]


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Fixes #106 

The issue stems from our usage of the [resource](https://docs.python.org/3/library/resource.html) package for limiting memory usage within containers (which is set with env CGROUP_MEMORY_LIMIT_ENABLED). The package is [unix-specific](https://docs.python.org/3.10/library/unix.html) and is not available for Windows machine.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

The `set_memory_limit` util now checks the `sys.platform` const. If it's `win32`, the function emits a warning and immediately returns **before** attempting to import the `resource` package.

Includes patch 1.3.1

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Untested due to lack of access to a Windows machine. Future improvement would be having a Windows build in CI that runs at least in some intervals to validate all tests pass on Windows.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->