### PR TITLE
Fix: DO-2004 deserializer running for already serialized values

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fix an issue where argument restoration for actions, derived variables and `py_component`s would attempt to restore a value to the annotated type even when the value was already of the correct type
+
 ## 1.4.0
 
 -   Implement new action API in the form of the `@action` decorator. This decorator takes a function and returns an action that can be passed to a component's callback. It injects an `ActionCtx` object (aliased as `action.Ctx`) as the first argument of the function, which contains the input sent from the component and exposes action methods. This allows for full control over the action's behaviour, including the ability to conditionally execute specific actions with control flow, error handling etc. See the updated `actions` documentation page for more details on the new API and migration guide for the existing APIs.

--- a/packages/dara-core/dara/core/interactivity/derived_variable.py
+++ b/packages/dara-core/dara/core/interactivity/derived_variable.py
@@ -211,6 +211,12 @@ class DerivedVariable(NonDataVariable, Generic[VariableType]):
 
     @staticmethod
     def _restore_pydantic_models(func: Callable[..., Any], *args):
+        """
+        Restore argument types based on their annotations.
+
+        :param func: the function to restore the arguments for
+        :param args: the arguments to restore
+        """
         parsed_args = []
         parameters = list(signature(func).parameters.values())
         # Scan the list for any var arg or kwarg arguments

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -26,7 +26,6 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 from dara.core.base_definitions import BaseTask
-from dara.core.logging import dev_logger
 
 
 class Encoder(TypedDict):
