### PR TITLE
Improvement: DO-2212 introduce request extras context

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Internal (JS): added `RequestExtras` context to allow injecting additional e.g. headers into requests made by Dara in different parts of the component tree
+
 ## 1.4.6
 
 -   Added `execute_action` convenience function to `ActionCtx` to allow for executing an arbitrary `ActionImpl` instance. This can be useful in certain situations when an external API returns an action impl object to be executed, or for custom action implementations.
@@ -28,7 +32,6 @@ dara start --reload-dir decision_app/pages decision_app/utils
 
 -   Fixed an issue where the client app would refresh on WebSocket error&reconnect even without the `--reload` flag enabled
 -   Moved WebSocket server-side errors to be displayed on the default dev logger rather than the opt-in `--debug` logger
-
 
 ## 1.4.5
 

--- a/packages/dara-core/js/actions/download-variable.tsx
+++ b/packages/dara-core/js/actions/download-variable.tsx
@@ -124,10 +124,10 @@ const createMatrixFromValue = (val: Array<Record<string, any>> | any[][]): any[]
 const DownloadVariable: ActionHandler<DownloadVariableImpl> = async (ctx, actionImpl): Promise<void> => {
     let value = getVariableValue(actionImpl.variable, true, {
         client: ctx.wsClient,
+        extras: ctx.extras,
         search: ctx.location.search,
         snapshot: ctx.snapshot,
         taskContext: ctx.taskCtx,
-        token: ctx.sessionToken,
     });
 
     if (value instanceof Promise) {

--- a/packages/dara-core/js/actions/reset-variables.tsx
+++ b/packages/dara-core/js/actions/reset-variables.tsx
@@ -26,13 +26,7 @@ const ResetVariables: ActionHandler<ResetVariablesImpl> = (ctx, actionImpl) => {
             // for data variables this is a noop
         } else {
             // For plain variables reset them to default values
-            const plainAtom = getOrRegisterPlainVariable(
-                variable,
-                ctx.wsClient,
-                ctx.taskCtx,
-                ctx.location.search,
-                ctx.extras
-            );
+            const plainAtom = getOrRegisterPlainVariable(variable, ctx.wsClient, ctx.taskCtx, ctx.extras);
             ctx.reset(plainAtom);
         }
     });

--- a/packages/dara-core/js/actions/reset-variables.tsx
+++ b/packages/dara-core/js/actions/reset-variables.tsx
@@ -31,7 +31,7 @@ const ResetVariables: ActionHandler<ResetVariablesImpl> = (ctx, actionImpl) => {
                 ctx.wsClient,
                 ctx.taskCtx,
                 ctx.location.search,
-                ctx.sessionToken
+                ctx.extras
             );
             ctx.reset(plainAtom);
         }

--- a/packages/dara-core/js/actions/update-variable.tsx
+++ b/packages/dara-core/js/actions/update-variable.tsx
@@ -26,7 +26,7 @@ const UpdateVariable: ActionHandler<UpdateVariableImpl> = (ctx, actionImpl) => {
                 ctx.wsClient,
                 ctx.taskCtx,
                 ctx.location.search,
-                ctx.sessionToken
+                ctx.extras
             );
             break;
         case 'UrlVariable':

