### PR TITLE
Fix: DO-2053 update action not registering variable

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where the update action would fail if the updated variable was not already registered on the client. The action now registers the variable if it is not already registered.
+
 ## 1.4.3
 
 -   `py_component` results are now normalized, which means multiple instances of the same variables within the returned components will be deduplicated. This should significantly reduce the amount of data sent over the wire in some cases.

--- a/packages/dara-core/js/actions/update-variable.tsx
+++ b/packages/dara-core/js/actions/update-variable.tsx
@@ -1,5 +1,5 @@
-import { getAtom } from '@/shared/interactivity';
-import { resolveNested, setNested } from '@/shared/interactivity/nested';
+import { getOrRegisterPlainVariable } from '@/shared/interactivity/plain-variable';
+import { getOrRegisterUrlVariable } from '@/shared/interactivity/url-variable';
 import { ActionHandler, UpdateVariableImpl } from '@/types/core';
 
 /**
@@ -12,55 +12,39 @@ export const INPUT = '__dara_input__';
  */
 export const TOGGLE = '__dara_toggle__';
 
-function isFunction(val: any): val is (args: any) => any {
-    return typeof val === 'function';
-}
-
-/**
- * Get an updater function for the variable.
- * For plain variables with a nested property this will return a function that will update the nested property.
- *
- * @param variable variable to update
- * @param updater value or function to update the variable with
- */
-function getUpdater<T = any>(
-    variable: UpdateVariableImpl['variable'],
-    updater: T | ((value: T) => T)
-): T | ((oldValue: T) => T) {
-    // is a Variable().get()
-    if (variable.__typename === 'Variable' && variable.nested && variable.nested.length > 0) {
-        const nested = variable.nested.map((n) => String(n));
-        return (oldValue: any) => {
-            let newValue = updater;
-            if (isFunction(updater)) {
-                newValue = updater(resolveNested(oldValue, nested));
-            }
-            return setNested(oldValue, nested, newValue);
-        };
-    }
-
-    // return as-is
-    return updater;
-}
-
 /**
  * Front-end handler for UpdateVariable action.
  */
 const UpdateVariable: ActionHandler<UpdateVariableImpl> = (ctx, actionImpl) => {
-    const varAtom = getAtom(actionImpl.variable);
+    let varAtom;
+
+    // Make sure the variable is registered
+    switch (actionImpl.variable.__typename) {
+        case 'Variable':
+            varAtom = getOrRegisterPlainVariable(
+                actionImpl.variable,
+                ctx.wsClient,
+                ctx.taskCtx,
+                ctx.location.search,
+                ctx.sessionToken
+            );
+            break;
+        case 'UrlVariable':
+            varAtom = getOrRegisterUrlVariable(actionImpl.variable);
+            break;
+        case 'DataVariable':
+            throw new Error('DataVariable is not supported in UpdateVariable action');
+    }
 
     if (actionImpl.value === INPUT) {
-        return ctx.set(varAtom, getUpdater(actionImpl.variable, ctx.input));
+        return ctx.set(varAtom, ctx.input);
     }
 
     if (actionImpl.value === TOGGLE) {
-        return ctx.set(
-            varAtom,
-            getUpdater(actionImpl.variable, (value) => !value)
-        );
+        return ctx.set(varAtom, (value) => !value);
     }
 
-    return ctx.set(varAtom, getUpdater(actionImpl.variable, actionImpl.value));
+    return ctx.set(varAtom, actionImpl.value);
 };
 
 export default UpdateVariable;

--- a/packages/dara-core/js/shared/interactivity/use-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable.tsx
@@ -71,5 +71,6 @@ export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Di
     const recoilState = useMemo(() => getOrRegisterPlainVariable(variable, WsClient, taskContext, search, token), []);
     const [loadable, setLoadable] = useRecoilStateLoadable(recoilState);
     const deferred = useDeferLoadable(loadable);
+
     return [deferred, setLoadable];
 }

--- a/packages/dara-core/tests/js/use-action.spec.tsx
+++ b/packages/dara-core/tests/js/use-action.spec.tsx
@@ -139,9 +139,9 @@ describe('useAction', () => {
             return <span data-testid="result">{a}</span>;
         };
 
-        const MockComponent = (props: { action: Action; var: SingleVariable<string> }): JSX.Element => {
+        const MockComponent = (props: { action: Action }): JSX.Element => {
             const [update, loading] = useAction(props.action);
-            const [render, setRender] = useState(false);
+            const [renderVariable, setRenderVariable] = useState(false);
 
             return (
                 <>
@@ -151,8 +151,10 @@ describe('useAction', () => {
                     </button>
                     <span data-testid="loading">{loading.toString()}</span>
                     {/* Do not render the nested component so not calling useVariable until true */}
-                    <button data-testid="render" onClick={() => setRender(true)} />
-                    {render && <MockComponent2 var={variable} />}
+                    <button data-testid="render" onClick={() => setRenderVariable(true)} type="button">
+                        render
+                    </button>
+                    {renderVariable && <MockComponent2 var={variable} />}
                 </>
             );
         };


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

This PR fixes a bug where the update action would not register the updated variable. Simplest way to reproduce would be to have two pages:
- first page updates some variable
```python
target = Variable()

Select(..., onchange=target.sync()
```
- second page uses the variable
```python
Text(text=target)
```

Previously the sync (so the underlying update) action would fail due to the variable not existing on the page yet. This was a regression introduced as part of the action revamp, added a regression test.

Fixed by using similar logic to other actions where the variable is registered if not already registered.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Using the `getOrRegister...` methods within `UpdateVariable` implementation.
Those methods already handle nested plain variables correctly so the implementation was simplified to remove the special nested handling.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a unit test to cover the scenario where the variable does not exist yet.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->