### PR TITLE
Improvement: DO-1993: Add explicit value support for Select/Multiselect/Combobox

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## Next
+
+-   Added support for displaying a `value` in `Select` that may not be part of the `items` list.
+
 ## 1.3.2
 
 -   Fixed an issue where `Table` would always overflow

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
+import { isArray } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
@@ -36,6 +37,9 @@ export function getMultiselectItems(values: Array<any>, items: Array<Item>): Arr
         return acc;
     }, []);
 }
+
+const toItem = (value: any): Item | undefined | null =>
+    typeof value === 'string' || typeof value === 'number' ? { label: String(value), value } : value;
 
 const StyledSelect = injectCss(UiSelect);
 const StyledMultiSelect = injectCss(MultiSelect);
@@ -137,9 +141,9 @@ function Select(props: SelectProps): JSX.Element {
 
     // We need to redefine items as the type is not known at this point
     const itemArray = formattedItems as Array<Item>;
-
     if (props.multiselect) {
-        const [selectedItems, setSelectedItems] = useState(getMultiselectItems(value, itemArray));
+        const explicitValues = isArray(value) ? value.map(toItem) : value;
+        const [selectedItems, setSelectedItems] = useState(explicitValues ?? getMultiselectItems(value, itemArray));
         const onSelect = useCallback(
             (_items: Array<Item>) => {
                 const currentSelection = _items.map((item: Item) => item.value);
@@ -169,10 +173,9 @@ function Select(props: SelectProps): JSX.Element {
             />
         );
     }
-    const explicitValue =
-        typeof value === 'string' || typeof value === 'number' ? { label: String(value), value } : value;
+    const explicitValue = toItem(value);
     const [selectedItem, setSelectedItem] = useState(
-        itemArray.find((item) => String(item.value) === String(value)) ?? explicitValue
+        explicitValue ?? itemArray.find((item) => String(item.value) === String(value))
     );
     const onSelect = useCallback(
         (item: Item) => {
@@ -187,7 +190,7 @@ function Select(props: SelectProps): JSX.Element {
     );
     // See explanation above
     useEffect(() => {
-        const selected = itemArray.find((item) => item.value === value) ?? explicitValue;
+        const selected = explicitValue ?? itemArray.find((item) => item.value === value);
         setSelectedItem(selected !== undefined ? selected : null);
     }, [formattedItems, value]);
     if (props.searchable) {

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -169,7 +169,11 @@ function Select(props: SelectProps): JSX.Element {
             />
         );
     }
-    const [selectedItem, setSelectedItem] = useState(itemArray.find((item) => String(item.value) === String(value)));
+    const explicitValue =
+        typeof value === 'string' || typeof value === 'number' ? { label: String(value), value } : value;
+    const [selectedItem, setSelectedItem] = useState(
+        itemArray.find((item) => String(item.value) === String(value)) ?? explicitValue
+    );
     const onSelect = useCallback(
         (item: Item) => {
             if (item) {
@@ -183,7 +187,7 @@ function Select(props: SelectProps): JSX.Element {
     );
     // See explanation above
     useEffect(() => {
-        const selected = itemArray.find((item) => item.value === value);
+        const selected = itemArray.find((item) => item.value === value) ?? explicitValue;
         setSelectedItem(selected !== undefined ? selected : null);
     }, [formattedItems, value]);
     if (props.searchable) {

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
-import { isArray } from 'lodash';
+import { isArray, isEmpty } from 'lodash';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
@@ -143,7 +143,8 @@ function Select(props: SelectProps): JSX.Element {
     const itemArray = formattedItems as Array<Item>;
     if (props.multiselect) {
         const explicitValues = isArray(value) ? value.map(toItem) : value;
-        const [selectedItems, setSelectedItems] = useState(explicitValues ?? getMultiselectItems(value, itemArray));
+        const foundItems = getMultiselectItems(value, itemArray);
+        const [selectedItems, setSelectedItems] = useState(isEmpty(foundItems) ? explicitValues : foundItems);
         const onSelect = useCallback(
             (_items: Array<Item>) => {
                 const currentSelection = _items.map((item: Item) => item.value);
@@ -175,7 +176,7 @@ function Select(props: SelectProps): JSX.Element {
     }
     const explicitValue = toItem(value);
     const [selectedItem, setSelectedItem] = useState(
-        explicitValue ?? itemArray.find((item) => String(item.value) === String(value))
+        itemArray.find((item) => String(item.value) === String(value)) ?? explicitValue
     );
     const onSelect = useCallback(
         (item: Item) => {
@@ -190,7 +191,7 @@ function Select(props: SelectProps): JSX.Element {
     );
     // See explanation above
     useEffect(() => {
-        const selected = explicitValue ?? itemArray.find((item) => item.value === value);
+        const selected = itemArray.find((item) => item.value === value) ?? explicitValue;
         setSelectedItem(selected !== undefined ? selected : null);
     }, [formattedItems, value]);
     if (props.searchable) {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
Currently, the select component will not display a value if it's not also present in the list of items. This presents a problem when that list of items uses a piece of derived state, which might not be available at the time of render.

This PR lets us explicitly state a `value` of a Select/Multiselect/Combobox, even if it's not in the list of `items`.

## Implementation Description
If an explicit value is set, it can either be a primitive, in which case it will get converted to an `Item`, or an object, which will be displayed as is.

For the multiselect case, every primitive item in the array will be converted to an `Item` as well.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
![image](https://github.com/causalens/dara/assets/119343173/b1ac2fd1-dbcb-440f-8974-9ac866d908b2)
