### PR TITLE
Improvement: DO-2030 normalize `py_component` responses

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   `py_component` results are now normalized, which means multiple instances of the same variables within the returned components will be deduplicated. This should significantly reduce the amount of data sent over the wire in some cases.
+
 ## 1.4.2
 
 -   Fixed an issue where `.get()` API on `Variable` would not behave correctly when used as the update target within actions (either legacy `UpdateVariable` or new `ActionCtx.update` method)

--- a/packages/dara-core/dara/core/internal/normalization.py
+++ b/packages/dara-core/dara/core/internal/normalization.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Generic, List, Mapping, Tuple, TypeVar, Union, cast, overload
+from typing import Any, Generic, List, Mapping, Optional, Tuple, TypeVar, Union, cast, overload
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict, TypeGuard
@@ -158,6 +158,10 @@ def normalize(obj: JsonLike, check_root: bool = True) -> Tuple[JsonLike, Mapping
     :param check_root: whether to check if the root object is also a referrable object
     """
     lookup = {}
+
+    if not isinstance(obj, (dict, list)):
+        return obj, lookup
+
     output: Union[Mapping[Any, Any], List[Any]] = {} if isinstance(obj, dict) else [None for x in range(len(obj))]
 
     # The whole object is referrable
@@ -192,13 +196,16 @@ def denormalize(normalized_obj: List, lookup: Mapping) -> List:
     ...
 
 
-def denormalize(normalized_obj: JsonLike, lookup: Mapping) -> JsonLike:
+def denormalize(normalized_obj: JsonLike, lookup: Mapping) -> Optional[JsonLike]:
     """
     Denormalize data by replacing Placeholders found with objects from the lookup
 
     :normalized_obj: object or list containing placeholders
     :lookup: dict mapping identifiers to referrables
     """
+    if normalized_obj is None:
+        return None
+
     output: Union[Mapping[Any, Any], List[Any]] = (
         {} if isinstance(normalized_obj, dict) else [None for x in range(len(normalized_obj))]
     )

--- a/packages/dara-core/dara/core/internal/normalization.py
+++ b/packages/dara-core/dara/core/internal/normalization.py
@@ -15,7 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from typing import Any, Generic, List, Mapping, Optional, Tuple, TypeVar, Union, cast, overload
+from typing import (
+    Any,
+    Generic,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict, TypeGuard
@@ -157,7 +168,7 @@ def normalize(obj: JsonLike, check_root: bool = True) -> Tuple[JsonLike, Mapping
     :param obj: object to normalize
     :param check_root: whether to check if the root object is also a referrable object
     """
-    lookup = {}
+    lookup: dict = {}
 
     if not isinstance(obj, (dict, list)):
         return obj, lookup

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -20,6 +20,7 @@ import os
 from functools import wraps
 from importlib.metadata import version
 from typing import Any, Callable, List, Mapping, Optional
+from fastapi.encoders import jsonable_encoder
 
 import pandas
 from fastapi import (

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -20,7 +20,6 @@ import os
 from functools import wraps
 from importlib.metadata import version
 from typing import Any, Callable, List, Mapping, Optional
-from fastapi.encoders import jsonable_encoder
 
 import pandas
 from fastapi import (

--- a/packages/dara-core/dara/core/internal/tasks.py
+++ b/packages/dara-core/dara/core/internal/tasks.py
@@ -509,7 +509,7 @@ class TaskManager:
                             if message.task_id in self.tasks:
                                 self.tasks[task.task_id].resolve(message.result)
                             # If the task has a cache key, update the cached value
-                            if message.cache_key is not None and message.reg_entry is not None:
+                            if message.cache_key is not None and message.reg_entry is not None and message.reg_entry.cache is not None:
                                 await self.store.set(message.reg_entry, key=message.cache_key, value=message.result)
                             # Notify the channels of the task's completion
                             await notify_channels(
@@ -522,7 +522,7 @@ class TaskManager:
 
                             # If the task has a cache key, set cached value to None
                             # This makes it so that the next request will recalculate the value rather than keep failing
-                            if message.cache_key is not None and message.reg_entry is not None:
+                            if message.cache_key is not None and message.reg_entry is not None and message.reg_entry.cache is not None:
                                 await self.store.set(message.reg_entry, key=message.cache_key, value=None)
 
             try:

--- a/packages/dara-core/dara/core/internal/tasks.py
+++ b/packages/dara-core/dara/core/internal/tasks.py
@@ -509,7 +509,11 @@ class TaskManager:
                             if message.task_id in self.tasks:
                                 self.tasks[task.task_id].resolve(message.result)
                             # If the task has a cache key, update the cached value
-                            if message.cache_key is not None and message.reg_entry is not None and message.reg_entry.cache is not None:
+                            if (
+                                message.cache_key is not None
+                                and message.reg_entry is not None
+                                and message.reg_entry.cache is not None
+                            ):
                                 await self.store.set(message.reg_entry, key=message.cache_key, value=message.result)
                             # Notify the channels of the task's completion
                             await notify_channels(
@@ -522,7 +526,11 @@ class TaskManager:
 
                             # If the task has a cache key, set cached value to None
                             # This makes it so that the next request will recalculate the value rather than keep failing
-                            if message.cache_key is not None and message.reg_entry is not None and message.reg_entry.cache is not None:
+                            if (
+                                message.cache_key is not None
+                                and message.reg_entry is not None
+                                and message.reg_entry.cache is not None
+                            ):
                                 await self.store.set(message.reg_entry, key=message.cache_key, value=None)
 
             try:

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -34,6 +34,8 @@ from typing import (
     overload,
 )
 
+from fastapi.encoders import jsonable_encoder
+
 from dara.core.base_definitions import BaseTask
 from dara.core.definitions import BaseFallback, ComponentInstance, PyComponentDef
 from dara.core.interactivity import (
@@ -51,7 +53,6 @@ from dara.core.internal.tasks import MetaTask, TaskManager
 from dara.core.internal.utils import run_user_handler
 from dara.core.logging import dev_logger, eng_logger
 from dara.core.visual.components import InvalidComponent, RawString
-from fastapi.encoders import jsonable_encoder
 
 CURRENT_COMPONENT_ID = ContextVar('current_component_id', default='')
 

--- a/packages/dara-core/dara/core/visual/dynamic_component.py
+++ b/packages/dara-core/dara/core/visual/dynamic_component.py
@@ -46,10 +46,12 @@ from dara.core.interactivity import (
 from dara.core.internal.cache_store import CacheStore
 from dara.core.internal.dependency_resolution import resolve_dependency
 from dara.core.internal.encoder_registry import deserialize
+from dara.core.internal.normalization import NormalizedPayload, normalize
 from dara.core.internal.tasks import MetaTask, TaskManager
 from dara.core.internal.utils import run_user_handler
 from dara.core.logging import dev_logger, eng_logger
 from dara.core.visual.components import InvalidComponent, RawString
+from fastapi.encoders import jsonable_encoder
 
 CURRENT_COMPONENT_ID = ContextVar('current_component_id', default='')
 
@@ -311,24 +313,28 @@ def _make_render_safe(handler: Callable):
     :param handler: the user handler to wrap
     """
 
-    async def _render_safe(**kwargs: Dict[str, Any]):
+    async def _render_safe(**kwargs: Dict[str, Any]) -> NormalizedPayload[Optional[ComponentInstance]]:
         result = await run_user_handler(handler, kwargs=kwargs)
+        safe_result: Optional[ComponentInstance] = None
 
         if result is None:
-            return None
+            safe_result = None
         elif isinstance(result, (str, float, int, bool)):
             # If it is ComponentInstance string(string start with '__dara__')
             if isinstance(result, str) and result.startswith('__dara__'):
-                return json.loads(result[8:])
+                safe_result = json.loads(result[8:])
 
             # Handle primitives being returned by just displaying the value as a string
-            return RawString(content=str(result))
+            safe_result = RawString(content=str(result))
         elif not isinstance(result, ComponentInstance):
             # Otherwise it must be a component instance, return the error for frontend to display
-            return InvalidComponent(
+            safe_result = InvalidComponent(
                 error=f'PyComponent "{handler.__name__}" did not return a ComponentInstance, found "{result}"'
             )
+        else:
+            safe_result = result
 
-        return result
+        normalized_data, normalized_lookup = normalize(jsonable_encoder(safe_result))
+        return NormalizedPayload(data=normalized_data, lookup=normalized_lookup)
 
     return _render_safe

--- a/packages/dara-core/js/shared/utils/normalization.tsx
+++ b/packages/dara-core/js/shared/utils/normalization.tsx
@@ -65,6 +65,10 @@ export function denormalize(obj: JsonArray, lookup: Mapping): JsonArray;
  * @param lookup map of identifier -> referrable
  */
 export function denormalize(obj: JsonLike, lookup: Mapping): Mapping | JsonArray {
+    if (!obj) {
+        return obj;
+    }
+
     if (isPlaceholder(obj)) {
         const referrable = lookup[obj.__ref];
         return denormalize(referrable, lookup);

--- a/packages/dara-core/tests/js/dynamic-component.spec.tsx
+++ b/packages/dara-core/tests/js/dynamic-component.spec.tsx
@@ -72,11 +72,14 @@ describe('DynamicComponent', () => {
             rest.post('/api/core/components/:component', async (req, res, ctx) => {
                 return res(
                     ctx.json({
-                        name: 'RawString',
-                        props: {
-                            content: 'test_content',
+                        data: {
+                            name: 'RawString',
+                            props: {
+                                content: 'test_content',
+                            },
+                            uid: 'uid',
                         },
-                        uid: 'uid',
+                        lookup: {},
                     })
                 );
             })
@@ -105,11 +108,14 @@ describe('DynamicComponent', () => {
             rest.post('/api/core/components/:component', async (req, res, ctx) => {
                 return res(
                     ctx.json({
-                        name: 'InvalidComponent',
-                        props: {
-                            error: 'test_error',
+                        data: {
+                            name: 'InvalidComponent',
+                            props: {
+                                error: 'test_error',
+                            },
+                            uid: 'uid',
                         },
-                        uid: 'uid',
+                        lookup: {},
                     })
                 );
             })

--- a/packages/dara-core/tests/js/progress-tracker.spec.tsx
+++ b/packages/dara-core/tests/js/progress-tracker.spec.tsx
@@ -540,11 +540,14 @@ describe('ProgressTracker', () => {
             rest.get('/api/core/tasks/:taskId', async (req, res, ctx) => {
                 return res(
                     ctx.json({
-                        name: 'RawString',
-                        props: {
-                            content: 'success',
+                        data: {
+                            name: 'RawString',
+                            props: {
+                                content: 'success',
+                            },
+                            uid: vuid,
                         },
-                        uid: vuid,
+                        lookup: {},
                     })
                 );
             })

--- a/packages/dara-core/tests/js/utils/test-server-handlers.tsx
+++ b/packages/dara-core/tests/js/utils/test-server-handlers.tsx
@@ -83,8 +83,11 @@ const handlers = [
     rest.post('/api/core/components/:component', async (req, res, ctx) => {
         return res(
             ctx.json({
-                name: 'RawString',
-                props: { content: `${String(req.params.component)}: ${JSON.stringify(req.body)}` },
+                data: {
+                    name: 'RawString',
+                    props: { content: `${String(req.params.component)}: ${JSON.stringify(req.body)}` },
+                },
+                lookup: {},
             })
         );
     }),

--- a/packages/dara-core/tests/python/test_data_variable.py
+++ b/packages/dara-core/tests/python/test_data_variable.py
@@ -533,7 +533,7 @@ async def test_py_component_with_derived_variable():
         response, status = await _get_template(client)
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': data_v.get(), 'input_val_2': dv.get()},
@@ -560,4 +560,4 @@ async def test_py_component_with_derived_variable():
         )
 
         # Should return (2 + len(df, where df.col1=3)) + len(df, where df.col1=1), so (2 + 1 + 2) = 5
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '5', 'action': None}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '5', 'action': None}, 'uid': 'uid'}

--- a/packages/dara-core/tests/python/test_derived_data_variable.py
+++ b/packages/dara-core/tests/python/test_derived_data_variable.py
@@ -1004,7 +1004,7 @@ async def test_py_component_with_derived_data_variable_run_as_task():
             assert result.status_code == 200
 
             # Should return (2 + len(df, where df.col1=2)) + len(df, where df.col1=3), so (2 + 2 + 1) = 5
-            assert result.json() == {'name': 'MockComponent', 'props': {'text': '5', 'action': None}, 'uid': 'uid'}
+            assert result.json() == {'data': {'name': 'MockComponent', 'props': {'text': '5', 'action': None}, 'uid': 'uid'}, 'lookup': {}}
 
 
 async def test_update_variable_extras_derived_data_variable_run_as_task():

--- a/packages/dara-core/tests/python/test_derived_data_variable.py
+++ b/packages/dara-core/tests/python/test_derived_data_variable.py
@@ -882,7 +882,7 @@ async def test_py_component_with_derived_data_variable():
         response, status = await _get_template(client)
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': data_v.get(), 'input_val_2': dv.get()},
@@ -915,7 +915,7 @@ async def test_py_component_with_derived_data_variable():
         )
 
         # Should return (2 + len(df, where df.col1=3)) + len(df, where df.col1=1), so (2 + 1 + 2) = 5
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '5', 'action': None}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '5', 'action': None}, 'uid': 'uid'}
 
 
 async def test_py_component_with_derived_data_variable_run_as_task():
@@ -990,8 +990,8 @@ async def test_py_component_with_derived_data_variable_run_as_task():
                 },
             )
 
-            assert 'task_id' in response.json()
-            task_id = response.json().get('task_id')
+            assert 'task_id' in response
+            task_id = response.get('task_id')
 
             raw_messages = await get_ws_messages(websocket, timeout=6)
             assert all(data['message']['status'] == 'COMPLETE' for data in raw_messages)

--- a/packages/dara-core/tests/python/test_main.py
+++ b/packages/dara-core/tests/python/test_main.py
@@ -948,7 +948,7 @@ async def test_py_component_respects_dv_empty_deps():
         assert counter == 1
 
         # Request the py_component that depends on the DV with variable=5
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'variable': dv},
@@ -959,8 +959,7 @@ async def test_py_component_respects_dv_empty_deps():
             },
         )
 
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '2'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '2'}, 'uid': 'uid'}
 
         # The DV should've been ran once - should hit cache because updated value was not in deps
         assert counter == 1
@@ -1015,7 +1014,7 @@ async def test_py_component_respects_dv_non_empty_deps():
         assert counter == 1
 
         # Request the py_component that depends on the DV with var1=1, var2=3 - non-deps variable changed
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'variable': dv},
@@ -1026,14 +1025,13 @@ async def test_py_component_respects_dv_non_empty_deps():
             },
         )
 
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '3'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '3'}, 'uid': 'uid'}
 
         # The DV should've been ran once - should hit cache because updated value was not in deps
         assert counter == 1
 
         # Request the py_component that depends on the DV with var1=2,var2=3
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'variable': dv},
@@ -1044,8 +1042,7 @@ async def test_py_component_respects_dv_non_empty_deps():
             },
         )
 
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '5'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '5'}, 'uid': 'uid'}
 
         # The DV should've been ran again - variable which changed was in deps
         assert counter == 2
@@ -1053,7 +1050,7 @@ async def test_py_component_respects_dv_non_empty_deps():
         # Now request py_component with var1=1,var2=6 - expected scenario is that cache is NOT hit because
         # it has been purged - to prevent stale cache issues - so result should be accurate
         # (as oppose to i.e. returning 3 or 4 as these results were cached for dep variable var1=1)
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'variable': dv},
@@ -1063,9 +1060,7 @@ async def test_py_component_respects_dv_non_empty_deps():
                 'ws_channel': 'test_channel',
             },
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '7'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '7'}, 'uid': 'uid'}
 
         # The DV should've been ran again - cache was purged
         assert counter == 3

--- a/packages/dara-core/tests/python/test_py_component.py
+++ b/packages/dara-core/tests/python/test_py_component.py
@@ -755,7 +755,7 @@ async def test_derive_var_with_run_as_task_flag():
             # Try to fetch the result via the rest api
             result = await client.get(f'/api/core/tasks/{task_id}', headers=AUTH_HEADERS)
             assert result.status_code == 200
-            assert result.json() == {'name': 'MockComponent', 'props': {'text': '15'}, 'uid': 'uid'}
+            assert result.json() == {'data': {'name': 'MockComponent', 'props': {'text': '15'}, 'uid': 'uid'}, 'lookup': {}}
 
 
 async def test_chain_derived_var_with_run_as_task_flag():
@@ -855,7 +855,7 @@ async def test_chain_derived_var_with_run_as_task_flag():
             # Try to fetch the result via the rest api
             result = await client.get(f'/api/core/tasks/{task_id}', headers=AUTH_HEADERS)
             assert result.status_code == 200
-            assert result.json() == {'name': 'MockComponent', 'props': {'text': '11'}, 'uid': 'uid'}
+            assert result.json() == {'data': {'name': 'MockComponent', 'props': {'text': '11'}, 'uid': 'uid'}, 'lookup': {}}
 
 
 async def test_single_dv_track_progress():
@@ -926,7 +926,7 @@ async def test_single_dv_track_progress():
             # Try to fetch the result via the rest api
             result = await client.get(f'/api/core/tasks/{task_id}', headers=AUTH_HEADERS)
             assert result.status_code == 200
-            assert result.json() == {'name': 'MockComponent', 'props': {'text': 'result'}, 'uid': 'uid'}
+            assert result.json() == {'data': {'name': 'MockComponent', 'props': {'text': 'result'}, 'uid': 'uid'}, 'lookup': {}}
 
 
 async def test_multiple_dv_track_progress():
@@ -1000,11 +1000,11 @@ async def test_multiple_dv_track_progress():
             # Try to fetch the result via the rest api
             result = await client.get(f'/api/core/tasks/{task_id}', headers=AUTH_HEADERS)
             assert result.status_code == 200
-            assert result.json() == {
+            assert result.json() == {'data': {
                 'name': 'MockComponentTwo',
                 'props': {'text': 'result', 'text2': 'result2'},
                 'uid': 'uid',
-            }
+            }, 'lookup': {}}
 
 
 @pytest.mark.parametrize('primitive', [(True), (False), (1), (-2.5), ('test_string')])

--- a/packages/dara-core/tests/python/test_py_component.py
+++ b/packages/dara-core/tests/python/test_py_component.py
@@ -129,15 +129,13 @@ async def test_variables():
         assert 'input_val' in component.get('props').get('dynamic_kwargs')
 
         # Check that the component can be fetched via the api, with input_val passed in the body
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': var},
             data={'uid': component.get('uid'), 'values': {'input_val': 'test'}, 'ws_channel': 'test_channel'},
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': 'test'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': 'test'}, 'uid': 'uid'}
 
 
 async def test_async_py_comp():
@@ -167,15 +165,13 @@ async def test_async_py_comp():
         assert 'input_val' in component.get('props').get('dynamic_kwargs')
 
         # Check that the component can be fetched via the api, with input_val passed in the body
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': var},
             data={'uid': component.get('uid'), 'values': {'input_val': 'test'}, 'ws_channel': 'test_channel'},
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': 'test'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': 'test'}, 'uid': 'uid'}
 
 
 async def test_derived_variables():
@@ -217,7 +213,7 @@ async def test_derived_variables():
         assert 'input_val' in component.get('props').get('dynamic_kwargs')
 
         # Check that the component can be fetched via the api, with input_val passed in the body
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': derived},
@@ -229,13 +225,11 @@ async def test_derived_variables():
                 'ws_channel': 'test_channel',
             },
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '15'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '15'}, 'uid': 'uid'}
         mock_func.assert_called_once()
 
         # Check that the derived state is cached on a subsequent request with the same args
-        response = await _get_py_component(
+        await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': derived},
@@ -250,7 +244,7 @@ async def test_derived_variables():
         mock_func.assert_called_once()
 
         # Check that calling it with different arguments calls the underlying function again
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': derived},
@@ -262,8 +256,7 @@ async def test_derived_variables():
                 'ws_channel': 'test_channel',
             },
         )
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '3'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '3'}, 'uid': 'uid'}
         assert mock_func.call_count == 2
 
 async def test_mixed_inputs():
@@ -294,7 +287,7 @@ async def test_mixed_inputs():
         assert 'input_val' in component.get('props').get('dynamic_kwargs')
 
         # Check that the component can be fetched via the api, with input_val passed in the body
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': var},
@@ -304,9 +297,7 @@ async def test_mixed_inputs():
                 'ws_channel': 'test_channel',
             },
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': 'test_2'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': 'test_2'}, 'uid': 'uid'}
 
 
 async def test_default_arguments():
@@ -331,15 +322,13 @@ async def test_default_arguments():
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
         # Check that the component can be fetched via the api, with input_val passed in the body
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': var},
             data={'uid': component.get('uid'), 'values': {'input_val': 'test'}, 'ws_channel': 'test_channel'},
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': 'test_3'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': 'test_3'}, 'uid': 'uid'}
 
 
 async def test_error_handling():
@@ -391,14 +380,13 @@ async def test_base_model_args_are_restored():
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
         # Check that the component can be fetched via the api, with input dict passed in the body
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': var},
             data={'uid': component.get('uid'), 'values': {'input_val': {'val': 'test'}}, 'ws_channel': 'test_channel'},
         )
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': 'test'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': 'test'}, 'uid': 'uid'}
 
 async def test_base_model_not_restored_when_already_instance():
     """Test that when a type is expected by a PyComponent handler that an already instantiated instance is not restored"""
@@ -425,7 +413,7 @@ async def test_base_model_not_restored_when_already_instance():
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
         # Check that the component can be fetched via the api, with input dict passed in the body
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': dv},
@@ -441,8 +429,7 @@ async def test_base_model_not_restored_when_already_instance():
                 'ws_channel': 'test_channel'
             },
         )
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': 'foo'}, 'uid': 'uid'}
+        assert data== {'name': 'MockComponent', 'props': {'text': 'foo'}, 'uid': 'uid'}
 
 async def test_compatibility_with_polling():
     """Test that a py_component with polling gets passed the param correctly"""
@@ -513,7 +500,7 @@ async def test_derived_variables_restore_base_models():
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
         # Check that the component can be fetched via the api, with a passed as a dict
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             name=component.get('name'),
             kwargs={'input_val': derived},
@@ -523,8 +510,7 @@ async def test_derived_variables_restore_base_models():
                 'ws_channel': 'test_channel',
             },
         )
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '15'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '15'}, 'uid': 'uid'}
 
 
 async def test_derived_variables_with_args():
@@ -562,7 +548,7 @@ async def test_derived_variables_with_args():
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
         # Check that the component can be fetched via the api, with a passed as a dict
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': derived},
@@ -572,9 +558,7 @@ async def test_derived_variables_with_args():
                 'ws_channel': 'test_channel',
             },
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '25'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '25'}, 'uid': 'uid'}
 
 
 async def test_derived_variables_with_polling():
@@ -646,7 +630,7 @@ async def test_chained_derived_variables():
         component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
         # Check that the component can be fetched via the api, with a passed as a dict
-        response = await _get_py_component(
+        data = await _get_py_component(
             client,
             component.get('name'),
             kwargs={'input_val': derived_2},
@@ -662,9 +646,7 @@ async def test_chained_derived_variables():
                 'ws_channel': 'test_channel',
             },
         )
-
-        assert response.status_code == 200
-        assert response.json() == {'name': 'MockComponent', 'props': {'text': '25'}, 'uid': 'uid'}
+        assert data == {'name': 'MockComponent', 'props': {'text': '25'}, 'uid': 'uid'}
 
 
 async def test_placeholder():
@@ -747,7 +729,7 @@ async def test_derive_var_with_run_as_task_flag():
             component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
             # Check that the fetching the component returns a task_id response
-            response = await _get_py_component(
+            data = await _get_py_component(
                 client,
                 component.get('name'),
                 kwargs={'var': derived},
@@ -757,8 +739,7 @@ async def test_derive_var_with_run_as_task_flag():
                     'ws_channel': init.get('message', {}).get('channel'),
                 },
             )
-            assert response.status_code == 200
-            task_id = response.json().get('task_id')
+            task_id = data.get('task_id')
             assert task_id is not None
 
             # Listen on the websocket channel for the notification of task completion
@@ -811,7 +792,7 @@ async def test_chain_derived_var_with_run_as_task_flag():
             component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
             # Check that the fetching the component returns a task_id response
-            response = await _get_py_component(
+            data = await _get_py_component(
                 client,
                 component.get('name'),
                 kwargs={'var': dv_top},
@@ -862,9 +843,7 @@ async def test_chain_derived_var_with_run_as_task_flag():
                     'ws_channel': init.get('message', {}).get('channel'),
                 },
             )
-
-            assert response.status_code == 200
-            task_id = response.json().get('task_id')
+            task_id = data.get('task_id')
             assert task_id is not None
 
             # Listen on the websocket channel for messages
@@ -911,7 +890,7 @@ async def test_single_dv_track_progress():
             component = response.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
 
             # Check that the fetching the component returns a task_id response
-            response = await _get_py_component(
+            data = await _get_py_component(
                 client,
                 component.get('name'),
                 kwargs={'var': derived},
@@ -921,9 +900,7 @@ async def test_single_dv_track_progress():
                     'ws_channel': init.get('message', {}).get('channel'),
                 },
             )
-
-            assert response.status_code == 200
-            task_id = response.json().get('task_id')
+            task_id = data.get('task_id')
             assert task_id is not None
 
             # Expect 5 progress updates in order
@@ -988,7 +965,7 @@ async def test_multiple_dv_track_progress():
             )
 
             # Check that the fetching the component returns a task_id response
-            response = await _get_py_component(
+            data = await _get_py_component(
                 client,
                 component.get('name'),
                 kwargs={'var1': derived, 'var2': derived_2},
@@ -1000,11 +977,8 @@ async def test_multiple_dv_track_progress():
                     },
                     'ws_channel': init.get('message', {}).get('channel'),
                 },
-                expect_success=False,
             )
-
-            assert response.status_code == 200
-            task_id = response.json().get('task_id')
+            task_id = data.get('task_id')
             assert task_id is not None
 
             messages = await get_ws_messages(websocket)
@@ -1065,7 +1039,7 @@ async def test_handles_primitives(primitive):
             )
 
             # Check that the fetching the component returns a RawString with the primitive value
-            response = await _get_py_component(
+            data = await _get_py_component(
                 client,
                 component.get('name'),
                 kwargs={},
@@ -1074,12 +1048,9 @@ async def test_handles_primitives(primitive):
                     'values': {},
                     'ws_channel': init.get('message', {}).get('channel'),
                 },
-                expect_success=False,
             )
-
-            assert response.status_code == 200
-            assert response.json()['props']['content'] == str(primitive)
-            assert response.json()['name'] == 'RawString'
+            assert data['props']['content'] == str(primitive)
+            assert data['name'] == 'RawString'
 
 
 async def test_handles_none():
@@ -1112,8 +1083,8 @@ async def test_handles_none():
                 template_data.get('layout').get('props').get('content').get('props').get('routes')[0].get('content')
             )
 
-            # Check that the fetching the component returns a RawString with the value 'None'
-            response = await _get_py_component(
+            # Check that the fetching the component returns None
+            data = await _get_py_component(
                 client,
                 component.get('name'),
                 kwargs={},
@@ -1122,11 +1093,8 @@ async def test_handles_none():
                     'values': {},
                     'ws_channel': init.get('message', {}).get('channel'),
                 },
-                expect_success=False,
             )
-
-            assert response.status_code == 200
-            assert response.json() == None
+            assert data == None
 
 
 async def test_handles_invalid_value():
@@ -1160,7 +1128,7 @@ async def test_handles_invalid_value():
             )
 
             # Check that the fetching the component returns an InvalidComponent
-            response = await _get_py_component(
+            data = await _get_py_component(
                 client,
                 component.get('name'),
                 kwargs={},
@@ -1169,9 +1137,6 @@ async def test_handles_invalid_value():
                     'values': {},
                     'ws_channel': init.get('message', {}).get('channel'),
                 },
-                expect_success=False,
             )
-
-            assert response.status_code == 200
-            assert response.json()['name'] == 'InvalidComponent'
-            assert 'did not return a ComponentInstance' in response.json()['props']['error']
+            assert data['name'] == 'InvalidComponent'
+            assert 'did not return a ComponentInstance' in data['props']['error']

--- a/packages/dara-core/tests/python/utils.py
+++ b/packages/dara-core/tests/python/utils.py
@@ -223,6 +223,13 @@ async def _get_py_component(
     response = await client.post(f'/api/core/components/{name}', json=data, headers=headers)
     if expect_success:
         assert response.status_code == 200
+        res = response.json()
+
+        if 'task_id' in res:
+            return res
+
+        return denormalize(res['data'], res['lookup'])
+
     return response
 
 class ActionRequestBody(TypedDict):


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Dara implements a normalization mechanism, previously used for template response, and requests for DerivedVariables and py_components. This looks for instances of variables, replaces them with references and puts the actual values in a lookup. This decreases payload size in cases where the same variables are referenced in multiple places in a payload, especially when `Variable` has a large `default`.

This was previously not implemented for `py_component` results. A recent discovery in one of the apps was that a response for a particular `py_component` was about 100MB. This was due to the scenario described above, where a `Variable` default was large and duplicated dozens of times, as the component returned a list of cards, each having an action updating that variable. While this to some extent can be attributed to bad architecture/coding, this should still be handled on Dara side.

This PR extends the normalization mechanism to handle results of `py_components`, both for non-tasks and tasks.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

`_make_render_safe` which is the final part of rendering a `py_component` has been updated to return a `NormalizedPayload`.

On the frontend we run the result of the component through `denormalize`.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Updated backend and frontend tests to use the new response structure.
Manually verified all types of py_component outputs work, including cases with tasks/progress trackers etc.

Verified in the app where the issue was found that this improvement reduces the request size from 100MB to 3.2MB.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->