### PR TITLE
Fix: DO-2141 Image and Anchor components base url handling

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `Anchor` and `Image` component would not handle relative links correctly when ran in an app with a custom base URL (e.g. in an iframe)
+
 ## 1.4.6
 
 -   Updated `EdgeConstraintType` to comply to `0.3.0` of `cai-causal-graph`.

--- a/packages/dara-core/js/utils.ts
+++ b/packages/dara-core/js/utils.ts
@@ -1,5 +1,14 @@
+/**
+ * Prepend window.dara.base_url to asset path if defined.
+ * This is required for static assets to be loaded correctly when the app is not hosted at the root of the domain.
+ *
+ * Since all static assets are server from `/static/`, this is only applied to asset paths that start with `/static/`.
+ * This way we're not affecting any other assets that are loaded from other domains.
+ *
+ * @param asset asset URL
+ */
 export const prependBaseUrl = (asset: string): string => {
-    if (window.dara?.base_url) {
+    if (window.dara?.base_url && asset.startsWith('/static/')) {
         const baseUrl = new URL(window.dara.base_url);
         const assetUrl = new URL(asset, baseUrl.origin);
         assetUrl.pathname = [baseUrl.pathname, assetUrl.pathname].join('/').replace(/\/+/g, '/');


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

It was found that the Image component does not handle base urls properly, and appends the base url prefix even to external asset URLs.

Similar issue was found with the `Anchor` tag.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

The utility used by the Image component now explicitly checks for `/static/` prefix (which is also validated on the backend) and applies the prefixing logic only to those requests.

The anchor component now uses the react router's `Link` component rather than an `<a>` tag for relative links since the router already handles the basename correctly.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in embedded and standard environments

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->