### PR TITLE
Fix: DO-1953 numeric input breaks when emptied

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -   Fixed an issue where `Table` would always overflow
+-   Fixed an issue where `NaN` was not handled in `Input` with `type=number`
 
 ## 1.1.10
 

--- a/packages/dara-components/js/common/input/input.tsx
+++ b/packages/dara-components/js/common/input/input.tsx
@@ -41,11 +41,14 @@ function Input(props: InputProps): JSX.Element {
     const debouncedUpdateForm = useMemo(() => _debounce(formCtx.updateForm, 500), [formCtx.updateForm]);
 
     function handleChange(val: string | number): void {
+        let newValue = val;
+        if (props.type === 'number') {
+            newValue = Number.isNaN(Number(newValue)) ? null : Number(newValue);
+        }
         // Immmediately update internal state
-        setInternalValue(props.type === 'number' ? Number(val) : val);
-
+        setInternalValue(newValue);
         // Debounce the update to the variable and the form to prevent multiple updates being fired at once
-        debouncedSetValue(props.type === 'number' ? Number(val) : val);
+        debouncedSetValue(newValue);
         debouncedAction(val);
         debouncedUpdateForm(val);
     }


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
It was found that when Input of type number was emptied and the user did not enter another number quickly it would crash.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue was due to when the NumericInput emptied its value became NaN which was not handled resulting in infinite updates to the point the component crashed. The fix was to handle it by setting to null when empty

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on a test version of an app

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->