### PR TITLE
Fix: DO-2171 cleanup of local storage

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -6,6 +6,7 @@ title: Changelog
 
 -   Internal (JS): added `RequestExtras` context to allow injecting additional e.g. headers into requests made by Dara in different parts of the component tree
 -   Move import discovery warnings to the `--debug` logger
+-   Fixed an issue where Local storage was not being cleared between sessions. 
 
 ## 1.4.6
 

--- a/packages/dara-core/js/shared/utils/clean-session-cache.tsx
+++ b/packages/dara-core/js/shared/utils/clean-session-cache.tsx
@@ -6,11 +6,19 @@
  */
 function cleanSessionCache(sessionToken: string): void {
     const sessionKeys = Object.keys(sessionStorage);
+    const localKeys = Object.keys(localStorage);
 
     sessionKeys.forEach((key) => {
         // Remove keys related to a different Dara session
         if (key.startsWith('dara-session') && !key.startsWith(`dara-session-${sessionToken}`)) {
             sessionStorage.removeItem(key);
+        }
+    });
+
+    localKeys.forEach((key) => {
+        // Remove keys related to a different Dara session such as persisted Variables
+        if (key.startsWith('dara-session') && !key.startsWith(`dara-session-${sessionToken}`)) {
+            localStorage.removeItem(key);
         }
     });
 }

--- a/packages/dara-core/js/shared/utils/clean-session-cache.tsx
+++ b/packages/dara-core/js/shared/utils/clean-session-cache.tsx
@@ -5,22 +5,16 @@
  * @param sessionToken current session token
  */
 function cleanSessionCache(sessionToken: string): void {
-    const sessionKeys = Object.keys(sessionStorage);
-    const localKeys = Object.keys(localStorage);
+    for (const storage of [sessionStorage, localStorage]) {
+        const keys = Object.keys(storage);
 
-    sessionKeys.forEach((key) => {
-        // Remove keys related to a different Dara session
-        if (key.startsWith('dara-session') && !key.startsWith(`dara-session-${sessionToken}`)) {
-            sessionStorage.removeItem(key);
-        }
-    });
-
-    localKeys.forEach((key) => {
-        // Remove keys related to a different Dara session such as persisted Variables
-        if (key.startsWith('dara-session') && !key.startsWith(`dara-session-${sessionToken}`)) {
-            localStorage.removeItem(key);
-        }
-    });
+        keys.forEach((key) => {
+            // Remove keys related to a different Dara session
+            if (key.startsWith('dara-session') && !key.startsWith(`dara-session-${sessionToken}`)) {
+                storage.removeItem(key);
+            }
+        });
+    }
 }
 
 export default cleanSessionCache;

--- a/packages/dara-core/tests/js/template-root.spec.tsx
+++ b/packages/dara-core/tests/js/template-root.spec.tsx
@@ -37,9 +37,13 @@ describe('TemplateRoot', () => {
 
         localStorage.setItem(invalidKey, 'val1');
         localStorage.setItem(validKey, 'val2');
+        sessionStorage.setItem(invalidKey, 'val3');
+        sessionStorage.setItem(validKey, 'val4');
 
         expect(localStorage.getItem(invalidKey)).toEqual('val1');
         expect(localStorage.getItem(validKey)).toEqual('val2');
+        expect(sessionStorage.getItem(invalidKey)).toEqual('val3');
+        expect(sessionStorage.getItem(validKey)).toEqual('val4');
 
         wrappedRender(<TemplateRoot />);
 
@@ -47,6 +51,8 @@ describe('TemplateRoot', () => {
         await waitFor(() => {
             expect(localStorage.getItem(invalidKey)).toEqual(undefined);
             expect(localStorage.getItem(validKey)).toEqual('val2');
+            expect(sessionStorage.getItem(invalidKey)).toEqual(undefined);
+            expect(sessionStorage.getItem(validKey)).toEqual('val4');
         });
     });
 });

--- a/packages/dara-core/tests/js/template-root.spec.tsx
+++ b/packages/dara-core/tests/js/template-root.spec.tsx
@@ -31,12 +31,12 @@ describe('TemplateRoot', () => {
         expect(getByText('Frame, Menu')).toBeInstanceOf(HTMLSpanElement);
     });
 
-    it('should clean up cache on startup', () => {
+    it('should clean up cache on startup', async () => {
         const invalidKey = getSessionKey('SOME_OTHER_SESSION_KEY', 'test-uid-1');
         const validKey = getSessionKey('TEST_TOKEN', 'test-uid-2');
 
-        localStorage.setItem(getSessionKey('SOME_OTHER_SESSION_KEY', 'test-uid-1'), 'val1');
-        localStorage.setItem(getSessionKey('TEST_TOKEN', 'test-uid-2'), 'val2');
+        localStorage.setItem(invalidKey, 'val1');
+        localStorage.setItem(validKey, 'val2');
 
         expect(localStorage.getItem(invalidKey)).toEqual('val1');
         expect(localStorage.getItem(validKey)).toEqual('val2');
@@ -44,8 +44,8 @@ describe('TemplateRoot', () => {
         wrappedRender(<TemplateRoot />);
 
         // Other session value should be cleaned up
-        waitFor(() => {
-            expect(localStorage.getItem(invalidKey)).toEqual(null);
+        await waitFor(() => {
+            expect(localStorage.getItem(invalidKey)).toEqual(undefined);
             expect(localStorage.getItem(validKey)).toEqual('val2');
         });
     });

--- a/packages/dara-core/tests/js/utils/mock-storage.tsx
+++ b/packages/dara-core/tests/js/utils/mock-storage.tsx
@@ -12,10 +12,42 @@ export class MockStorage {
     clear(): void {
         this.storage.clear();
     }
+
+    removeItem(key: string): void {
+        this.storage.delete(key);
+    }
+
+    key(index: number): string | null {
+        const keys = Array.from(this.storage.keys());
+        return keys[index] || null;
+    }
+
+    // Custom method to get all keys
+    getKeys(): string[] {
+        return Array.from(this.storage.keys());
+    }
 }
 
 export function mockLocalStorage(): void {
+    const mockStorage = new MockStorage();
+    // Proxy to intercept Object.keys() calls and return the keys of the storage
+    const localStorageProxy = new Proxy(mockStorage, {
+        // necessary so Object.keys() recognize as enumerable
+        getOwnPropertyDescriptor(target, prop: any) {
+            if (target.getKeys().includes(prop)) {
+                return {
+                    configurable: true,
+                    enumerable: true,
+                };
+            }
+            return Object.getOwnPropertyDescriptor(target, prop);
+        },
+        // necessary so Object.keys() can be intercepted to work with our definition of get keys
+        ownKeys(target) {
+            return target.getKeys();
+        },
+    });
     Object.defineProperty(global, 'localStorage', {
-        value: new MockStorage(),
+        value: localStorageProxy,
     });
 }


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
It was found that at some point local storage was running out of space. Seems like we were not cleaning up session related values.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Added so that we clean session related objects from Local storage.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by using `Variable`s with persist flag and checking that storage was cleaned after log out/log in

Also updated a test for cleaning cache. Before it falsely succeeded due to waitFor not being properly awaited.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
### Before
![not clean](https://github.com/causalens/dara/assets/104359539/f1a0a381-7cd1-4372-8b5f-47ef2b1b3c18)

### After
![clear storage](https://github.com/causalens/dara/assets/104359539/c5a2fed2-011d-4c6f-afb5-8fb042306f1b)

