### PR TITLE
Fix: DO-2136 live reload without --reload flag, move websocket errors to dev_logger

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -24,6 +24,9 @@ dara start --reload-dir decision_app/pages
 dara start --reload-dir decision_app/pages decision_app/utils
 ```
 
+-   Fixed an issue where the client app would refresh on WebSocket error&reconnect even without the `--reload` flag enabled
+-   Moved WebSocket server-side errors to be displayed on the default dev logger rather than the opt-in `--debug` logger
+
 ## 1.4.5
 
 -   Relax `python-dotenv` dependency from `^0.19.2` to `>=0.19.2`

--- a/packages/dara-core/dara/core/cli.py
+++ b/packages/dara-core/dara/core/cli.py
@@ -117,6 +117,10 @@ def start(
         os.environ['VITE_REACTJS_HMR'] = 'False'
         os.environ['VITE_SERVE_MODE'] = 'False'
 
+    # Tell frontend to restart on WS reconnection
+    if reload:
+        os.environ['DARA_LIVE_RELOAD'] = 'TRUE'
+
     # Check that if production/dev mode is set, node is installed - unless we're in docker mode
     if not docker and (production or enable_hmr):
         exit_code = os.system('node -v')

--- a/packages/dara-core/dara/core/internal/websocket.py
+++ b/packages/dara-core/dara/core/internal/websocket.py
@@ -32,7 +32,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from dara.core.auth.definitions import AuthError, TokenData
 from dara.core.auth.utils import decode_token
-from dara.core.logging import eng_logger
+from dara.core.logging import dev_logger, eng_logger
 
 
 # Client message types
@@ -356,7 +356,7 @@ async def ws_handler(websocket: WebSocket, token: Optional[str] = Query(default=
     with catch(
         {
             WebSocketDisconnect: lambda _: eng_logger.warning('Websocket disconnected'),
-            BaseException: lambda e: eng_logger.error('Error in websocket handler', error=Exception(e)),
+            BaseException: lambda e: dev_logger.error('Error in websocket handler', error=Exception(e)),
         }
     ):
         try:

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -97,8 +97,8 @@ def _start_application(config: Configuration):
         jinja_templates.env.globals['vite_asset'] = fastapi_vite.vite_asset
         jinja_templates.env.globals['entry'] = '_entry.tsx'
 
-        # If dev mode enabled, set live reload to true
-        if os.environ.get('VITE_SERVE_MODE') or os.environ.get('DARA_LIVE_RELOAD'):
+        # If --enable-hmr or --reload enabled, set live reload to true
+        if os.environ.get('DARA_HMR_MODE') == 'TRUE' or os.environ.get('DARA_LIVE_RELOAD') == 'TRUE':
             config.live_reload = True
 
     # Configure the default executor for threads run via the async loop


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

This PR fixes an issue with live reloading happening even without the `--reload` flag on. 

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Turns out we've had a bug ever since the `--reload` flag was first introduced (for the curious, internal pre-Dara version commit `0836b23`) where the condition to enable `config.live_reload` was using `os.environ.get("VITE_SERVE_MODE")` which is always truthy, since it's a string `"True"` or `"False"`. This is now changed to check for equality rather than truthiness.

Also fixed an issue where tracking down forced refreshes was difficult due to the errors being emitted into the `eng_logger` rather than `dev_logger`. It's no longer necessary to run Dara with `--debug ERROR` or higher to see the error.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in an app

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->