### PR TITLE
Fix: DO-1984 numeric input controlled value

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed issue where in some cases if `Input` of type number value variable was update outside the component, the value would not show.
+
 ## 1.4.0
 
 -   Added support for displaying a `value` in `Select` that may not be part of the `items` list.

--- a/packages/dara-components/js/common/input/input.tsx
+++ b/packages/dara-components/js/common/input/input.tsx
@@ -59,8 +59,13 @@ function Input(props: InputProps): JSX.Element {
         debouncedSetValue.cancel();
         debouncedUpdateForm.cancel();
 
+        // If value has been coerced to string convert it back to number for NumericInput
+        let newValue = value;
+        if (props.type === 'number') {
+            newValue = Number.isNaN(Number(newValue)) ? null : Number(newValue);
+        }
         // Sync the internal value with the variable value when the variable value changes
-        setInternalValue(value);
+        setInternalValue(newValue);
     }, [value]);
 
     if (props.type === 'number') {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
When using an input of type number in scenario manager I noticed that it would not load with any value.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue was found due to if the variable value became a string in the update then the component could would not show it. The fix was to handle external updates by converting it to a number, in the same way that we do with its own updates.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by updating the variable's value through actions

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->