--- a/packages/dara-core/js/actions/update-variable.tsx
+++ b/packages/dara-core/js/actions/update-variable.tsx
@@ -21,13 +21,7 @@ const UpdateVariable: ActionHandler<UpdateVariableImpl> = (ctx, actionImpl) => {
     // Make sure the variable is registered
     switch (actionImpl.variable.__typename) {
         case 'Variable':
-            varAtom = getOrRegisterPlainVariable(
-                actionImpl.variable,
-                ctx.wsClient,
-                ctx.taskCtx,
-                ctx.location.search,
-                ctx.extras
-            );
+            varAtom = getOrRegisterPlainVariable(actionImpl.variable, ctx.wsClient, ctx.taskCtx, ctx.extras);
             break;
         case 'UrlVariable':
             varAtom = getOrRegisterUrlVariable(actionImpl.variable);

--- a/packages/dara-core/js/api/core.tsx
+++ b/packages/dara-core/js/api/core.tsx
@@ -3,11 +3,11 @@ import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import { HTTP_METHOD, RequestError, validateResponse } from '@darajs/ui-utils';
 
 import { handleAuthErrors } from '@/auth/auth';
-import { useSessionToken } from '@/auth/auth-context';
+import { useRequestExtras } from '@/shared/context';
 import { denormalize } from '@/shared/utils/normalization';
 import { ActionDef, Component, Config, NormalizedPayload, Template } from '@/types';
 
-import { request } from './http';
+import { RequestExtras, request } from './http';
 
 /** Api call to fetch the action registry from the backend */
 export function useActions(): UseQueryResult<
@@ -16,10 +16,10 @@ export function useActions(): UseQueryResult<
     },
     RequestError
 > {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     return useQuery({
         queryFn: async () => {
-            const res = await request('/api/core/actions', { method: HTTP_METHOD.GET }, token);
+            const res = await request('/api/core/actions', { method: HTTP_METHOD.GET }, extras);
             await handleAuthErrors(res, true);
             await validateResponse(res, 'Failed to fetch the actions for this app');
             return res.json();
@@ -31,11 +31,11 @@ export function useActions(): UseQueryResult<
 
 /** Api call to fetch the main configuration from the backend */
 export function useConfig(): UseQueryResult<Config, RequestError> {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
 
     return useQuery({
         queryFn: async () => {
-            const res = await request('/api/core/config', { method: HTTP_METHOD.GET }, token);
+            const res = await request('/api/core/config', { method: HTTP_METHOD.GET }, extras);
             await handleAuthErrors(res, true);
             await validateResponse(res, 'Failed to fetch the config for this app');
             return res.json();
@@ -52,10 +52,10 @@ export function useComponents(): UseQueryResult<
     },
     RequestError
 > {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     return useQuery({
         queryFn: async () => {
-            const res = await request('/api/core/components', { method: HTTP_METHOD.GET }, token);
+            const res = await request('/api/core/components', { method: HTTP_METHOD.GET }, extras);
             await handleAuthErrors(res, true);
             await validateResponse(res, 'Failed to fetch the config for this app');
             return res.json();
@@ -71,12 +71,12 @@ export function useComponents(): UseQueryResult<
  * @param template - the template name to fetch
  */
 export function useTemplate(template: string): UseQueryResult<Template, RequestError> {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     return useQuery({
         enabled: !!template,
 
         queryFn: async () => {
-            const res = await request(`/api/core/template/${template}`, { method: HTTP_METHOD.GET }, token);
+            const res = await request(`/api/core/template/${template}`, { method: HTTP_METHOD.GET }, extras);
             await handleAuthErrors(res, true);
             await validateResponse(res, 'Failed to fetch the template');
             const { data: normalizedTemplate, lookup } = (await res.json()) as NormalizedPayload<Template>;
@@ -96,8 +96,8 @@ export function useTemplate(template: string): UseQueryResult<Template, RequestE
  * @param taskId the id of the task to fetch
  * @param token the session token to use
  */
-export async function fetchTaskResult<T>(taskId: string, token: string): Promise<T> {
-    const res = await request(`/api/core/tasks/${taskId}`, { method: HTTP_METHOD.GET }, token);
+export async function fetchTaskResult<T>(taskId: string, extras: RequestExtras): Promise<T> {
+    const res = await request(`/api/core/tasks/${taskId}`, { method: HTTP_METHOD.GET }, extras);
     await validateResponse(res, `Failed to fetch the result of task with id: ${taskId}`);
 
     const resJson = await res.json();
@@ -115,8 +115,8 @@ export async function fetchTaskResult<T>(taskId: string, token: string): Promise
  * @param taskId the id of the task to fetch
  * @param token the session token to use
  */
-export async function cancelTask(taskId: string, token: string): Promise<boolean> {
-    const res = await request(`/api/core/tasks/${taskId}`, { method: HTTP_METHOD.DELETE }, token);
+export async function cancelTask(taskId: string, extras: RequestExtras): Promise<boolean> {
+    const res = await request(`/api/core/tasks/${taskId}`, { method: HTTP_METHOD.DELETE }, extras);
     await validateResponse(res, `Failed to cancel task with id: ${taskId}`);
     return true;
 }

--- a/packages/dara-core/js/api/http.tsx
+++ b/packages/dara-core/js/api/http.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 
+import cloneDeep from 'lodash/cloneDeep';
+
 /**
  * Request options to merge into the provided options.
  */
@@ -26,6 +28,9 @@ export class RequestExtrasSerializable {
         this.extras = extras;
     }
 
+    /**
+     * Serialize the extras into a string.
+     */
     toJSON(): string {
         if (!this.extras) {
             return null;
@@ -35,10 +40,7 @@ export class RequestExtrasSerializable {
             return this.extras;
         }
 
-        const serializable = {
-            options: this.extras.options,
-            sessionToken: this.extras.sessionToken,
-        };
+        const serializable = cloneDeep(this.extras);
 
         // Make headers serializable
         if (serializable.options?.headers) {

--- a/packages/dara-core/js/api/http.tsx
+++ b/packages/dara-core/js/api/http.tsx
@@ -16,6 +16,41 @@ export interface RequestOptions {
 export type RequestExtras = string | RequestOptions;
 
 /**
+ * Serializable form of RequestExtras.
+ * Required to use for e.g. recoil params as they need to be serializable.
+ */
+export class RequestExtrasSerializable {
+    extras: RequestExtras;
+
+    constructor(extras: RequestExtras) {
+        this.extras = extras;
+    }
+
+    toJSON(): string {
+        if (!this.extras) {
+            return null;
+        }
+
+        if (typeof this.extras === 'string') {
+            return this.extras;
+        }
+
+        const serializable = {
+            options: this.extras.options,
+            sessionToken: this.extras.sessionToken,
+        };
+
+        // Make headers serializable
+        if (serializable.options?.headers) {
+            const headers = new Headers(serializable.options.headers);
+            serializable.options.headers = Object.fromEntries(headers.entries());
+        }
+
+        return JSON.stringify(serializable);
+    }
+}
+
+/**
  * Light wrapper around fetch.
  *
  * @param url URL

--- a/packages/dara-core/js/api/http.tsx
+++ b/packages/dara-core/js/api/http.tsx
@@ -1,14 +1,32 @@
 /* eslint-disable import/prefer-default-export */
 
 /**
+ * Request options to merge into the provided options.
+ */
+export interface RequestOptions {
+    options?: RequestInit;
+    sessionToken?: string;
+}
+
+/**
+ * Extra options to pass to the request function.
+ * If a string is passed, it is assumed to be the session token.
+ * If an object is passed, it is assumed to be a RequestOptions object with the token and additional options.
+ */
+export type RequestExtras = string | RequestOptions;
+
+/**
  * Light wrapper around fetch.
  *
  * @param url URL
  * @param options  fetch options
- * @param sessionToken token to use for auth
+ * @param extras request extras to be merged into the options
  */
-export async function request(url: string | URL, options: RequestInit, sessionToken?: string): Promise<Response> {
-    const { headers, ...other } = options;
+export async function request(url: string | URL, options: RequestInit, extras?: RequestExtras): Promise<Response> {
+    const sessionToken = typeof extras === 'string' ? extras : extras?.sessionToken;
+    const mergedOptions = extras && typeof extras === 'object' ? { ...options, ...extras.options } : options;
+
+    const { headers, ...other } = mergedOptions;
 
     const baseUrl: string = window.dara?.base_url ?? '';
 
@@ -16,9 +34,11 @@ export async function request(url: string | URL, options: RequestInit, sessionTo
 
     return fetch(baseUrl + urlString, {
         headers: {
-            Accept: (options?.headers as Record<string, string>)?.Accept ?? 'application/json',
+            Accept: (mergedOptions?.headers as Record<string, string>)?.Accept ?? 'application/json',
             // Only set content-type json when body is included but it's not formdata
-            ...(options?.body && !(options?.body instanceof FormData) ? { 'Content-Type': 'application/json' } : {}),
+            ...(mergedOptions?.body && !(mergedOptions?.body instanceof FormData)
+                ? { 'Content-Type': 'application/json' }
+                : {}),
             // Add auth header if token is passed
             ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
             ...(headers ?? {}),

--- a/packages/dara-core/js/api/index.tsx
+++ b/packages/dara-core/js/api/index.tsx
@@ -1,4 +1,4 @@
 export { useSession, getSessionToken, verifySessionToken, useUser, handleAuthErrors } from '../auth/auth';
 export { cancelTask, fetchTaskResult, useConfig, useComponents, useTemplate, useActions } from './core';
 export { WebSocketClientInterface, WebSocketClient, setupWebsocket } from './websocket';
-export { request } from './http';
+export { request, RequestExtras, RequestOptions } from './http';

--- a/packages/dara-core/js/auth/auth.tsx
+++ b/packages/dara-core/js/auth/auth.tsx
@@ -3,10 +3,9 @@ import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import { HTTP_METHOD, RequestError, validateResponse } from '@darajs/ui-utils';
 
 import { request } from '@/api/http';
+import { useRequestExtras } from '@/shared/context';
 import { getTokenKey } from '@/shared/utils/embed';
 import { User, UserData } from '@/types';
-
-import { useSessionToken } from './auth-context';
 
 enum AuthenticationErrorReason {
     BAD_REQUEST = 'bad_request',
@@ -155,10 +154,10 @@ export async function handleAuthErrors(
  * Api call to get user data from the backend
  */
 export function useUser(): UseQueryResult<UserData, RequestError> {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     return useQuery({
         queryFn: async () => {
-            const res = await request('/api/auth/user', { method: HTTP_METHOD.GET }, token);
+            const res = await request('/api/auth/user', { method: HTTP_METHOD.GET }, extras);
             await handleAuthErrors(res);
             await validateResponse(res, 'Failed to fetch user for this app');
             return res.json();

--- a/packages/dara-core/js/index.tsx
+++ b/packages/dara-core/js/index.tsx
@@ -1,3 +1,4 @@
+import type { RequestExtras, RequestOptions } from './api';
 import run from './run';
 import type { RawCssProp } from './shared';
 import type {
@@ -54,6 +55,8 @@ export type {
     BaseStylingProps,
     StyledComponentProps,
     BaseComponentProps,
+    RequestExtras,
+    RequestOptions,
 };
 
 export { UpdateVariable, TriggerVariable, NavigateTo, ResetVariables, DownloadVariable, Notify } from './actions';
@@ -98,6 +101,9 @@ export {
     DARA_JWT_TOKEN,
     getToken,
     getTokenKey,
+    useRequestExtras,
+    RequestExtrasProvider,
+    PartialRequestExtrasProvider,
 } from './shared';
 export { ConditionOperator, isVariable } from './types';
 export type { RawCssProp };

--- a/packages/dara-core/js/shared/context/global-task-context.tsx
+++ b/packages/dara-core/js/shared/context/global-task-context.tsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { useRecoilCallback } from 'recoil';
 
 import { cancelTask } from '@/api';
-import { useSessionToken } from '@/auth/auth-context';
 import { TriggerIndexValue, atomRegistry } from '@/shared/interactivity/store';
+
+import { useRequestExtras } from './request-extras-context';
 
 export interface GlobalTaskContext {
     /**
@@ -63,7 +64,7 @@ export default function GlobalTaskProvider({ tasks, variableTaskMap, children }:
      */
     const mapRef = React.useRef<Map<string, Array<VariableTaskEntry>>>(variableTaskMap ?? new Map());
 
-    const token = useSessionToken();
+    const extras = useRequestExtras();
 
     const refreshSelector = useRecoilCallback(({ set }) => (key: string) => {
         // refresh the selector by incrementing the associated trigger so next run will skip the cache
@@ -82,7 +83,7 @@ export default function GlobalTaskProvider({ tasks, variableTaskMap, children }:
                     // found a match
                     if (taskToCancel) {
                         // cancel the task and mark it as stopped
-                        cancelTask(runningTask, token);
+                        cancelTask(runningTask, extras);
                         tasksRef.current.delete(runningTask);
 
                         // make sure next time the selector runs it will run from scratch rather than using the cached value
@@ -91,7 +92,7 @@ export default function GlobalTaskProvider({ tasks, variableTaskMap, children }:
                 }
             }
         },
-        [token]
+        [extras]
     );
 
     const startTask = React.useCallback((taskId: string, variableId?: string, triggerKey?: string): void => {

--- a/packages/dara-core/js/shared/context/index.tsx
+++ b/packages/dara-core/js/shared/context/index.tsx
@@ -7,3 +7,9 @@ export { default as WebSocketCtx } from './websocket-context';
 export { default as RegistriesCtx } from './registries-context';
 export { default as DisplayCtx } from './display-context';
 export { default as FallbackCtx } from './fallback-context';
+export {
+    default as RequestExtrasCtx,
+    useRequestExtras,
+    RequestExtrasProvider,
+    PartialRequestExtrasProvider,
+} from './request-extras-context';

--- a/packages/dara-core/js/shared/context/request-extras-context.tsx
+++ b/packages/dara-core/js/shared/context/request-extras-context.tsx
@@ -46,6 +46,29 @@ export function RequestExtrasProvider({
 }
 
 /**
+ * Merge second request extras into first.
+ *
+ * Handles merging header objects rather than overwriting.
+ *
+ * @param a First request init
+ * @param b Second request init
+ */
+function mergeRequestInits(a: RequestInit, b: RequestInit): RequestInit {
+    const mergedHeaders = new Headers(a.headers);
+    const bHeaders = new Headers(b.headers);
+
+    bHeaders.forEach((value, key) => {
+        mergedHeaders.set(key, value);
+    });
+
+    return {
+        ...a,
+        ...b,
+        headers: mergedHeaders,
+    };
+}
+
+/**
  * Request extras provider which merges the provided options with the parent options.
  */
 export function PartialRequestExtrasProvider({
@@ -57,9 +80,7 @@ export function PartialRequestExtrasProvider({
 }): JSX.Element {
     const { options: parentOptions } = useContext(requestExtrasCtx);
 
-    return (
-        <requestExtrasCtx.Provider value={{ options: { ...parentOptions, ...options } }}>
-            {children}
-        </requestExtrasCtx.Provider>
-    );
+    const mergedInits = useMemo(() => mergeRequestInits(parentOptions, options), [parentOptions, options]);
+
+    return <requestExtrasCtx.Provider value={{ options: mergedInits }}>{children}</requestExtrasCtx.Provider>;
 }

--- a/packages/dara-core/js/shared/context/request-extras-context.tsx
+++ b/packages/dara-core/js/shared/context/request-extras-context.tsx
@@ -34,6 +34,10 @@ export function useRequestExtras(): RequestExtras {
 
 /**
  * Request extras provider that sets the default options for all requests.
+ *
+ * @param props
+ * @param props.children Child components
+ * @param props.options RequestInit object to provide
  */
 export function RequestExtrasProvider({
     children,
@@ -70,6 +74,10 @@ function mergeRequestInits(a: RequestInit, b: RequestInit): RequestInit {
 
 /**
  * Request extras provider which merges the provided options with the parent options.
+ *
+ * @param props
+ * @param props.children Child components
+ * @param props.options RequestInit object to merge with parent options
  */
 export function PartialRequestExtrasProvider({
     children,

--- a/packages/dara-core/js/shared/context/request-extras-context.tsx
+++ b/packages/dara-core/js/shared/context/request-extras-context.tsx
@@ -1,0 +1,65 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { useDeepCompare } from '@darajs/ui-utils';
+
+import { RequestExtras } from '@/api/http';
+import { useSessionToken } from '@/auth/auth-context';
+
+interface RequestExtrasCtx {
+    options: RequestInit;
+}
+
+const requestExtrasCtx = createContext<RequestExtrasCtx>({ options: {} });
+
+export default requestExtrasCtx;
+
+/**
+ * Get request extras to be passed into request function.
+ * Uses auth context for session token and merges with the options provided by the request extras provider.
+ */
+export function useRequestExtras(): RequestExtras {
+    const sessionToken = useSessionToken();
+    const { options } = useContext(requestExtrasCtx);
+
+    const extras = useMemo(() => {
+        return {
+            options,
+            sessionToken,
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [useDeepCompare(options), sessionToken]);
+
+    return extras;
+}
+
+/**
+ * Request extras provider that sets the default options for all requests.
+ */
+export function RequestExtrasProvider({
+    children,
+    options,
+}: {
+    children: React.ReactNode;
+    options: RequestInit;
+}): JSX.Element {
+    return <requestExtrasCtx.Provider value={{ options }}>{children}</requestExtrasCtx.Provider>;
+}
+
+/**
+ * Request extras provider which merges the provided options with the parent options.
+ */
+export function PartialRequestExtrasProvider({
+    children,
+    options,
+}: {
+    children: React.ReactNode;
+    options: RequestInit;
+}): JSX.Element {
+    const { options: parentOptions } = useContext(requestExtrasCtx);
+
+    return (
+        <requestExtrasCtx.Provider value={{ options: { ...parentOptions, ...options } }}>
+            {children}
+        </requestExtrasCtx.Provider>
+    );
+}

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -239,7 +239,7 @@ function DynamicComponent(props: DynamicComponentProps): JSX.Element {
 
     function onResetErrorBoundary(error: unknown): void {
         if (isSelectorError(error)) {
-            refreshSelector(error.selectorId);
+            refreshSelector(error.selectorId, error.selectorExtras);
         }
     }
 

--- a/packages/dara-core/js/shared/error-handling/types.tsx
+++ b/packages/dara-core/js/shared/error-handling/types.tsx
@@ -1,12 +1,13 @@
 export interface SelectorError {
+    selectorExtras: string;
     selectorId: string;
 }
 
 /**
- * Check whether an error originated from a Recoil selector, i.e. it has a selectorId attached
+ * Check whether an error originated from a Recoil selector, i.e. it has a selectorId and extras attached
  *
  * @param e error to check
  */
 export function isSelectorError(e: unknown): e is SelectorError {
-    return e !== undefined && e !== null && typeof e === 'object' && 'selectorId' in e;
+    return e !== undefined && e !== null && typeof e === 'object' && 'selectorId' in e && 'selectorExtras' in e;
 }

--- a/packages/dara-core/js/shared/index.tsx
+++ b/packages/dara-core/js/shared/index.tsx
@@ -1,7 +1,17 @@
 import type { RawCssProp } from './utils';
 
 export { default as Center } from './center/center';
-export { AuthCtx, DirectionCtx, ImportersCtx, WebSocketCtx, DisplayCtx } from './context';
+export {
+    AuthCtx,
+    DirectionCtx,
+    ImportersCtx,
+    WebSocketCtx,
+    DisplayCtx,
+    useRequestExtras,
+    RequestExtrasCtx,
+    RequestExtrasProvider,
+    PartialRequestExtrasProvider,
+} from './context';
 export { default as DynamicComponent } from './dynamic-component/dynamic-component';
 export { default as TemplateRoot } from './template-root/template-root';
 export { default as PrivateRoute } from './private-route/private-route';

--- a/packages/dara-core/js/shared/interactivity/data-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/data-variable.tsx
@@ -6,11 +6,11 @@ import { atom } from 'recoil';
 import { HTTP_METHOD, validateResponse } from '@darajs/ui-utils';
 
 import { WebSocketClientInterface, fetchTaskResult } from '@/api';
-import { request } from '@/api/http';
-import { useSessionToken } from '@/auth/auth-context';
+import { RequestExtras, request } from '@/api/http';
 import { GlobalTaskContext } from '@/shared/context/global-task-context';
 import { DataFrame, DataVariable, DerivedDataVariable, FilterQuery, Pagination, ResolvedDataVariable } from '@/types';
 
+import { useRequestExtras } from '../context';
 import { combineFilters } from './filtering';
 // eslint-disable-next-line import/no-cycle
 import { DerivedVariableValueResponse } from './internal';
@@ -61,19 +61,19 @@ function createDataUrl(path: string, pagination?: Pagination): URL {
  * Retrieve the value of a data variable from the backend
  *
  * @param uid
- * @param token
+ * @param extras request extras to be merged into the options
  * @param filters
  * @param pagination
  */
 export async function fetchDataVariable(
     uid: string,
-    token: string,
+    extras: RequestExtras,
     filters?: FilterQuery,
     pagination?: Pagination
 ): Promise<DataFrame> {
     const url = createDataUrl(`/api/core/data-variable/${uid}`, pagination);
 
-    const response = await request(url, { body: JSON.stringify({ filters }), method: HTTP_METHOD.POST }, token);
+    const response = await request(url, { body: JSON.stringify({ filters }), method: HTTP_METHOD.POST }, extras);
     await validateResponse(response, 'Failed to fetch data variable');
     return response.json();
 }
@@ -95,7 +95,7 @@ export function isDataResponse(response: any): response is DataResponse {
  * Retrieve the value of a derived data variable from the backend
  *
  * @param uid
- * @param token
+ * @param extras request extras to be merged into the options
  * @param filters
  * @param pagination
  * @param cacheKey - cache key of the underlying DV, required for DerivedDataVariables
@@ -103,7 +103,7 @@ export function isDataResponse(response: any): response is DataResponse {
  */
 export async function fetchDerivedDataVariable(
     uid: string,
-    token: string,
+    extras: RequestExtras,
     cacheKey: string,
     wsChannel: string,
     filters?: FilterQuery,
@@ -113,7 +113,7 @@ export async function fetchDerivedDataVariable(
     const response = await request(
         url,
         { body: JSON.stringify({ cache_key: cacheKey, filters, ws_channel: wsChannel }), method: HTTP_METHOD.POST },
-        token
+        extras
     );
     await validateResponse(response, 'Failed to fetch data variable');
     return response.json();
@@ -123,19 +123,19 @@ export async function fetchDerivedDataVariable(
  * Get total count of data in a data variable
  *
  * @param uid uid of the variable
- * @param token session token
+ * @param extras request extras to be merged into the options
  * @param cacheKey cache key of the underlying DV in the case of derived data variables
  */
 async function fetchDataVariableCount(
     uid: string,
-    token: string,
+    extras: RequestExtras,
     filters?: FilterQuery,
     cacheKey?: string
 ): Promise<number> {
     const response = await request(
         `/api/core/data-variable/${uid}/count`,
         { body: JSON.stringify({ cache_key: cacheKey, filters }), method: HTTP_METHOD.POST },
-        token
+        extras
     );
     await validateResponse(response, 'Failed to fetch data variable total count');
     return response.json();
@@ -145,28 +145,28 @@ async function fetchDataVariableCount(
  * Get a callback to fetch data variable from the backend
  *
  * @param variable variable instance
- * @param token session token
  * @param serverTriggerCounter a counter to force recreation of the callback
  */
 export function useFetchDataVariable(
     variable: DataVariable,
     serverTriggerCounter: number
 ): (filters?: FilterQuery, pagination?: Pagination) => Promise<DataResponse> {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
+
     const dataCallback = useCallback(
         async (filters?: FilterQuery, pagination?: Pagination) => {
             const mergedFilters = combineFilters('AND', [variable.filters, filters]);
 
-            const data = await fetchDataVariable(variable.uid, token, mergedFilters, pagination);
+            const data = await fetchDataVariable(variable.uid, extras, mergedFilters, pagination);
 
-            const totalCount = await fetchDataVariableCount(variable.uid, token, mergedFilters);
+            const totalCount = await fetchDataVariableCount(variable.uid, extras, mergedFilters);
 
             return {
                 data,
                 totalCount,
             };
         },
-        [variable, token, serverTriggerCounter]
+        [variable, extras, serverTriggerCounter]
     );
 
     return dataCallback;
@@ -188,7 +188,7 @@ export function useFetchDerivedDataVariable(
     wsClient: WebSocketClientInterface,
     dvValuePromise: Promise<DerivedVariableValueResponse<any>>
 ): (filters?: FilterQuery, pagination?: Pagination) => Promise<DataResponse> {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     const previousResult = useRef<DataResponse>({ data: null, totalCount: 0 });
     const dataCallback = useCallback(
         async (filters?: FilterQuery, pagination?: Pagination) => {
@@ -197,7 +197,7 @@ export function useFetchDerivedDataVariable(
 
             const response = await fetchDerivedDataVariable(
                 variable.uid,
-                token,
+                extras,
                 dvValue.cache_key,
                 await wsClient.getChannel(),
                 mergedFilters,
@@ -229,7 +229,7 @@ export function useFetchDerivedDataVariable(
                     taskContext.endTask(taskId);
                 }
 
-                data = await fetchTaskResult<DataFrame>(taskId, token);
+                data = await fetchTaskResult<DataFrame>(taskId, extras);
             } else {
                 // otherwise use response directly
                 data = response as DataFrame | null;
@@ -237,7 +237,7 @@ export function useFetchDerivedDataVariable(
 
             // For derived data variables count can only be fetched when task is not running so we have to make the request here
             // As the total count could have changed because of the underlying DV changing
-            const totalCount = await fetchDataVariableCount(variable.uid, token, mergedFilters, dvValue.cache_key);
+            const totalCount = await fetchDataVariableCount(variable.uid, extras, mergedFilters, dvValue.cache_key);
 
             previousResult.current = { data, totalCount };
 
@@ -246,7 +246,7 @@ export function useFetchDerivedDataVariable(
                 totalCount,
             };
         },
-        [variable, token, dvValuePromise]
+        [variable, extras, dvValuePromise]
     );
 
     return dataCallback;

--- a/packages/dara-core/js/shared/interactivity/data-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/data-variable.tsx
@@ -180,7 +180,6 @@ export function useFetchDataVariable(
  * @param taskContext global task context
  * @param wsClient websocket client instance
  * @param dvValuePromise promise representing underlying derived variable state
- * @param token session token
  */
 export function useFetchDerivedDataVariable(
     variable: DerivedDataVariable,

--- a/packages/dara-core/js/shared/interactivity/derived-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/derived-variable.tsx
@@ -90,7 +90,7 @@ interface FetchDerivedVariableArgs {
  * @param input Function inputs
  * - `cache`, the cache option for the derived variable.
  * - `force`, send force=true in the request body
- * - `sessionToken`, bearer token for the session
+ * - `extras`, request extras to be merged into the options
  * - `uid`, the uid of the derived variable
  * - `values`, values to pass in the request
  * - `wsClient`, websocket client

--- a/packages/dara-core/js/shared/interactivity/derived-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/derived-variable.tsx
@@ -35,8 +35,8 @@ import {
     TriggerIndexValue,
     depsRegistry,
     getRegistryKey,
+    selectorFamilyMembersRegistry,
     selectorFamilyRegistry,
-    selectorFamilySelectorsRegistry,
 } from './store';
 
 export interface DerivedVariableValueResponse<T> {
@@ -568,10 +568,10 @@ export function getOrRegisterDerivedVariable(
     const selectorInstance = family(serializableExtras);
 
     // register selector instance in the selector family registry
-    if (!selectorFamilySelectorsRegistry.has(family)) {
-        selectorFamilySelectorsRegistry.set(family, new Map());
+    if (!selectorFamilyMembersRegistry.has(family)) {
+        selectorFamilyMembersRegistry.set(family, new Map());
     }
-    selectorFamilySelectorsRegistry.get(family).set(serializableExtras.toJSON(), selectorInstance);
+    selectorFamilyMembersRegistry.get(family).set(serializableExtras.toJSON(), selectorInstance);
 
     return selectorInstance;
 }
@@ -626,10 +626,10 @@ export function getOrRegisterDerivedVariableValue(
     const selectorInstance = family(serializableExtras);
 
     // register selector instance in the selector family registry
-    if (!selectorFamilySelectorsRegistry.has(family)) {
-        selectorFamilySelectorsRegistry.set(family, new Map());
+    if (!selectorFamilyMembersRegistry.has(family)) {
+        selectorFamilyMembersRegistry.set(family, new Map());
     }
-    selectorFamilySelectorsRegistry.get(family).set(serializableExtras.toJSON(), selectorInstance);
+    selectorFamilyMembersRegistry.get(family).set(serializableExtras.toJSON(), selectorInstance);
 
     return selectorInstance;
 }

--- a/packages/dara-core/js/shared/interactivity/derived-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/derived-variable.tsx
@@ -2,7 +2,7 @@
 
 import { isEqual } from 'lodash';
 import { useCallback, useMemo } from 'react';
-import { GetRecoilValue, RecoilValue, selector, useRecoilValue, useSetRecoilState } from 'recoil';
+import { GetRecoilValue, RecoilValue, selector, selectorFamily, useRecoilValue, useSetRecoilState } from 'recoil';
 import { BehaviorSubject, Observable, from } from 'rxjs';
 import { debounceTime, filter, share, switchMap, take } from 'rxjs/operators';
 import shortid from 'shortid';
@@ -10,7 +10,7 @@ import shortid from 'shortid';
 import { HTTP_METHOD, validateResponse } from '@darajs/ui-utils';
 
 import { WebSocketClientInterface, fetchTaskResult, request } from '@/api';
-import { RequestExtras } from '@/api/http';
+import { RequestExtras, RequestExtrasSerializable } from '@/api/http';
 import { GlobalTaskContext } from '@/shared/context/global-task-context';
 import { getUniqueIdentifier } from '@/shared/utils/hashing';
 import { normalizeRequest } from '@/shared/utils/normalization';
@@ -31,7 +31,14 @@ import {
 
 // eslint-disable-next-line import/no-cycle
 import { getOrRegisterTrigger, registerChildTriggers, resolveNested, resolveVariable } from './internal';
-import { TriggerIndexValue, depsRegistry, getRegistryKey, selectorRegistry } from './store';
+import {
+    TriggerIndexValue,
+    depsRegistry,
+    getRegistryKey,
+    selectorFamilyRegistry,
+    selectorFamilySelectorsRegistry,
+    selectorRegistry,
+} from './store';
 
 export interface DerivedVariableValueResponse<T> {
     cache_key: string;
@@ -79,8 +86,15 @@ interface FetchDerivedVariableArgs {
     extras: RequestExtras;
     force: boolean;
     is_data_variable?: boolean;
-    uid: string;
+    /**
+     * selector instance key  - each selector's requests should be treated separately
+     */
+    selectorKey: string;
     values: Record<string | number, any>;
+    /**
+     * Variable uid
+     */
+    variableUid: string;
     wsClient: WebSocketClientInterface;
 }
 
@@ -99,7 +113,7 @@ export async function fetchDerivedVariable<T>({
     cache,
     force,
     extras,
-    uid,
+    variableUid,
     values,
     wsClient,
     is_data_variable = false,
@@ -113,7 +127,7 @@ export async function fetchDerivedVariable<T>({
 
     const ws_channel = await wsClient.getChannel();
     const res = await request(
-        `/api/core/derived-variable/${uid}`,
+        `/api/core/derived-variable/${variableUid}`,
         {
             body: JSON.stringify({ force, is_data_variable, values, ws_channel }),
             headers: { ...cacheControl },
@@ -121,7 +135,7 @@ export async function fetchDerivedVariable<T>({
         },
         extras
     );
-    await validateResponse(res, `Failed to fetch the derived variable with uid: ${uid}`);
+    await validateResponse(res, `Failed to fetch the derived variable with uid: ${variableUid}`);
     return res.json();
 }
 
@@ -138,7 +152,8 @@ const debouncedFetchCache: {
 } = {};
 
 async function debouncedFetchDerivedVariable({
-    uid,
+    variableUid,
+    selectorKey,
     values,
     wsClient,
     force,
@@ -146,10 +161,10 @@ async function debouncedFetchDerivedVariable({
     cache,
     is_data_variable = false,
 }: FetchDerivedVariableArgs): Promise<DerivedVariableResponse<any>> {
-    // If this is the first time this is called then set up a subject and return stream for this variable.
-    if (!debouncedFetchSubjects[uid]) {
-        debouncedFetchSubjects[uid] = new BehaviorSubject<FetchDerivedVariableArgs>(null);
-        debouncedFetchCache[uid] = debouncedFetchSubjects[uid].pipe(
+    // If this is the first time this is called then set up a subject and return stream for this selector
+    if (!debouncedFetchSubjects[selectorKey]) {
+        debouncedFetchSubjects[selectorKey] = new BehaviorSubject<FetchDerivedVariableArgs>(null);
+        debouncedFetchCache[selectorKey] = debouncedFetchSubjects[selectorKey].pipe(
             filter((args) => !!args),
             debounceTime(10),
             switchMap((args) => from(fetchDerivedVariable(args))),
@@ -158,11 +173,20 @@ async function debouncedFetchDerivedVariable({
     }
 
     // Push the next set of args to the subject
-    debouncedFetchSubjects[uid].next({ cache, extras, force, is_data_variable, uid, values, wsClient });
+    debouncedFetchSubjects[selectorKey].next({
+        cache,
+        extras,
+        force,
+        is_data_variable,
+        selectorKey,
+        values,
+        variableUid,
+        wsClient,
+    });
 
     // Return the debounced response from the backend
     return new Promise((resolve, reject) => {
-        debouncedFetchCache[uid].pipe(take(1)).subscribe(resolve, reject);
+        debouncedFetchCache[selectorKey].pipe(take(1)).subscribe(resolve, reject);
     });
 }
 
@@ -394,141 +418,160 @@ export async function resolveDerivedValue(
  * @param variable variable to register
  * @param wsClient WebSocket client from context
  * @param tasks tasks list from context
- * @param search search query from location
- * @param extras request extras to be merged into the options
+ * @param currentExtras request extras to be merged into the options
  */
 export function getOrRegisterDerivedVariable(
     variable: DerivedVariable | DerivedDataVariable,
     wsClient: WebSocketClientInterface,
     taskContext: GlobalTaskContext,
-    search: string,
-    extras: RequestExtras
+    currentExtras: RequestExtras
 ): RecoilValue<DerivedVariableValueResponse<any>> {
     const key = getRegistryKey(variable, 'selector');
 
-    if (!selectorRegistry.has(key)) {
-        /**
-         * Recursively resolve variables to list of values
-         *
-         * For derived variables, put ResolvedDerivedVariable object with values resolved to recoil atoms/selectors,
-         * and deps resolved to array of indexes of variables (or null if not set)
-         * For data variables, put ResolvedDataVariable object.
-         */
-        const resolvedVariables = variable.variables.map((v) =>
-            resolveVariable(v, wsClient, taskContext, search, extras)
-        );
-
+    if (!selectorFamilyRegistry.has(key)) {
         getOrRegisterTrigger(variable);
 
-        selectorRegistry.set(
+        // register a family for this particular variable
+        selectorFamilyRegistry.set(
             key,
-            selector({
+            selectorFamily({
                 cachePolicy_UNSTABLE: {
                     eviction: 'most-recent',
                 },
-                get: async ({ get }) => {
-                    const selfTrigger = get(getOrRegisterTrigger(variable));
+                get:
+                    (extrasSerializable: RequestExtrasSerializable) =>
+                    async ({ get }) => {
+                        /**
+                         * Recursively resolve variables to list of values
+                         *
+                         * For derived variables, put ResolvedDerivedVariable object with values resolved to recoil atoms/selectors,
+                         * and deps resolved to array of indexes of variables (or null if not set)
+                         * For data variables, put ResolvedDataVariable object.
+                         */
+                        const resolvedVariables = variable.variables.map((v) =>
+                            resolveVariable(v, wsClient, taskContext, currentExtras)
+                        );
 
-                    const derivedResult = await resolveDerivedValue(
-                        key,
-                        variable.variables,
-                        variable.deps,
-                        resolvedVariables,
-                        wsClient,
-                        get,
-                        selfTrigger
-                    );
+                        const selfTrigger = get(getOrRegisterTrigger(variable));
+                        const { extras } = extrasSerializable;
 
-                    if (derivedResult.type === 'previous') {
-                        return { cache_key: derivedResult.entry.cacheKey, value: derivedResult.entry.result };
-                    }
-
-                    let variableResponse = null;
-
-                    try {
-                        variableResponse = await debouncedFetchDerivedVariable({
-                            cache: variable.cache,
-                            extras,
-                            force: derivedResult.force,
-                            is_data_variable: isDerivedDataVariable(variable),
-                            uid: variable.uid,
-                            values: normalizeRequest(
-                                formatDerivedVariableRequest(derivedResult.values),
-                                variable.variables
-                            ),
+                        // for deps use a different key for each selector instance rather than one per family
+                        const selectorKey = key + extrasSerializable.toJSON();
+                        const derivedResult = await resolveDerivedValue(
+                            selectorKey,
+                            variable.variables,
+                            variable.deps,
+                            resolvedVariables,
                             wsClient,
-                        });
-                    } catch (e) {
-                        // On DV error put selectorId into the error so the boundary can reset the selector cache
-                        e.selectorId = key;
-                        throw e;
-                    }
+                            get,
+                            selfTrigger
+                        );
 
-                    const cacheKey = variableResponse.cache_key;
-                    let variableValue = null;
-
-                    // We're only interested in the actual value for DVs.
-                    // For DerivedDataVariables we only need the cache key and the backend will handle the rest, regardless
-                    // of whether it's running as a task or not
-                    if (isDerivedVariable(variable)) {
-                        // If there is a task running related to the current variable then something has changed, so cancel them
-                        taskContext.cleanupRunningTasks(variable.uid);
-
-                        // If the variable is computed as a task then wait for it to finish and fetch the result
-                        if (isTaskResponse(variableResponse)) {
-                            const taskId = variableResponse.task_id;
-
-                            // register task being started
-                            taskContext.startTask(taskId, variable.uid, getRegistryKey(variable, 'trigger'));
-
-                            try {
-                                await wsClient.waitForTask(taskId);
-                            } catch {
-                                // If there was an error waiting for task it means it was cancelled (by a re-run)
-                                // It should be safe to return `null` here as the selector will re-run and throw suspense again
-                                return {
-                                    cache_key: cacheKey,
-                                    value: null,
-                                };
-                            } finally {
-                                taskContext.endTask(taskId);
-                            }
-
-                            try {
-                                variableValue = await fetchTaskResult<any>(taskId, extras);
-                            } catch (e) {
-                                // On DV task error put selectorId into the error so the boundary can reset the selector cache
-                                e.selectorId = key;
-                                throw e;
-                            }
-                        } else {
-                            variableValue = variableResponse.value;
+                        if (derivedResult.type === 'previous') {
+                            return { cache_key: derivedResult.entry.cacheKey, value: derivedResult.entry.result };
                         }
-                    }
 
-                    // Store the final result and arguments used if deps is specified
+                        let variableResponse = null;
 
-                    // resolve nested if defined (i.e. for DerivedVariable, DerivedDataVariable does not have nested)
-                    variableValue =
-                        'nested' in variable ? resolveNested(variableValue, variable.nested) : variableValue;
+                        try {
+                            variableResponse = await debouncedFetchDerivedVariable({
+                                cache: variable.cache,
+                                extras,
+                                force: derivedResult.force,
+                                is_data_variable: isDerivedDataVariable(variable),
+                                selectorKey,
+                                values: normalizeRequest(
+                                    formatDerivedVariableRequest(derivedResult.values),
+                                    variable.variables
+                                ),
+                                variableUid: variable.uid,
+                                wsClient,
+                            });
+                        } catch (e) {
+                            // On DV error put selectorId into the error so the boundary can reset the selector cache
+                            e.selectorId = key;
+                            throw e;
+                        }
 
-                    depsRegistry.set(key, {
-                        args: derivedResult.relevantValues,
-                        cacheKey,
-                        result: variableValue,
-                    });
+                        const cacheKey = variableResponse.cache_key;
+                        let variableValue = null;
 
-                    return {
-                        cache_key: cacheKey,
-                        value: variableValue,
-                    };
-                },
+                        // We're only interested in the actual value for DVs.
+                        // For DerivedDataVariables we only need the cache key and the backend will handle the rest, regardless
+                        // of whether it's running as a task or not
+                        if (isDerivedVariable(variable)) {
+                            // If there is a task running related to the current variable then something has changed, so cancel them
+                            taskContext.cleanupRunningTasks(variable.uid);
+
+                            // If the variable is computed as a task then wait for it to finish and fetch the result
+                            if (isTaskResponse(variableResponse)) {
+                                const taskId = variableResponse.task_id;
+
+                                // register task being started
+                                taskContext.startTask(taskId, variable.uid, getRegistryKey(variable, 'trigger'));
+
+                                try {
+                                    await wsClient.waitForTask(taskId);
+                                } catch {
+                                    // If there was an error waiting for task it means it was cancelled (by a re-run)
+                                    // It should be safe to return `null` here as the selector will re-run and throw suspense again
+                                    return {
+                                        cache_key: cacheKey,
+                                        value: null,
+                                    };
+                                } finally {
+                                    taskContext.endTask(taskId);
+                                }
+
+                                try {
+                                    variableValue = await fetchTaskResult<any>(taskId, extras);
+                                } catch (e) {
+                                    // On DV task error put selectorId into the error so the boundary can reset the selector cache
+                                    e.selectorId = key;
+                                    throw e;
+                                }
+                            } else {
+                                variableValue = variableResponse.value;
+                            }
+                        }
+
+                        // Store the final result and arguments used if deps is specified
+
+                        // resolve nested if defined (i.e. for DerivedVariable, DerivedDataVariable does not have nested)
+                        variableValue =
+                            'nested' in variable ? resolveNested(variableValue, variable.nested) : variableValue;
+
+                        depsRegistry.set(selectorKey, {
+                            args: derivedResult.relevantValues,
+                            cacheKey,
+                            result: variableValue,
+                        });
+
+                        return {
+                            cache_key: cacheKey,
+                            value: variableValue,
+                        };
+                    },
                 key: shortid.generate(),
             })
         );
     }
 
-    return selectorRegistry.get(key);
+    const family = selectorFamilyRegistry.get(key);
+
+    // Get a selector instance for this particular extras value
+    // This is required as otherwise the selector is not aware of different possible extras values
+    // at the call site of e.g. useVariable and would otherwise be a stale closure using the initial extras when
+    // first registered
+    const selectorInstance = family(new RequestExtrasSerializable(currentExtras));
+
+    // register selector instance in the selector family registry
+    if (!selectorFamilySelectorsRegistry.has(family)) {
+        selectorFamilySelectorsRegistry.set(family, new Set());
+    }
+    selectorFamilySelectorsRegistry.get(family).add(selectorInstance);
+
+    return selectorInstance;
 }
 
 /**
@@ -545,10 +588,9 @@ export function getOrRegisterDerivedVariableValue(
     variable: DerivedVariable,
     wsClient: WebSocketClientInterface,
     taskContext: GlobalTaskContext,
-    search: string,
     extras: RequestExtras
 ): RecoilValue<any> {
-    const dvSelector = getOrRegisterDerivedVariable(variable, wsClient, taskContext, search, extras);
+    const dvSelector = getOrRegisterDerivedVariable(variable, wsClient, taskContext, extras);
 
     const key = getRegistryKey(variable, 'derived-selector');
 
@@ -581,10 +623,9 @@ export function useDerivedVariable(
     variable: DerivedVariable | DerivedDataVariable,
     WsClient: WebSocketClientInterface,
     taskContext: GlobalTaskContext,
-    search: string,
     extras: RequestExtras
 ): RecoilValue<DerivedVariableValueResponse<any>> {
-    const dvSelector = getOrRegisterDerivedVariable(variable, WsClient, taskContext, search, extras);
+    const dvSelector = getOrRegisterDerivedVariable(variable, WsClient, taskContext, extras);
 
     /**
      * Workaround for forcing a re-calculation for derived variables by creating a triggerIndex atom and making it a dependency of

--- a/packages/dara-core/js/shared/interactivity/index.tsx
+++ b/packages/dara-core/js/shared/interactivity/index.tsx
@@ -2,7 +2,7 @@ export { useVariable } from './use-variable';
 export { useAnyVariable } from './use-any-variable';
 export { default as useVariableValue, getVariableValue } from './use-variable-value';
 export { resolveValue } from './resolve-value';
-export { TriggerIndexValue, getAtom } from './store';
+export { TriggerIndexValue } from './store';
 export { useDataVariable } from './use-data-variable';
 export { combineFilters } from './filtering';
 export { default as useRefreshSelector } from './use-refresh-selector';

--- a/packages/dara-core/js/shared/interactivity/plain-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/plain-variable.tsx
@@ -1,14 +1,21 @@
-import { RecoilState, atom, selector } from 'recoil';
+import { RecoilState, atom, atomFamily, selectorFamily } from 'recoil';
 
 import { WebSocketClientInterface } from '@/api';
-import { RequestExtras } from '@/api/http';
+import { RequestExtras, RequestExtrasSerializable } from '@/api/http';
 import { GlobalTaskContext } from '@/shared/context/global-task-context';
 import { isEmbedded } from '@/shared/utils/embed';
-import { SingleVariable, isDerivedVariable } from '@/types';
+import { DerivedVariable, SingleVariable, isDerivedVariable } from '@/types';
 
 // eslint-disable-next-line import/no-cycle
 import { getOrRegisterDerivedVariableValue, resolveNested, setNested } from './internal';
-import { atomRegistry, getRegistryKey, selectorRegistry } from './store';
+import {
+    AtomFamily,
+    atomFamilyMembersRegistry,
+    atomFamilyRegistry,
+    atomRegistry,
+    getRegistryKey,
+    selectorFamilyRegistry,
+} from './store';
 
 /**
  * Get the session key used to persist a variable value
@@ -25,6 +32,58 @@ export function getSessionKey(extras: RequestExtras, uid: string): string {
     }
 
     return `dara-session-${sessionToken}-var-${uid}`;
+}
+
+type Listener = (...args: any[]) => void;
+
+/**
+ * State synchronizer singleton
+ *
+ * Used to synchronize changes across atoms of the same family
+ */
+class StateSynchronizer {
+    static #instance: StateSynchronizer;
+
+    #listenersMap = new Map<string, Set<Listener>>();
+
+    // eslint-disable-next-line no-useless-constructor, no-empty-function
+    private constructor() {}
+
+    static getInstance(): StateSynchronizer {
+        if (!StateSynchronizer.#instance) {
+            StateSynchronizer.#instance = new StateSynchronizer();
+        }
+
+        return StateSynchronizer.#instance;
+    }
+
+    /**
+     * Subscribe to changes on a given key
+     *
+     * @param key key to subscribe to
+     * @param listener listener to invoke on change
+     * @returns a cleanup function to unsubscribe
+     */
+    subscribe(key: string, listener: Listener): () => void {
+        if (!this.#listenersMap.has(key)) {
+            this.#listenersMap.set(key, new Set());
+        }
+        this.#listenersMap.get(key).add(listener);
+
+        return () => {
+            this.#listenersMap.get(key).delete(listener);
+        };
+    }
+
+    /**
+     * Notify listeners for a given key
+     *
+     * @param key key to notify listeners for
+     * @param args arguments to pass to the listeners
+     */
+    notify(key: string, ...args: any[]): void {
+        this.#listenersMap.get(key)?.forEach((listener) => listener(...args));
+    }
 }
 
 /**
@@ -44,84 +103,147 @@ export function getOrRegisterPlainVariable<T>(
     extras: RequestExtras
 ): RecoilState<T> {
     const isNested = variable.nested && variable.nested.length > 0;
+    const isDefaultDerived = isDerivedVariable(variable.default);
 
-    if (!atomRegistry.has(variable.uid)) {
-        let defaultValue = variable.default;
-        // Variables created from DVs cannot be persisted
-        const persistValue = (variable.persist_value || isEmbedded()) && !isDerivedVariable(variable.default);
+    let atomInstance: RecoilState<T>;
+    let family: AtomFamily | null = null;
 
-        // If persist_value flag is set, try to retrieve persisted value and use it if we found one instead of default
-        if (persistValue) {
-            const persistedValue = localStorage.getItem(getSessionKey(extras, variable.uid));
+    // Variables created from DV need to be registered as atomFamily to dynamically pick up the right DV
+    if (isDefaultDerived) {
+        if (!atomFamilyRegistry.has(variable.uid)) {
+            atomFamilyRegistry.set(
+                variable.uid,
+                atomFamily({
+                    /*
+                If created from a DerivedVariable, link the default state to that DV's selector
+                From Recoil docs:
+                "If a selector is used as the default the atom will dynamically update as the default selector updates.
+                Once the atom is set, then it will retain that value unless the atom is reset."
+                */
+                    default: (extrasSerializable: RequestExtrasSerializable) =>
+                        getOrRegisterDerivedVariableValue(
+                            variable.default as DerivedVariable,
+                            wsClient,
+                            taskContext,
+                            extrasSerializable.extras
+                        ),
+                    effects: [
+                        ({ onSet, setSelf, resetSelf }) => {
+                            // Synchronize changes across atoms of the same family
+                            const unsub = StateSynchronizer.getInstance().subscribe(
+                                variable.uid,
+                                (newValue, oldValue, isReset) => {
+                                    if (isReset) {
+                                        resetSelf();
+                                    } else {
+                                        setSelf(newValue);
+                                    }
+                                }
+                            );
 
-            if (persistedValue) {
-                defaultValue = JSON.parse(persistedValue);
-            }
-        }
-
-        atomRegistry.set(
-            variable.uid,
-            atom({
-                /*
-            If created from a DerivedVariable, link the default state to that DV's selector
-            From Recoil docs:
-            "If a selector is used as the default the atom will dynamically update as the default selector updates.
-            Once the atom is set, then it will retain that value unless the atom is reset."
-            */
-                default: isDerivedVariable(variable.default)
-                    ? getOrRegisterDerivedVariableValue(variable.default, wsClient, taskContext, extras)
-                    : defaultValue,
-                effects: [
-                    ({ onSet }) => {
-                        // If persist_value flag is set, register an effect which updates the selected value in sessionStorage on each variable update
-                        if (persistValue) {
-                            onSet((newValue) => {
-                                localStorage.setItem(getSessionKey(extras, variable.uid), JSON.stringify(newValue));
+                            onSet((newValue, oldValue, isReset) => {
+                                StateSynchronizer.getInstance().notify(variable.uid, newValue, oldValue, isReset);
                             });
-                        }
-                    },
-                ],
-                key: variable.uid,
-            })
-        );
-    }
 
-    // In case of a nested variable, register a selector
-    if (isNested) {
-        const key = getRegistryKey(variable, 'selector');
-
-        if (!selectorRegistry.has(key)) {
-            // Below we make sure nested is a list of strings
-            // this is validated on the Python side but when using @template we can't validate it and is replaced at runtime
-            // so we coerce it to a list of strings here
-            selectorRegistry.set(
-                key,
-                selector<any>({
-                    get: ({ get }) => {
-                        const variableValue = get(atomRegistry.get(variable.uid));
-
-                        return resolveNested(
-                            variableValue,
-                            variable.nested.map((n) => String(n))
-                        );
-                    },
-                    key,
-                    set: ({ set }, newValue) => {
-                        set(atomRegistry.get(variable.uid), (v) =>
-                            setNested(
-                                v,
-                                variable.nested.map((n) => String(n)),
-                                newValue
-                            )
-                        );
-                    },
+                            return () => unsub();
+                        },
+                    ],
+                    key: variable.uid,
                 })
             );
         }
 
-        // We cast it since it's a writeable selector
-        return selectorRegistry.get(key) as RecoilState<T>;
+        family = atomFamilyRegistry.get(variable.uid);
+        const extrasSerializable = new RequestExtrasSerializable(extras);
+        atomInstance = family(extrasSerializable);
+
+        // Register the atom instance in the atomFamilyMembersRegistry so we can retrieve it later
+        if (!atomFamilyMembersRegistry.has(family)) {
+            atomFamilyMembersRegistry.set(family, new Map());
+        }
+        atomFamilyMembersRegistry.get(family).set(extrasSerializable.toJSON(), atomInstance);
+    } else {
+        // otherwise register it as a plain atom
+        if (!atomRegistry.has(variable.uid)) {
+            let defaultValue = variable.default;
+            const persistValue = variable.persist_value || isEmbedded();
+
+            // If persist_value flag is set, try to retrieve persisted value and use it if we found one instead of default
+            if (persistValue) {
+                const persistedValue = localStorage.getItem(getSessionKey(extras, variable.uid));
+
+                if (persistedValue) {
+                    defaultValue = JSON.parse(persistedValue);
+                }
+            }
+
+            atomRegistry.set(
+                variable.uid,
+                atom({
+                    default: defaultValue,
+                    // If persist_value flag is set, register an effect which updates the selected value in sessionStorage on each variable update
+                    effects: persistValue
+                        ? [
+                              ({ onSet }) => {
+                                  onSet((newValue) => {
+                                      localStorage.setItem(
+                                          getSessionKey(extras, variable.uid),
+                                          JSON.stringify(newValue)
+                                      );
+                                  });
+                              },
+                          ]
+                        : [],
+                    key: variable.uid,
+                })
+            );
+        }
+
+        atomInstance = atomRegistry.get(variable.uid);
     }
 
-    return atomRegistry.get(variable.uid);
+    // In case of a nested variable, register and return a selector to resolve the nested values
+    if (isNested) {
+        const key = getRegistryKey(variable, 'selector');
+
+        if (!selectorFamilyRegistry.has(key)) {
+            // Below we make sure nested is a list of strings
+            // this is validated on the Python side but when using @template we can't validate it and is replaced at runtime
+            // so we coerce it to a list of strings here
+            selectorFamilyRegistry.set(
+                key,
+                selectorFamily({
+                    get:
+                        (extrasSerializable: RequestExtrasSerializable) =>
+                        ({ get }) => {
+                            const variableValue = get(family ? family(extrasSerializable) : atomInstance);
+
+                            return resolveNested(
+                                variableValue,
+                                variable.nested.map((n) => String(n))
+                            );
+                        },
+                    key,
+                    set:
+                        (extrasSerializable: RequestExtrasSerializable) =>
+                        ({ set }, newValue) => {
+                            set(family ? family(extrasSerializable) : atomInstance, (v) =>
+                                setNested(
+                                    v,
+                                    variable.nested.map((n) => String(n)),
+                                    newValue
+                                )
+                            );
+                        },
+                })
+            );
+        }
+        const selectorFamilyInstance = selectorFamilyRegistry.get(key);
+        const extrasSerializable = new RequestExtrasSerializable(extras);
+
+        // We cast it since it's a writeable selector
+        return selectorFamilyInstance(extrasSerializable) as RecoilState<T>;
+    }
+
+    return atomInstance;
 }

--- a/packages/dara-core/js/shared/interactivity/plain-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/plain-variable.tsx
@@ -41,7 +41,6 @@ export function getOrRegisterPlainVariable<T>(
     variable: SingleVariable<T>,
     wsClient: WebSocketClientInterface,
     taskContext: GlobalTaskContext,
-    search: string,
     extras: RequestExtras
 ): RecoilState<T> {
     const isNested = variable.nested && variable.nested.length > 0;
@@ -70,7 +69,7 @@ export function getOrRegisterPlainVariable<T>(
             Once the atom is set, then it will retain that value unless the atom is reset."
             */
                 default: isDerivedVariable(variable.default)
-                    ? getOrRegisterDerivedVariableValue(variable.default, wsClient, taskContext, search, extras)
+                    ? getOrRegisterDerivedVariableValue(variable.default, wsClient, taskContext, extras)
                     : defaultValue,
                 effects: [
                     ({ onSet }) => {

--- a/packages/dara-core/js/shared/interactivity/resolve-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/resolve-variable.tsx
@@ -30,7 +30,6 @@ import {
  * @param variable variable to resolve
  * @param client websocket client from context
  * @param taskContext global task context
- * @param search search query from location
  * @param extras request extras to be merged into the options
  * @param resolver function to run the value through (for non-derived variables)
  */
@@ -38,7 +37,6 @@ export function resolveVariable<VariableType>(
     variable: AnyVariable<VariableType>,
     client: WebSocketClientInterface,
     taskContext: GlobalTaskContext,
-    search: string,
     extras: RequestExtras,
     resolver: (val: RecoilState<VariableType>) => RecoilState<VariableType> | ResolvedDerivedVariable | VariableType = (
         val: RecoilState<VariableType>
@@ -50,10 +48,10 @@ export function resolveVariable<VariableType>(
     | ResolvedDataVariable
     | VariableType {
     if (isDerivedVariable(variable) || isDerivedDataVariable(variable)) {
-        getOrRegisterDerivedVariable(variable, client, taskContext, search, extras);
+        getOrRegisterDerivedVariable(variable, client, taskContext, extras);
 
         // For derived variable, recursively resolve the dependencies
-        const values = variable.variables.map((v) => resolveVariable(v, client, taskContext, search, extras, resolver));
+        const values = variable.variables.map((v) => resolveVariable(v, client, taskContext, extras, resolver));
 
         // Store indexes of values which are in deps
         const deps = variable.deps.map((dep) => variable.variables.findIndex((v) => v.uid === dep.uid));
@@ -84,5 +82,5 @@ export function resolveVariable<VariableType>(
         return resolver(getOrRegisterUrlVariable(variable));
     }
 
-    return resolver(getOrRegisterPlainVariable(variable, client, taskContext, search, extras));
+    return resolver(getOrRegisterPlainVariable(variable, client, taskContext, extras));
 }

--- a/packages/dara-core/js/shared/interactivity/store.tsx
+++ b/packages/dara-core/js/shared/interactivity/store.tsx
@@ -105,7 +105,14 @@ export function isRegistered<T>(variable: AnyVariable<T>): boolean {
     }
 
     switch (variable.__typename) {
-        case 'Variable':
+        case 'Variable': {
+            if (atomRegistry.has(variable.uid)) {
+                return true;
+            }
+            const family = atomFamilyRegistry.get(variable.uid);
+            return atomFamilyMembersRegistry.get(family)?.size > 0;
+        }
+
         case 'UrlVariable':
         case 'DataVariable':
             return atomRegistry.has(variable.uid);
@@ -122,29 +129,5 @@ export function isRegistered<T>(variable: AnyVariable<T>): boolean {
 
         default:
             return false;
-    }
-}
-
-/**
- * Get an atom for a given variable.
- *
- * Useful in cases where we need to atom directly to e.g. write to it.
- *
- * @param variable variable to get the atom for
- */
-export function getAtom<T>(variable: AnyVariable<T>): RecoilState<T> {
-    if (!isRegistered(variable)) {
-        throw new Error(`Variable ${variable.uid} is not registered.`);
-    }
-
-    switch (variable.__typename) {
-        case 'Variable':
-        case 'UrlVariable':
-            return atomRegistry.get(variable.uid);
-
-        default:
-            throw new Error(
-                `Variable ${variable.uid} of type ${variable.__typename} does not have an associated atom.`
-            );
     }
 }

--- a/packages/dara-core/js/shared/interactivity/store.tsx
+++ b/packages/dara-core/js/shared/interactivity/store.tsx
@@ -5,6 +5,16 @@ import { getUniqueIdentifier } from '@/shared/utils/hashing';
 import { AnyVariable, isVariable } from '@/types';
 
 /**
+ * Selector family type which constructs a selector from a given set of extras.
+ */
+export type SelectorFamily = (P: RequestExtrasSerializable) => RecoilValue<any>;
+
+/**
+ * Atom family type which constructs an atom from a given set of extras.
+ */
+export type AtomFamily = (P: RequestExtrasSerializable) => RecoilState<any>;
+
+/**
  * Key -> trigger atom
  */
 export const dataRegistry = new Map<string, RecoilState<TriggerIndexValue>>();
@@ -13,22 +23,29 @@ export const dataRegistry = new Map<string, RecoilState<TriggerIndexValue>>();
  */
 export const atomRegistry = new Map<string, RecoilState<any>>();
 /**
+ * Key -> atom family
+ */
+export const atomFamilyRegistry = new Map<string, AtomFamily>();
+/**
+ * Atom family function => {extras => atom}
+ *
+ * Stores all instances of a given atom family, as a map of seriailzed extras to atom.
+ */
+export const atomFamilyMembersRegistry = new Map<AtomFamily, Map<string, RecoilState<any>>>();
+/**
  * Key -> selector
  */
 export const selectorRegistry = new Map<string, RecoilValue<any>>();
 /**
  * Key -> selector family
  */
-export const selectorFamilyRegistry = new Map<string, (P: RequestExtrasSerializable) => RecoilValue<any>>();
+export const selectorFamilyRegistry = new Map<string, SelectorFamily>();
 /**
- * Selector family -> selectors
+ * Selector family function => {extras => selector}
  *
- * Stores all instances of a selector family
+ * Stores all instances of a given selector family, as a map of seriailzed extras to selector.
  */
-export const selectorFamilySelectorsRegistry = new Map<
-    (P: RequestExtrasSerializable) => RecoilValue<any>,
-    Set<RecoilValue<any>>
->();
+export const selectorFamilyMembersRegistry = new Map<SelectorFamily, Map<string, RecoilValue<any>>>();
 /**
  * Key -> dependencies data for a selector
  */
@@ -65,10 +82,12 @@ export function clearRegistries_TEST(): void {
     for (const registry of [
         dataRegistry,
         atomRegistry,
+        atomFamilyRegistry,
+        atomFamilyMembersRegistry,
         selectorRegistry,
         depsRegistry,
         selectorFamilyRegistry,
-        selectorFamilySelectorsRegistry,
+        selectorFamilyMembersRegistry,
     ]) {
         registry.clear();
     }

--- a/packages/dara-core/js/shared/interactivity/url-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/url-variable.tsx
@@ -30,7 +30,5 @@ export function getOrRegisterUrlVariable<T>(variable: UrlVariable<T>): RecoilSta
 }
 
 export function useUrlVariable<T>(variable: UrlVariable<T>): [T, (value: T) => void] {
-    const [val, setVal] = useRecoilState<T>(getOrRegisterUrlVariable(variable));
-
-    return [val, setVal];
+    return useRecoilState<T>(getOrRegisterUrlVariable(variable));
 }

--- a/packages/dara-core/js/shared/interactivity/use-data-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-data-variable.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { useContext, useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { useRecoilValueLoadable } from 'recoil';
 
 // eslint-disable-next-line import/no-cycle

--- a/packages/dara-core/js/shared/interactivity/use-data-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-data-variable.tsx
@@ -6,8 +6,7 @@ import { useLocation } from 'react-router-dom';
 import { useRecoilValueLoadable } from 'recoil';
 
 // eslint-disable-next-line import/no-cycle
-import { useSessionToken } from '@/auth/auth-context';
-import { VariableCtx, WebSocketCtx, useTaskContext } from '@/shared/context';
+import { VariableCtx, WebSocketCtx, useRequestExtras, useTaskContext } from '@/shared/context';
 import { AnyDataVariable, FilterQuery, Pagination, isDataVariable } from '@/types';
 
 import {
@@ -30,7 +29,7 @@ import {
 export function useDataVariable(
     variable: AnyDataVariable
 ): (filters?: FilterQuery, pagination?: Pagination) => Promise<DataResponse> {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     const { client: WsClient } = useContext(WebSocketCtx);
 
     if (isDataVariable(variable)) {
@@ -60,7 +59,7 @@ export function useDataVariable(
     const taskContext = useTaskContext();
     const { search } = useLocation();
 
-    const dvSelector = useDerivedVariable(variable, WsClient, taskContext, search, token);
+    const dvSelector = useDerivedVariable(variable, WsClient, taskContext, search, extras);
     const dvLoadable = useRecoilValueLoadable(dvSelector);
 
     // We can't directly use the loadable as the callback's dependency because the loadable identity

--- a/packages/dara-core/js/shared/interactivity/use-data-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-data-variable.tsx
@@ -57,9 +57,8 @@ export function useDataVariable(
     }, []);
 
     const taskContext = useTaskContext();
-    const { search } = useLocation();
 
-    const dvSelector = useDerivedVariable(variable, WsClient, taskContext, search, extras);
+    const dvSelector = useDerivedVariable(variable, WsClient, taskContext, extras);
     const dvLoadable = useRecoilValueLoadable(dvSelector);
 
     // We can't directly use the loadable as the callback's dependency because the loadable identity

--- a/packages/dara-core/js/shared/interactivity/use-refresh-selector.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-refresh-selector.tsx
@@ -1,17 +1,21 @@
 import { useRecoilCallback } from 'recoil';
 
-import { selectorRegistry } from './store';
+import { selectorFamilyRegistry, selectorFamilySelectorsRegistry } from './store';
 
 /**
  * Helper hook to refresh a selector by its key
  */
-export default function useRefreshSelector(): (key: string) => void {
+export default function useRefreshSelector(): (key: string, extras: string) => void {
     return useRecoilCallback(({ refresh }) => {
-        return (key: string) => {
-            const selector = selectorRegistry.get(key);
+        return (key: string, extras: string) => {
+            const family = selectorFamilyRegistry.get(key);
 
-            if (selector) {
-                refresh(selector);
+            if (family) {
+                const selector = selectorFamilySelectorsRegistry.get(family)?.get(extras);
+
+                if (selector) {
+                    refresh(selector);
+                }
             }
         };
     });

--- a/packages/dara-core/js/shared/interactivity/use-refresh-selector.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-refresh-selector.tsx
@@ -1,6 +1,6 @@
 import { useRecoilCallback } from 'recoil';
 
-import { selectorFamilyRegistry, selectorFamilySelectorsRegistry } from './store';
+import { selectorFamilyMembersRegistry, selectorFamilyRegistry } from './store';
 
 /**
  * Helper hook to refresh a selector by its key
@@ -11,7 +11,7 @@ export default function useRefreshSelector(): (key: string, extras: string) => v
             const family = selectorFamilyRegistry.get(key);
 
             if (family) {
-                const selector = selectorFamilySelectorsRegistry.get(family)?.get(extras);
+                const selector = selectorFamilyMembersRegistry.get(family)?.get(extras);
 
                 if (selector) {
                     refresh(selector);

--- a/packages/dara-core/js/shared/interactivity/use-server-component.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-server-component.tsx
@@ -1,15 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 
 import { useContext, useEffect } from 'react';
-import {
-    RecoilState,
-    RecoilValue,
-    atom,
-    selector,
-    selectorFamily,
-    useRecoilCallback,
-    useRecoilValueLoadable,
-} from 'recoil';
+import { RecoilState, RecoilValue, atom, selectorFamily, useRecoilCallback, useRecoilValueLoadable } from 'recoil';
 
 import { HTTP_METHOD, validateResponse } from '@darajs/ui-utils';
 
@@ -36,7 +28,6 @@ import {
     depsRegistry,
     selectorFamilyMembersRegistry,
     selectorFamilyRegistry,
-    selectorRegistry,
 } from './store';
 
 function isTaskResponse(response: any): response is TaskResponse {

--- a/packages/dara-core/js/shared/interactivity/use-server-component.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-server-component.tsx
@@ -34,8 +34,8 @@ import {
     TriggerIndexValue,
     atomRegistry,
     depsRegistry,
+    selectorFamilyMembersRegistry,
     selectorFamilyRegistry,
-    selectorFamilySelectorsRegistry,
     selectorRegistry,
 } from './store';
 
@@ -282,10 +282,10 @@ function getOrRegisterServerComponent(
     const selectorInstance = family(serializableExtras);
 
     // register selector instance in the selector family registry
-    if (!selectorFamilySelectorsRegistry.has(family)) {
-        selectorFamilySelectorsRegistry.set(family, new Map());
+    if (!selectorFamilyMembersRegistry.has(family)) {
+        selectorFamilyMembersRegistry.set(family, new Map());
     }
-    selectorFamilySelectorsRegistry.get(family).set(serializableExtras.toJSON(), selectorInstance);
+    selectorFamilyMembersRegistry.get(family).set(serializableExtras.toJSON(), selectorInstance);
 
     return selectorInstance;
 }

--- a/packages/dara-core/js/shared/interactivity/use-server-component.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-server-component.tsx
@@ -224,6 +224,7 @@ function getOrRegisterServerComponent(
                             );
                         } catch (e) {
                             e.selectorId = key;
+                            e.selectorExtras = extrasSerializable.toJSON();
                             throw e;
                         }
 
@@ -248,6 +249,7 @@ function getOrRegisterServerComponent(
                                 result = await fetchTaskResult<NormalizedPayload<ComponentInstance>>(taskId, extras);
                             } catch (e) {
                                 e.selectorId = key;
+                                e.selectorExtras = extrasSerializable.toJSON();
                                 throw e;
                             }
                         }
@@ -276,13 +278,14 @@ function getOrRegisterServerComponent(
     // This is required as otherwise the selector is not aware of different possible extras values
     // at the call site of e.g. useVariable and would otherwise be a stale closure using the initial extras when
     // first registered
-    const selectorInstance = family(new RequestExtrasSerializable(currentExtras));
+    const serializableExtras = new RequestExtrasSerializable(currentExtras);
+    const selectorInstance = family(serializableExtras);
 
     // register selector instance in the selector family registry
     if (!selectorFamilySelectorsRegistry.has(family)) {
-        selectorFamilySelectorsRegistry.set(family, new Set());
+        selectorFamilySelectorsRegistry.set(family, new Map());
     }
-    selectorFamilySelectorsRegistry.get(family).add(selectorInstance);
+    selectorFamilySelectorsRegistry.get(family).set(serializableExtras.toJSON(), selectorInstance);
 
     return selectorInstance;
 }

--- a/packages/dara-core/js/shared/interactivity/use-variable-state.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable-state.tsx
@@ -2,16 +2,10 @@ import { useContext } from 'react';
 import { useRecoilCallback } from 'recoil';
 
 import { WebSocketCtx, useRequestExtras, useTaskContext } from '@/shared/context';
-import {
-    AnyVariable,
-    ResolvedDataVariable,
-    ResolvedDerivedDataVariable,
-    ResolvedDerivedVariable,
-    isVariable,
-} from '@/types';
+import { AnyVariable, ResolvedDataVariable, ResolvedDerivedDataVariable, ResolvedDerivedVariable } from '@/types';
 
 import { resolveVariable } from './resolve-variable';
-import { atomRegistry, isRegistered } from './store';
+import { isRegistered } from './store';
 
 type AnyResolvedVariable = ResolvedDataVariable | ResolvedDerivedDataVariable | ResolvedDerivedVariable;
 
@@ -31,13 +25,7 @@ export default function useVariableState(): any | AnyResolvedVariable {
                 return '__NOT_REGISTERED__';
             }
 
-            // For variables and url-variables, get the value directly out of recoil store
-            if (isVariable(variable) && (variable.__typename === 'Variable' || variable.__typename === 'UrlVariable')) {
-                const atom = atomRegistry.get(variable.uid);
-                return snapshot.getLoadable(atom).getValue();
-            }
-
-            // otherwise we'll just get the resolved form of the variable
+            // get the resolved form of the variable
             const resolvedVariable = resolveVariable<AnyResolvedVariable>(variable, client, taskCtx, extras, (v) =>
                 snapshot.getLoadable(v).getValue()
             );

--- a/packages/dara-core/js/shared/interactivity/use-variable-state.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable-state.tsx
@@ -1,5 +1,4 @@
 import { useContext } from 'react';
-import { useLocation } from 'react-router';
 import { useRecoilCallback } from 'recoil';
 
 import { WebSocketCtx, useRequestExtras, useTaskContext } from '@/shared/context';
@@ -25,7 +24,6 @@ export default function useVariableState(): any | AnyResolvedVariable {
     const extras = useRequestExtras();
     const { client } = useContext(WebSocketCtx);
     const taskCtx = useTaskContext();
-    const { search } = useLocation();
 
     return useRecoilCallback(({ snapshot }) => {
         return (variable: AnyVariable<any>) => {
@@ -40,13 +38,8 @@ export default function useVariableState(): any | AnyResolvedVariable {
             }
 
             // otherwise we'll just get the resolved form of the variable
-            const resolvedVariable = resolveVariable<AnyResolvedVariable>(
-                variable,
-                client,
-                taskCtx,
-                search,
-                extras,
-                (v) => snapshot.getLoadable(v).getValue()
+            const resolvedVariable = resolveVariable<AnyResolvedVariable>(variable, client, taskCtx, extras, (v) =>
+                snapshot.getLoadable(v).getValue()
             );
 
             return resolvedVariable;

--- a/packages/dara-core/js/shared/interactivity/use-variable-state.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable-state.tsx
@@ -2,8 +2,7 @@ import { useContext } from 'react';
 import { useLocation } from 'react-router';
 import { useRecoilCallback } from 'recoil';
 
-import { useSessionToken } from '@/auth/auth-context';
-import { WebSocketCtx, useTaskContext } from '@/shared/context';
+import { WebSocketCtx, useRequestExtras, useTaskContext } from '@/shared/context';
 import {
     AnyVariable,
     ResolvedDataVariable,
@@ -23,7 +22,7 @@ type AnyResolvedVariable = ResolvedDataVariable | ResolvedDerivedDataVariable | 
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export default function useVariableState(): any | AnyResolvedVariable {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     const { client } = useContext(WebSocketCtx);
     const taskCtx = useTaskContext();
     const { search } = useLocation();
@@ -46,7 +45,7 @@ export default function useVariableState(): any | AnyResolvedVariable {
                 client,
                 taskCtx,
                 search,
-                token,
+                extras,
                 (v) => snapshot.getLoadable(v).getValue()
             );
 

--- a/packages/dara-core/js/shared/interactivity/use-variable-value.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable-value.tsx
@@ -66,7 +66,7 @@ export function getVariableValue<VV, B extends boolean = false>(
     | Promise<VV>
     | Promise<DataFrame> {
     // Using loadable since the resolver is only used for simple atoms and shouldn't cause problems
-    const resolved = resolveVariable<any>(variable, ctx.client, ctx.taskContext, ctx.search, ctx.extras, (v) =>
+    const resolved = resolveVariable<any>(variable, ctx.client, ctx.taskContext, ctx.extras, (v) =>
         ctx.snapshot.getLoadable(v).getValue()
     );
 
@@ -99,11 +99,16 @@ export function getVariableValue<VV, B extends boolean = false>(
         cache: (variable as DerivedVariable | DerivedDataVariable).cache,
         extras: ctx.extras,
         force: false,
-        uid: resolved.uid,
+        /**
+         * In this case we're not concerned about different selectors fetching the value so just use the uid
+         */
+        selectorKey: resolved.uid,
+
         values: normalizeRequest(
             formatDerivedVariableRequest(resolved.values),
             (variable as DerivedVariable | DerivedDataVariable).variables
         ),
+        variableUid: resolved.uid,
         wsClient: ctx.client,
     }).then((resp) => {
         // This is really only used in DownloadVariable currently; we can add support for tasks

--- a/packages/dara-core/js/shared/interactivity/use-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable.tsx
@@ -2,8 +2,7 @@ import { Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } fr
 import { useLocation } from 'react-router-dom';
 import { useRecoilStateLoadable, useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE } from 'recoil';
 
-import { useSessionToken } from '@/auth/auth-context';
-import { VariableCtx, WebSocketCtx, useTaskContext } from '@/shared/context';
+import { VariableCtx, WebSocketCtx, useRequestExtras, useTaskContext } from '@/shared/context';
 import { useDeferLoadable } from '@/shared/utils';
 import { Variable, isDataVariable, isDerivedDataVariable, isDerivedVariable, isUrlVariable, isVariable } from '@/types';
 
@@ -32,7 +31,7 @@ function warnUpdateOnDerivedState(): void {
  * @param variable the possible variable to use
  */
 export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Dispatch<SetStateAction<T>>] {
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     const { client: WsClient } = useContext(WebSocketCtx);
     const taskContext = useTaskContext();
     const variablesContext = useContext(VariableCtx);
@@ -56,7 +55,7 @@ export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Di
     }
 
     if (isDerivedVariable(variable)) {
-        const selector = useDerivedVariable(variable, WsClient, taskContext, search, token);
+        const selector = useDerivedVariable(variable, WsClient, taskContext, search, extras);
         const selectorLoadable = useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE(selector);
 
         const deferred = useDeferLoadable(selectorLoadable);
@@ -68,7 +67,7 @@ export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Di
         return useUrlVariable(variable);
     }
 
-    const recoilState = useMemo(() => getOrRegisterPlainVariable(variable, WsClient, taskContext, search, token), []);
+    const recoilState = useMemo(() => getOrRegisterPlainVariable(variable, WsClient, taskContext, search, extras), []);
     const [loadable, setLoadable] = useRecoilStateLoadable(recoilState);
     const deferred = useDeferLoadable(loadable);
 

--- a/packages/dara-core/js/shared/interactivity/use-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable.tsx
@@ -1,5 +1,4 @@
-import { Dispatch, SetStateAction, useContext, useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { Dispatch, SetStateAction, useContext, useEffect, useState } from 'react';
 import { useRecoilStateLoadable, useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE } from 'recoil';
 
 import { VariableCtx, WebSocketCtx, useRequestExtras, useTaskContext } from '@/shared/context';
@@ -32,10 +31,10 @@ function warnUpdateOnDerivedState(): void {
  */
 export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Dispatch<SetStateAction<T>>] {
     const extras = useRequestExtras();
+
     const { client: WsClient } = useContext(WebSocketCtx);
     const taskContext = useTaskContext();
     const variablesContext = useContext(VariableCtx);
-    const { search } = useLocation();
 
     if (!isVariable(variable)) {
         return useState(variable);
@@ -55,7 +54,7 @@ export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Di
     }
 
     if (isDerivedVariable(variable)) {
-        const selector = useDerivedVariable(variable, WsClient, taskContext, search, extras);
+        const selector = useDerivedVariable(variable, WsClient, taskContext, extras);
         const selectorLoadable = useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE(selector);
 
         const deferred = useDeferLoadable(selectorLoadable);
@@ -67,7 +66,7 @@ export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Di
         return useUrlVariable(variable);
     }
 
-    const recoilState = useMemo(() => getOrRegisterPlainVariable(variable, WsClient, taskContext, search, extras), []);
+    const recoilState = getOrRegisterPlainVariable(variable, WsClient, taskContext, extras);
     const [loadable, setLoadable] = useRecoilStateLoadable(recoilState);
     const deferred = useDeferLoadable(loadable);
 

--- a/packages/dara-core/js/shared/utils/use-action.tsx
+++ b/packages/dara-core/js/shared/utils/use-action.tsx
@@ -37,16 +37,10 @@ async function invokeAction(
     // resolve kwargs to primitives, this registers variables if not already registered
     const resolvedKwargs = Object.keys(annotatedAction.dynamic_kwargs).reduce((acc, k) => {
         const value = annotatedAction.dynamic_kwargs[k];
-        acc[k] = resolveVariable(
-            value,
-            actionCtx.wsClient,
-            actionCtx.taskCtx,
-            actionCtx.location.search,
-            actionCtx.extras,
-            (v) =>
-                // This is only called for primitive variables so it should always resolve successfully
-                // hence not using a promise
-                actionCtx.snapshot.getLoadable(v).getValue()
+        acc[k] = resolveVariable(value, actionCtx.wsClient, actionCtx.taskCtx, actionCtx.extras, (v) =>
+            // This is only called for primitive variables so it should always resolve successfully
+            // hence not using a promise
+            actionCtx.snapshot.getLoadable(v).getValue()
         );
         return acc;
     }, {} as Record<string, any>);

--- a/packages/dara-core/js/shared/utils/use-component-registry.tsx
+++ b/packages/dara-core/js/shared/utils/use-component-registry.tsx
@@ -7,8 +7,7 @@ import { HTTP_METHOD, validateResponse } from '@darajs/ui-utils';
 
 import { request } from '@/api';
 import { handleAuthErrors } from '@/auth/auth';
-import { useSessionToken } from '@/auth/auth-context';
-import { RegistriesCtx } from '@/shared/context';
+import { RegistriesCtx, useRequestExtras } from '@/shared/context';
 import { Component, ComponentInstance } from '@/types/core';
 
 interface ComponentRegistryInterface {
@@ -21,7 +20,7 @@ interface ComponentRegistryInterface {
  */
 function useComponentRegistry(maxRetries = 5): ComponentRegistryInterface {
     const { componentRegistry: components, refetchComponents } = useContext(RegistriesCtx);
-    const token = useSessionToken();
+    const extras = useRequestExtras();
     const get = useCallback(
         async (instance: ComponentInstance): Promise<Component> => {
             let component: Component = null;
@@ -36,7 +35,7 @@ function useComponentRegistry(maxRetries = 5): ComponentRegistryInterface {
                     const res = await request(
                         `/api/core/components?name=${instance.name}`,
                         { method: HTTP_METHOD.GET },
-                        token
+                        extras
                     );
                     await handleAuthErrors(res, true);
                     await validateResponse(res, 'Failed to fetch the config for this app');

--- a/packages/dara-core/js/types/core.tsx
+++ b/packages/dara-core/js/types/core.tsx
@@ -72,7 +72,7 @@ interface CachePolicy {
 
 export interface SingleVariable<T> {
     __typename: 'Variable';
-    default: T;
+    default: T | DerivedVariable;
     nested: string[];
     persist_value?: boolean;
     uid: string;

--- a/packages/dara-core/js/types/core.tsx
+++ b/packages/dara-core/js/types/core.tsx
@@ -7,6 +7,7 @@ import { CallbackInterface } from 'recoil';
 
 import { WebSocketClientInterface } from '@/api/websocket';
 import { GlobalTaskContext } from '@/shared/context/global-task-context';
+import { RequestExtras } from '@/api/http';
 
 export interface NormalizedPayload<T> {
     data: T;
@@ -363,9 +364,9 @@ export type NotifyImpl = ActionImpl & NotificationPayload;
  */
 export interface ActionContext extends CallbackInterface {
     /**
-     * Current auth session token
+     * Request extras to be passed into requests made
      */
-    sessionToken: string;
+    extras: RequestExtras;
     /**
      * Websocket Client instance
      */

--- a/packages/dara-core/tests/js/request-extras.spec.tsx
+++ b/packages/dara-core/tests/js/request-extras.spec.tsx
@@ -1,0 +1,161 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { ReactNode, useState } from 'react';
+
+import { request } from '@/api';
+import { AuthCtx, PartialRequestExtrasProvider, RequestExtrasProvider, useRequestExtras } from '@/shared';
+
+/**
+ * Testbed component that makes a request and displays the result.
+ *
+ * This is simply testing `useRequestExtras` -> `extras` under the assumption
+ * that all network requests are made using the `request` function and pass through `useRequestExtras`.
+ */
+function TestComponent(): JSX.Element {
+    const extras = useRequestExtras();
+    const [result, setResult] = useState(null);
+
+    async function makeRequest(): Promise<void> {
+        const res = await request('/foo', { method: 'GET' }, extras);
+        setResult(await res.json());
+    }
+
+    return (
+        <div>
+            <button data-testid="request" onClick={makeRequest} type="button">
+                Make Request
+            </button>
+            <div data-testid="response">{JSON.stringify(result)}</div>
+        </div>
+    );
+}
+
+const server = setupServer(
+    rest.get('/foo', (req, res, ctx) => {
+        return res(ctx.json(Object.fromEntries(req.headers.entries())));
+    })
+);
+
+function authRender({ children }: { children: ReactNode }): JSX.Element {
+    return <AuthCtx.Provider value={{ setToken: () => {}, token: 'TEST_TOKEN' }}>{children}</AuthCtx.Provider>;
+}
+
+describe('Request Extras', () => {
+    beforeEach(() => {
+        server.listen();
+    });
+
+    afterEach(() => server.resetHandlers());
+    afterAll(() => server.close());
+
+    it('should send session token', async () => {
+        const { getByTestId } = render(<TestComponent />, { wrapper: authRender });
+
+        act(() => {
+            fireEvent.click(getByTestId('request'));
+        });
+
+        await waitFor(() => {
+            const parsedHeaders = JSON.parse(getByTestId('response').textContent);
+            expect(parsedHeaders.accept).toEqual('application/json');
+            expect(parsedHeaders.authorization).toEqual('Bearer TEST_TOKEN');
+        });
+    });
+
+    it('should include request extras from context', async () => {
+        const { getByTestId } = render(
+            <RequestExtrasProvider
+                options={{
+                    headers: {
+                        'X-Dara-Test': 'test-value',
+                    },
+                }}
+            >
+                <TestComponent />
+            </RequestExtrasProvider>,
+            { wrapper: authRender }
+        );
+
+        act(() => {
+            fireEvent.click(getByTestId('request'));
+        });
+
+        await waitFor(() => {
+            const parsedHeaders = JSON.parse(getByTestId('response').textContent);
+            expect(parsedHeaders.accept).toEqual('application/json');
+            expect(parsedHeaders.authorization).toEqual('Bearer TEST_TOKEN');
+            expect(parsedHeaders['x-dara-test']).toEqual('test-value');
+        });
+    });
+
+    it('should override request extras with nested context', async () => {
+        const { getByTestId } = render(
+            <RequestExtrasProvider
+                options={{
+                    headers: {
+                        'X-Dara-Test': 'test-value',
+                    },
+                }}
+            >
+                <RequestExtrasProvider
+                    options={{
+                        headers: {
+                            'X-Dara-Test-2': 'test-value-2',
+                        },
+                    }}
+                >
+                    <TestComponent />
+                </RequestExtrasProvider>
+            </RequestExtrasProvider>,
+            { wrapper: authRender }
+        );
+
+        act(() => {
+            fireEvent.click(getByTestId('request'));
+        });
+
+        await waitFor(() => {
+            const parsedHeaders = JSON.parse(getByTestId('response').textContent);
+            expect(parsedHeaders.accept).toEqual('application/json');
+            expect(parsedHeaders.authorization).toEqual('Bearer TEST_TOKEN');
+            expect(parsedHeaders['x-dara-test-2']).toEqual('test-value-2');
+            expect(parsedHeaders['x-dara-test']).toBeUndefined();
+        });
+    });
+
+    it('should merge request extras with nested context when using Partial Provider', async () => {
+        const { getByTestId } = render(
+            <RequestExtrasProvider
+                options={{
+                    headers: {
+                        'X-Dara-Test': 'test-value',
+                    },
+                }}
+            >
+                <PartialRequestExtrasProvider
+                    options={{
+                        headers: {
+                            'X-Dara-Test-2': 'test-value-2',
+                        },
+                    }}
+                >
+                    <TestComponent />
+                </PartialRequestExtrasProvider>
+            </RequestExtrasProvider>,
+            { wrapper: authRender }
+        );
+
+        act(() => {
+            fireEvent.click(getByTestId('request'));
+        });
+
+        await waitFor(() => {
+            const parsedHeaders = JSON.parse(getByTestId('response').textContent);
+            expect(parsedHeaders.accept).toEqual('application/json');
+            expect(parsedHeaders.authorization).toEqual('Bearer TEST_TOKEN');
+            expect(parsedHeaders['x-dara-test-2']).toEqual('test-value-2');
+            expect(parsedHeaders['x-dara-test']).toEqual('test-value');
+        });
+    });
+});

--- a/packages/dara-core/tests/js/use-variable.spec.tsx
+++ b/packages/dara-core/tests/js/use-variable.spec.tsx
@@ -2,10 +2,15 @@ import { Matcher, MatcherOptions, act, fireEvent, render, renderHook, waitFor } 
 import { createMemoryHistory } from 'history';
 import { rest } from 'msw';
 import hash from 'object-hash';
+import { useRecoilCallback } from 'recoil';
 
 import { RequestExtrasProvider, useAction, useVariable } from '../../js/shared';
 import { getSessionKey } from '../../js/shared/interactivity/plain-variable';
-import { clearRegistries_TEST } from '../../js/shared/interactivity/store';
+import {
+    atomFamilyMembersRegistry,
+    atomFamilyRegistry,
+    clearRegistries_TEST,
+} from '../../js/shared/interactivity/store';
 import { getIdentifier } from '../../js/shared/utils/normalization';
 import { Action, DerivedVariable, SingleVariable, UrlVariable, Variable } from '../../js/types';
 import { DataVariable, TriggerVariableImpl } from '../../js/types/core';
@@ -306,6 +311,297 @@ describe('useVariable', () => {
             // Stored value should be used instead of default
             expect(result.current[0]).toEqual(storedValue.val);
             expect(getItemSpy).toHaveBeenCalledWith(getSessionKey(SESSION_TOKEN, 'session-test-4'));
+        });
+
+        it('should handle DerivedVariable as the default', async () => {
+            const inputVariableDef: SingleVariable<number> = {
+                __typename: 'Variable',
+                default: 1,
+                nested: [],
+                uid: 'input-variable',
+            };
+
+            const derivedVariableDef: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [inputVariableDef],
+                nested: [],
+                uid: 'derived-variable',
+                variables: [inputVariableDef],
+            };
+
+            const variableFromDerived: SingleVariable<string> = {
+                __typename: 'Variable',
+                default: derivedVariableDef,
+                nested: [],
+                uid: 'variable-from-derived',
+            };
+
+            function TestComponent(): JSX.Element {
+                const [inputVar, setInputVar] = useVariable(inputVariableDef);
+                const [derivedVar] = useVariable(derivedVariableDef);
+                const [varFromDerived, setVarFromDerived] = useVariable(variableFromDerived);
+
+                const resetAtom = useRecoilCallback(({ reset }) => () => {
+                    const family = atomFamilyRegistry.get(variableFromDerived.uid);
+                    // reset first instance
+                    const atomInstance = atomFamilyMembersRegistry.get(family).values().next().value;
+                    reset(atomInstance);
+                });
+
+                return (
+                    <div>
+                        <button data-testid="set-input" onClick={() => setInputVar(inputVar + 1)} type="button">
+                            click
+                        </button>
+                        <span data-testid="derived">{JSON.stringify(derivedVar)}</span>
+                        <span data-testid="var-from-derived">{JSON.stringify(varFromDerived)}</span>
+                        <button
+                            data-testid="set-var-from-derived"
+                            onClick={() => setVarFromDerived('test3')}
+                            type="button"
+                        >
+                            click
+                        </button>
+                        <button data-testid="reset" onClick={() => resetAtom()} type="button">
+                            reset
+                        </button>
+                    </div>
+                );
+            }
+
+            const { getByTestId } = wrappedRender(<TestComponent />);
+
+            await waitFor(() => expect(getByTestId('derived')).toBeVisible());
+
+            // Derived and input-from-derived should be the same
+            expect(getByTestId('derived').innerHTML).toEqual(getByTestId('var-from-derived').innerHTML);
+            const initialDerived = getByTestId('derived').innerHTML;
+            // Update the input variable
+            act(() => {
+                fireEvent.click(getByTestId('set-input'));
+            });
+            await waitFor(() => expect(getByTestId('derived')).toBeVisible());
+            expect(getByTestId('derived').innerHTML).not.toEqual(initialDerived);
+            // Derived and input-from-derived should be the same again
+            expect(getByTestId('derived').innerHTML).toEqual(getByTestId('var-from-derived').innerHTML);
+
+            const secondDerived = getByTestId('derived').innerHTML;
+
+            // Update the variable from derived
+            act(() => {
+                fireEvent.click(getByTestId('set-var-from-derived'));
+            });
+
+            // var-from-derived should be 'test3'
+            expect(getByTestId('var-from-derived').innerHTML).toEqual('"test3"');
+
+            // update derived again
+            act(() => {
+                fireEvent.click(getByTestId('set-input'));
+            });
+
+            await waitFor(() => expect(getByTestId('derived')).toBeVisible());
+            // Derived should be updated
+            expect(getByTestId('derived').innerHTML).not.toEqual(secondDerived);
+
+            const thirdDerived = getByTestId('derived').innerHTML;
+
+            // input-from-derived should not have been updated
+            expect(getByTestId('var-from-derived').innerHTML).toEqual('"test3"');
+
+            // Reset the variable from derived
+            act(() => {
+                fireEvent.click(getByTestId('reset'));
+            });
+
+            // var-from-derived should be back to the previous dv value
+            await waitFor(() => expect(getByTestId('var-from-derived').innerHTML).toEqual(thirdDerived));
+        });
+
+        it('handles RequestExtras contexts for Variable with default DerivedVariable', async () => {
+            /*
+             * Here we're testing that the RequestExtras is correctly used for different callsites
+             * of the same variable with a default DerivedVariable.
+             * Expected behaviour:
+             * - all call-sites are kept in-sync with each other
+             * - correct 'default' behaviour is preserved (as in previous test)
+             * - local extras are sent for initial DV requests
+             */
+
+            // keep track of headers received
+            const receivedHeaders: Headers[] = [];
+
+            server.use(
+                rest.post('/api/core/derived-variable/:uid', async (req, res, ctx) => {
+                    receivedHeaders.push(req.headers);
+                    return res(
+                        ctx.json({
+                            cache_key: JSON.stringify(req.body.values),
+                            value: req.body,
+                        })
+                    );
+                })
+            );
+
+            const inputVariableDef: SingleVariable<number> = {
+                __typename: 'Variable',
+                default: 1,
+                nested: [],
+                uid: 'input-variable',
+            };
+
+            const derivedVariableDef: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [inputVariableDef],
+                nested: [],
+                uid: 'derived-variable',
+                variables: [inputVariableDef],
+            };
+
+            const variableFromDerived: SingleVariable<string> = {
+                __typename: 'Variable',
+                default: derivedVariableDef,
+                nested: [],
+                uid: 'variable-from-derived',
+            };
+
+            function TestComponent({ dvKey }: { dvKey: string }): JSX.Element {
+                const [inputVar, setInputVar] = useVariable(inputVariableDef);
+                const [varFromDerived, setVarFromDerived] = useVariable(variableFromDerived);
+
+                const resetAtom = useRecoilCallback(({ reset }) => () => {
+                    const family = atomFamilyRegistry.get(variableFromDerived.uid);
+                    // reset one of them, we don't care which as both should be reset
+                    const atomInstance = atomFamilyMembersRegistry.get(family).values().next().value;
+                    reset(atomInstance);
+                });
+
+                return (
+                    <div>
+                        <button
+                            data-testid={`${dvKey}-set-input`}
+                            onClick={() => setInputVar(inputVar + 1)}
+                            type="button"
+                        >
+                            click
+                        </button>
+                        <span data-testid={`${dvKey}-var-from-derived`}>{JSON.stringify(varFromDerived)}</span>
+                        <button
+                            data-testid={`${dvKey}-set-var-from-derived`}
+                            onClick={() => setVarFromDerived('test3')}
+                            type="button"
+                        >
+                            click
+                        </button>
+                        <button data-testid={`${dvKey}-reset`} onClick={() => resetAtom()} type="button">
+                            reset
+                        </button>
+                    </div>
+                );
+            }
+
+            const { getByTestId } = wrappedRender(
+                <>
+                    <RequestExtrasProvider
+                        options={{
+                            headers: {
+                                'X-Dara-Test': 'test',
+                            },
+                        }}
+                    >
+                        <TestComponent dvKey="dv-1" />
+                    </RequestExtrasProvider>
+                    <RequestExtrasProvider
+                        options={{
+                            headers: {
+                                'X-Dara-Test': 'test2',
+                            },
+                        }}
+                    >
+                        <TestComponent dvKey="dv-2" />
+                    </RequestExtrasProvider>
+                </>
+            );
+
+            // wait for both components to be rendered
+            await waitFor(() => {
+                expect(getByTestId('dv-1-var-from-derived')).toBeVisible();
+                expect(getByTestId('dv-2-var-from-derived')).toBeVisible();
+            });
+
+            // Check both components have the same initial value
+            expect(getByTestId('dv-1-var-from-derived').innerHTML).toEqual(
+                getByTestId('dv-2-var-from-derived').innerHTML
+            );
+
+            const initialDerived = getByTestId('dv-1-var-from-derived').innerHTML;
+
+            await waitFor(() => expect(receivedHeaders.length).toBe(2));
+
+            // check headers were received and different - order unknown
+            expect(new Set(receivedHeaders.map((h) => h.get('X-Dara-Test')))).toEqual(new Set(['test', 'test2']));
+
+            // Clear headers
+            receivedHeaders.length = 0;
+
+            // update the input variable for the DV
+            act(() => {
+                fireEvent.click(getByTestId('dv-1-set-input'));
+            });
+
+            // wait for both components to be rendered
+            await waitFor(() => {
+                expect(getByTestId('dv-1-var-from-derived')).toBeVisible();
+                expect(getByTestId('dv-2-var-from-derived')).toBeVisible();
+            });
+
+            // Check both components have the same updated value but different than before
+            expect(getByTestId('dv-1-var-from-derived').innerHTML).not.toEqual(initialDerived);
+            expect(getByTestId('dv-1-var-from-derived').innerHTML).toEqual(
+                getByTestId('dv-2-var-from-derived').innerHTML
+            );
+
+            const dvAfterUpdate = getByTestId('dv-1-var-from-derived').innerHTML;
+
+            // Check we got 2 more headers, one for each component
+            expect(receivedHeaders.length).toBe(2);
+            expect(new Set(receivedHeaders.map((h) => h.get('X-Dara-Test')))).toEqual(new Set(['test', 'test2']));
+
+            // Clear headers again
+            receivedHeaders.length = 0;
+
+            // Update one of the variables directly
+            act(() => {
+                fireEvent.click(getByTestId('dv-1-set-var-from-derived'));
+            });
+
+            // wait for both components to be rendered
+            await waitFor(() => {
+                expect(getByTestId('dv-1-var-from-derived')).toBeVisible();
+                expect(getByTestId('dv-2-var-from-derived')).toBeVisible();
+            });
+
+            // Both should have updated
+            expect(getByTestId('dv-1-var-from-derived').innerHTML).toEqual('"test3"');
+            expect(getByTestId('dv-2-var-from-derived').innerHTML).toEqual('"test3"');
+
+            // Reset one of the variables
+            act(() => {
+                fireEvent.click(getByTestId('dv-1-reset'));
+            });
+
+            // wait for both components to be rendered
+            await waitFor(() => {
+                expect(getByTestId('dv-1-var-from-derived')).toBeVisible();
+                expect(getByTestId('dv-2-var-from-derived')).toBeVisible();
+            });
+
+            // They should go back to the (previous) DV value
+            expect(getByTestId('dv-1-var-from-derived').innerHTML).toEqual(dvAfterUpdate);
+            expect(getByTestId('dv-2-var-from-derived').innerHTML).toEqual(dvAfterUpdate);
+
+            // No new headers should be received - DV was not recalculated
+            expect(receivedHeaders.length).toBe(0);
         });
     });
 

--- a/packages/dara-core/tests/js/utils/wrapped-render.tsx
+++ b/packages/dara-core/tests/js/utils/wrapped-render.tsx
@@ -106,9 +106,7 @@ export const Wrapper = ({
         <ThemeProvider theme={theme}>
             <ImportersCtx.Provider value={importers}>
                 <WebSocketCtx.Provider value={{ client: client ?? wsClient }}>
-                    <AuthCtx.Provider
-                        value={{ authType: AuthType.BASIC, setAuthType: noop, setToken: noop, token: 'TEST_TOKEN' }}
-                    >
+                    <AuthCtx.Provider value={{ setToken: noop, token: 'TEST_TOKEN' }}>
                         <RecoilRoot>
                             <RecoilURLSync {...syncOptions}>
                                 <React.Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

In certain situations it's desirable to uniquely identify where from on the page a Dara component/variable/action was called; this is not currently possible.

This PR implements a solution to that, where it is possible to inject `RequestExtras` into all requests made by Dara by simply wrapping parts of the tree in contexts:

```tsx
                <>
                    <RequestExtrasProvider
                        options={{
                            headers: {
                                'X-Dara-Test': 'test',
                            },
                        }}
                    >
                        <DaraTree />
                    </RequestExtrasProvider>
                    <RequestExtrasProvider
                        options={{
                            headers: {
                                'X-Dara-Test': 'test2',
                            },
                        }}
                    >
                        <DaraTree />
                    </RequestExtrasProvider>
                </>
```

This is not a breaking change, but obviously code relying on our implementation details might break. This should likely land in a minor release as it's a pretty significant internal refactor.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->


### `request` util changes

All requests in Dara are already made through the central `request` utility function, which is a light wrapper around `fetch`. This PR updates its last argument, which used to be a string (token) to also accept a `RequestOptions` object (in addition to string, for backwards compatibility). The object can contain both the token and extra options to be merged into the original options.

Changes have been made throughout Dara internals to update most places to use the new `RequestExtras = string | RequestOptions` type rather than a `token: string`. A new hook was added, `useRequestExtras` which pulls in session token and extras from nearest context - most usages of `useSessionToken` have been replaced with the above. 
Note this was not done in ALL places as sometimes we only cared about the token.

### variable hook changes

As the above was updated, an issue was discovered with the way the current `useVariable` hook and its internals are architected. Whenever a variable (or py_component, it works similarly) is first discovered, a new atom/selector is created for it and cached in a Map. The selectors though are essentially closures, so they capture the arguments passed into them when they were created. This means that the selectors capture `sessionToken` and requestExtras used **in the first place in the tree that they were passed into useVariable**. 
This was not an issue before as the token rarely changed. With the aforementioned changes though this meant that if the same variable was re-used in another part of the tree, only one set of request extras would always be used.

In order to be able to capture extras depending on the 'call site' of the variable, the hooks had to be modified.

#### DerivedVariable and `py_component internals`

These two were previously simple selectors. Because of the stale closure issue, they now utilize the [`selectorFamily` API](https://recoiljs.org/docs/api-reference/utils/selectorFamily). This means that rather than a static selector, they are now a function of `(requestExtras) => selector()`. The `useVariable` hook (and its internal methods like `getOrRegisterDerivedVariable`) now only register a *family* once per variable, and then call the variable with the fresh set of extras. Recoil then internally caches selector instances based on requestExtras passed.

Recoil compares arguments by value, so a `RequestExtrasSerializable` wrapper was created to adhere to Recoil's serializability needs (implements a `toJSON` method). 

Store internals were changed to keep track of `key => selectorFamily` and also `selectorFamily => Map(extras => selector)`. 


#### Variable

Variable used to be a simple `atom`, however it can relate to DerivedVariables through the `default` (i.e. `Variable.create_from_derived` API on the Python side). This means that if a DerivedVariable is used as a Variable's default, we need to again deal with the issue of using the correct selector from the DV's selectorFamily to use the correct requestExtras for the request.

The change was to again use an `atomFamily` instead in those cases, and instantiate it with the up-to-date extras. This way the default changed from

```tsx
default: getOrRegisterDerivedVariable(variable.default, ...)
```

to

```tsx
default: (requestExtras) => getOrRegisterDerivedVariable(variable.default, ..., requestExtras)
```

Note that because of the usage of `atomFamily`, each created instance of it will maintain its own pieces of state. This is obviously undesirable as we want variable state to be consistent on a page, regardless of the request params.
This is solved by using a simple effect attach to the atomFamily members. We're utilizing a simple `StateSynchronizer` singleton where we subscribe to notifications from other family members in order to propagate changes to one atom in a family to other family members. This behaviour has been covered by tests.

### other

I noticed the `useLocation` hook was used throughout the variable internals but was never actually used. Linters did not pick it up because of the circular dependencies. These are now removed which should help with performance especially when tweaking query params.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a few test cases covering the new behaviour of RequestExtras, as well as missing tests for the existing behaviour of `create_from_derived`.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->