@@ -123,7 +122,7 @@ def deserialize(value: Any, typ: Optional[Type]):
     :param value: the value to deserialize
     :param typ: the type to deserialize into
     """
-    # This funtion is commonly used to deserialize parameters, which can be empty rather than None
+    # This funtion is commonly used to deserialize parameters, which can be Parameter.empty rather than None
     if typ == Parameter.empty:
         return value
 

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -155,7 +155,7 @@ def deserialize(value: Any, typ: Optional[Type]):
         if isclass(typ) and issubclass(typ, BaseModel) and value is not None:
             return typ(**value)
     except Exception as e:
-        dev_logger.error(f'Failed to deserialize value {value} into type {typ}', e)
+        dev_logger.error(f'Failed to deserialize value {value} into expected type {typ}. Consider defining a custom deserializer for the type using the `config.add_encoder` API', e)
 
     # Fall back to returning the value
     return value

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -155,7 +155,7 @@ def deserialize(value: Any, typ: Optional[Type]):
         if isclass(typ) and issubclass(typ, BaseModel) and value is not None:
             return typ(**value)
     except Exception as e:
-        dev_logger.error(f'Failed to deserialize value {value} into expected type {typ}. Consider defining a custom deserializer for the type using the `config.add_encoder` API', e)
+        dev_logger.error(f'Failed to deserialize value {value} into expected type {typ}. Consider defining a custom deserializer for the type using the `config.add_encoder` API or removing the type annotation and handling the raw value manually', e)
 
     # Fall back to returning the value
     return value

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -155,7 +155,7 @@ def deserialize(value: Any, typ: Optional[Type]):
         if isclass(typ) and issubclass(typ, BaseModel) and value is not None:
             return typ(**value)
     except Exception as e:
-        dev_logger.error(f'Failed to deserialize value {value} into expected type {typ}. Consider defining a custom deserializer for the type using the `config.add_encoder` API or removing the type annotation and handling the raw value manually', e)
+        raise ValueError(f'Failed to deserialize value "{value}" into expected type "{typ}". Consider defining a custom deserializer for the type using the `config.add_encoder` API or removing the type annotation and handling the raw value manually') from e
 
     # Fall back to returning the value
     return value

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -139,7 +139,7 @@ def deserialize(value: Any, typ: Optional[Type]):
     if type(value) == typ:
         return value
 
-    # Handle Optional[foo] -> call deserialize(value, foo)
+    # Handle Optional[foo] / Union[foo, None] -> call deserialize(value, foo)
     if get_origin(typ) == Union:
         args = get_args(typ)
         if len(args) == 2 and type(None) in args:

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -113,10 +113,14 @@ def test_deserialize_error_falls_back_to_value():
     assert deserialize('foo', int) == 'foo'
 
 
-def test_deserialize_complex_type():
-    """Complex types e.g. unions work, they are simply ignored"""
+def test_deserialize_UNION_type():
+    """Unions are not supported"""
     typ = Union[str, int]
     assert deserialize('foo', typ) == 'foo'
 
-    assert deserialize(None, Optional[str]) == None
-    assert deserialize('foo', Optional[str]) == 'foo'
+def test_deserialize_optional():
+    assert deserialize(None, Optional[int]) == None
+    assert deserialize('123', Optional[int]) == 123
+    assert deserialize('123', Union[int, None]) == 123
+    assert deserialize('123', Union[None, int]) == 123
+

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -108,9 +108,10 @@ def test_deserialize_same_type():
     bar = Bar(value='foo')
     assert deserialize(bar, Bar) == bar
 
-def test_deserialize_error_falls_back_to_value():
-    # Test that if deserialize errors, the value is returned raw instead
-    assert deserialize('foo', int) == 'foo'
+def test_deserialize_error_raises():
+    # Test that if deserialize errors, an error is raised
+    with pytest.raises(ValueError):
+        deserialize('foo', int)
 
 
 def test_deserialize_UNION_type():

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -1,5 +1,6 @@
 from inspect import Parameter
 import json
+from typing import Optional, Union
 from dara.core.base_definitions import PendingTask
 from dara.core.internal.tasks import Task
 
@@ -111,3 +112,11 @@ def test_deserialize_error_falls_back_to_value():
     # Test that if deserialize errors, the value is returned raw instead
     assert deserialize('foo', int) == 'foo'
 
+
+def test_deserialize_complex_type():
+    """Complex types e.g. unions work, they are simply ignored"""
+    typ = Union[str, int]
+    assert deserialize('foo', typ) == 'foo'
+
+    assert deserialize(None, Optional[str]) == None
+    assert deserialize('foo', Optional[str]) == 'foo'

--- a/packages/dara-core/tests/python/test_py_component.py
+++ b/packages/dara-core/tests/python/test_py_component.py
@@ -401,6 +401,49 @@ async def test_base_model_args_are_restored():
         assert response.status_code == 200
         assert response.json() == {'name': 'MockComponent', 'props': {'text': 'test'}, 'uid': 'uid'}
 
+async def test_base_model_not_restored_when_already_instance():
+    """Test that when a type is expected by a PyComponent handler that an already instantiated instance is not restored"""
+    builder = ConfigurationBuilder()
+
+    class InputClass(BaseModel):
+        val: str
+
+    @py_component
+    def TestBasicComp(input_val: InputClass):
+        return MockComponent(text=input_val.val)
+
+    var = Variable('foo')
+    dv = DerivedVariable(lambda x: InputClass(val=x), variables=[var])
+    builder.add_page('Test', content=TestBasicComp(dv))
+    config = create_app(builder)
+
+    # Run the app so the component is initialized
+    app = _start_application(config)
+    async with AsyncClient(app) as client:
+
+        # Get the components ID from the template
+        response, status = await _get_template(client)
+        component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
+
+        # Check that the component can be fetched via the api, with input dict passed in the body
+        response = await _get_py_component(
+            client,
+            component.get('name'),
+            kwargs={'input_val': dv},
+            data={
+                'uid': component.get('uid'),
+                'values': {
+                    'input_val': {
+                        'type': 'derived',
+                        'uid': str(dv.uid),
+                        'values': ['foo']
+                    }
+                },
+                'ws_channel': 'test_channel'
+            },
+        )
+        assert response.status_code == 200
+        assert response.json() == {'name': 'MockComponent', 'props': {'text': 'foo'}, 'uid': 'uid'}
 
 async def test_compatibility_with_polling():
     """Test that a py_component with polling gets passed the param correctly"""


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Previous PR moved the shared arg restoration logic to a central `deserialize` method (previously scattered in DV and py_component logic) as it's now also reused by actions.

It turns out there was a bug there where when the incoming type was already correct (e.g. the type was coming from a derived variable - serverside - or a static kwarg) the deserializer would still attempt to run and fail in some cases.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Several improvements made to the deserializer:
- ensured if `type(value) == type`, skip deserialization
- handle `Optional[foo]` to call `deserialize(value, foo)`
- on failed deserialization, the raw value is returned and an error is logged; this means in case of an error it should still be clear what went wrong and we display an error message

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on a demo app where the issue occured, copying over the fixed file resolved the issue.
Updated tests to cover the restoration logic for actions, py_components and DVs
Added tests for the deserialize method to cover all cases

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->