### PR TITLE
Fix: DO-2052 radio group does not update when starting with an empty var

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -7,6 +7,7 @@ title: Changelog
 -   Changed `Plotly` default `min-height` to be `350px`.
 -   Changed default font-sizes for `Bokeh` and `Plotly` components to use `16px` for title, and `14px` for axis labels, legends and tooltips.
 -   Reduced default `Plotly` margins. Update default tooltip background color to be grey.
+-   Fixed an issue where if `RadioGroup` had a `value` of an empty `Variable` that that `Variable` would not update.
 
 ## 1.4.4
 

--- a/packages/dara-components/js/common/radio-group/radio-group.tsx
+++ b/packages/dara-components/js/common/radio-group/radio-group.tsx
@@ -53,7 +53,7 @@ function RadioGroup(props: RadioGroupProps): JSX.Element {
             items={items}
             onChange={onChange}
             style={style}
-            value={items.find((item) => item.value === value)}
+            value={value === null ? value : items.find((item) => item.value === value)}
         />
     );
 }

--- a/packages/dara-components/js/common/radio-group/radio-group.tsx
+++ b/packages/dara-components/js/common/radio-group/radio-group.tsx
@@ -53,7 +53,7 @@ function RadioGroup(props: RadioGroupProps): JSX.Element {
             items={items}
             onChange={onChange}
             style={style}
-            value={value === null ? value : items.find((item) => item.value === value)}
+            value={items.find((item) => item.value === value) ?? null}
         />
     );
 }


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Noticed that when passing an empty Variable to a RadioGroup component in dara the Variable value was never updated.


## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

When Variable was empty this line `items.find((item) => item.value === value)` returned `undefined`.
This meant the `RadioGroup` component behaved in uncontrolled mode and did not trigger on change events. Resulting in the variable never being updated.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on a test app

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->