### PR TITLE
Fix: DO-1909 cannot set margin for text component

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Fixed an issue where `Table` would always overflow
+-   Fixed an issue where one could not set `margin` to `Text` component
 
 ## 1.1.10
 

--- a/packages/dara-components/js/common/label/label.tsx
+++ b/packages/dara-components/js/common/label/label.tsx
@@ -36,8 +36,8 @@ function Label(props: LabelProps): JSX.Element {
             $rawCss={css}
             className={props.className}
             style={{
-                ...style,
                 flexDirection: props.direction === 'horizontal' ? 'row' : 'column',
+                ...style,
             }}
         >
             {typeof props.value === 'string' ? (

--- a/packages/dara-components/js/common/paragraph/paragraph.tsx
+++ b/packages/dara-components/js/common/paragraph/paragraph.tsx
@@ -20,7 +20,7 @@ const StyledP = injectCss('p');
 function Paragraph(props: ParagraphProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     return (
-        <StyledP $rawCss={css} className={props.className} style={{ ...style, textAlign: props.align }}>
+        <StyledP $rawCss={css} className={props.className} style={{ textAlign: props.align, ...style }}>
             <DisplayCtx.Provider value={{ component: ComponentType.PARAGRAPH, direction: 'horizontal' }}>
                 {props.children.map((child, idx) => (
                     <DynamicComponent component={child} key={`stack-${idx}-${child.name}`} />

--- a/packages/dara-components/js/common/text/text.tsx
+++ b/packages/dara-components/js/common/text/text.tsx
@@ -32,7 +32,6 @@ function Text(props: TextProps): JSX.Element {
                 $rawCss={css}
                 className={props.className}
                 style={{
-                    ...style,
                     border: props?.border ?? 'none',
                     color,
                     fontStyle: props.italic ? 'italic' : 'normal',
@@ -40,6 +39,7 @@ function Text(props: TextProps): JSX.Element {
                     marginRight: '0.1em',
                     textAlign: props.align,
                     textDecoration: props.underline ? 'underline' : '',
+                    ...style,
                 }}
             >
                 {`${typeof text === 'string' ? text.trimEnd() : text} `}

--- a/packages/dara-components/js/common/text/text.tsx
+++ b/packages/dara-components/js/common/text/text.tsx
@@ -54,10 +54,10 @@ function Text(props: TextProps): JSX.Element {
             as={tag}
             className={props.className}
             style={{
-                ...style,
                 color,
                 margin: '0',
                 textAlign: props.align,
+                ...style,
             }}
         >
             {text}


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Could not set `margin` for a `Text` component

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
`...style` was applied before `margin` on `Text`, this meant that margin prop, was overwritten by the Text's own styling.

Also took the opportunity to check and fix other places where this might happen
## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on a test app

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->