### PR TITLE
Fix: DOS-479 Added support for multi websocket channels

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -6,6 +6,7 @@ title: Changelog
 
 -   Fixed an issue where Local storage was not being cleared between sessions
 -   Fixed an issue where the `@action` decorator would not work properly for instance methods, or class methods
+-   Changed the session tie up to websocket channels to allow a single session to be tied to multiple channels
 
 ## 1.5.0
 

--- a/packages/dara-core/dara/core/interactivity/any_variable.py
+++ b/packages/dara-core/dara/core/interactivity/any_variable.py
@@ -134,7 +134,7 @@ async def get_current_value(variable: dict, timeout: float = 3, raw: bool = Fals
             )
             return None
 
-        session_channels: Dict[str, str] = {}
+        session_channels: Dict[str, set[str]] = {}
 
         # Collect sessions which are active
         for sid in session_ids:

--- a/packages/dara-core/dara/core/interactivity/any_variable.py
+++ b/packages/dara-core/dara/core/interactivity/any_variable.py
@@ -140,13 +140,13 @@ async def get_current_value(variable: dict, timeout: float = 3, raw: bool = Fals
         # Collect sessions which are active
         for sid in session_ids:
             if websocket_registry.has(sid):
-                ws_channel = websocket_registry.get(sid)
+                ws_channels = websocket_registry.get(sid)
                 # If saved websocket channel is not none, then only save the session of that channel
                 if saved_ws_channel is not None:
-                    if saved_ws_channel in ws_channel:
+                    if saved_ws_channel in ws_channels:
                         session_channels[sid] = {saved_ws_channel}
                 else:
-                    session_channels[sid] = ws_channel
+                    session_channels[sid] = ws_channels
 
         if len(session_channels) == 0:
             dev_logger.warning(

--- a/packages/dara-core/dara/core/interactivity/any_variable.py
+++ b/packages/dara-core/dara/core/interactivity/any_variable.py
@@ -222,13 +222,14 @@ async def get_current_value(variable: dict, timeout: float = 3, raw: bool = Fals
                 results[ws] = result
 
         # If we have a channel selected -- get just from that channel
-        if WS_CHANNEL.get() is not None:
-            return results.get(WS_CHANNEL.get(), None)
+        saved_ws_channel = WS_CHANNEL.get()
+        if saved_ws_channel is not None:
+            return results.get(saved_ws_channel, None)
 
         # In most cases, there should be one value only
         if len(results) == 1:
             return list(results.values())[0]
-        
+
         # No results - just return None instead of empty dict
         if len(results) == 0:
             return None

--- a/packages/dara-core/dara/core/internal/devtools.py
+++ b/packages/dara-core/dara/core/internal/devtools.py
@@ -70,9 +70,10 @@ async def send_error_for_session(ws_mgr: WebsocketManager, session_id: str):
         from dara.core.internal.registries import websocket_registry
 
         try:
-            ws_channel = websocket_registry.get(session_id)
+            ws_channels = websocket_registry.get(session_id)
 
-            if ws_channel:
-                await ws_mgr.send_message(ws_channel, message=get_error_for_channel())
+            if ws_channels:
+                for ws_channel in ws_channels:
+                    await ws_mgr.send_message(ws_channel, message=get_error_for_channel())
         except KeyError:
             eng_logger.warning('No ws_channel found for session', {'session_id': session_id})

--- a/packages/dara-core/dara/core/internal/registries.py
+++ b/packages/dara-core/dara/core/internal/registries.py
@@ -51,7 +51,7 @@ auth_registry = Registry[BaseAuthConfig](RegistryType.AUTH_CONFIG)
 utils_registry = Registry[Any](RegistryType.UTILS, INITIAL_CORE_INTERNALS)
 static_kwargs_registry = Registry[Mapping[str, Any]](RegistryType.STATIC_KWARGS)
 
-websocket_registry = Registry[str](RegistryType.WEBSOCKET_CHANNELS)
+websocket_registry = Registry[Set[str]](RegistryType.WEBSOCKET_CHANNELS)
 """maps session_id -> WS channel"""
 
 sessions_registry = Registry[Set[str]](RegistryType.USER_SESSION)

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -422,7 +422,7 @@ def create_router(config: Configuration):
         result = await variable_def.get_value(variable_def, store, task_mgr, values, body.force)
 
         response: Any = result
-        
+
         WS_CHANNEL.set(body.ws_channel)
 
         if isinstance(result['value'], BaseTask):

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -114,6 +114,7 @@ def _start_application(config: Configuration):
     # so cleaning them up here would result in an error
     latest_value_registry.replace({}, deepcopy=False)
     websocket_registry.replace({}, deepcopy=False)
+    sessions_registry.replace({}, deepcopy=False)
     config_registry.replace({}, deepcopy=False)
 
     @asynccontextmanager

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -114,7 +114,6 @@ def _start_application(config: Configuration):
     # so cleaning them up here would result in an error
     latest_value_registry.replace({}, deepcopy=False)
     websocket_registry.replace({}, deepcopy=False)
-    sessions_registry.replace({}, deepcopy=False)
     config_registry.replace({}, deepcopy=False)
 
     @asynccontextmanager

--- a/packages/dara-core/tests/python/test_websocket.py
+++ b/packages/dara-core/tests/python/test_websocket.py
@@ -258,8 +258,6 @@ async def test_two_websockets_both_with_values_with_set_ws_channel():
 
                 async with anyio.create_task_group() as tg_second:
                     ## run the first client again to return two values
-                    tg_second.start_soon(client)
-
                     tg_second.start_soon(second_client)
                     tg_second.start_soon(second_server)
                 
@@ -468,7 +466,6 @@ async def test_two_websockets_only_one_with_value_return_exact():
                     })
 
                 async with anyio.create_task_group() as tg_second:
-                    tg_second.start_soon(client)
                     tg_second.start_soon(second_client)
                     tg_second.start_soon(second_server)
                 

--- a/packages/dara-core/tests/python/test_websocket.py
+++ b/packages/dara-core/tests/python/test_websocket.py
@@ -1,6 +1,12 @@
 import asyncio
 import os
 from uuid import uuid4
+import anyio
+
+
+from dara.core.interactivity.any_variable import NOT_REGISTERED, get_current_value
+from dara.core.auth import BasicAuthConfig
+from dara.core.auth.definitions import SessionRequestBody
 from exceptiongroup import BaseExceptionGroup
 
 import pytest
@@ -10,6 +16,7 @@ from dara.core import DerivedVariable, UpdateVariable, Variable
 from dara.core.configuration import ConfigurationBuilder
 from dara.core.definitions import ComponentInstance
 from dara.core.main import _start_application
+from dara.core.internal.websocket import WS_CHANNEL
 
 from tests.python.tasks import exception_task
 from tests.python.utils import (
@@ -188,3 +195,232 @@ async def test_action_task_error():
             # Task should have error stored as its result
             result = (await client.get(f'/api/core/tasks/{str(task_id)}', headers=AUTH_HEADERS)).json()
             assert 'error' in result
+
+async def test_two_websockets_both_with_values():
+    app, token = setup_two_websocket_tests()
+
+    async with AsyncTestClient(app) as testclient:
+        async with _async_ws_connect(testclient, token) as websocket:
+            # get the init message
+            await websocket.receive_json()
+            variable = Variable(default='current')
+            expected_return_value = 'return_value'
+            var_value = None
+
+            async def server():
+                nonlocal var_value
+                var_value = await variable.get_current_value()
+
+            async def client():
+                # get msg from server
+                websocket_msg = await websocket.receive_json()
+
+                # Assert that the request is correct
+                assert websocket_msg.get('message').get('variable').get('__typename') == 'Variable'
+                assert websocket_msg.get('message').get('variable').get('default') == 'current'
+
+                # send a response back for the first websocket
+                await websocket.send_json({
+                    'type': 'message',
+                    'channel': websocket_msg.get('message').get('__rchan'),
+                    'message': expected_return_value
+                })
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(client)
+                tg.start_soon(server)
+
+            async with _async_ws_connect(testclient, token) as second_ws:
+                second_init = await second_ws.receive_json()
+
+                ## Make sure the websocket channel is set correctly
+                WS_CHANNEL.set(second_init.get('message').get('channel'))
+
+                second_var_expected_value = 'second_var_expected_value'
+                second_var_value = None
+                async def second_server():
+                    nonlocal second_var_value
+                    second_var_value = await variable.get_current_value()
+
+                async def second_client():
+                    # get msg from server
+                    second_ws_message = await second_ws.receive_json()
+
+                    # Assert that the request is correct
+                    assert second_ws_message.get('message').get('variable').get('__typename') == 'Variable'
+                    assert second_ws_message.get('message').get('variable').get('default') == 'current'
+
+                    # send a response back for the second websocket
+                    await second_ws.send_json({
+                        'type': 'message',
+                        'channel': second_ws_message.get('message').get('__rchan'),
+                        'message': second_var_expected_value
+                    })
+
+                async with anyio.create_task_group() as tg_second:
+                    ## run the first client again to return two values
+                    tg_second.start_soon(client)
+
+                    tg_second.start_soon(second_client)
+                    tg_second.start_soon(second_server)
+                
+                # Assert that the second variable is correctly set based on the second response because of the WS_CHANNEL
+                assert second_var_value == second_var_expected_value
+
+            # Assert that the first value remains unaffected by the second value
+            assert var_value == expected_return_value
+
+async def test_two_websockets_only_one_with_value(): 
+    app, token = setup_two_websocket_tests()
+
+    async with AsyncTestClient(app) as testclient:
+        async with _async_ws_connect(testclient, token) as websocket:
+            init = await websocket.receive_json()
+            variable = Variable(default='current')
+            expected_return_value = 'return_value'
+            var_value = None
+
+            async def server():
+                nonlocal var_value
+                var_value = await variable.get_current_value()
+
+            async def client():
+                # get msg from server
+                websocket_msg = await websocket.receive_json()
+
+                # Assert that the request is correct
+                assert websocket_msg.get('message').get('variable').get('__typename') == 'Variable'
+                assert websocket_msg.get('message').get('variable').get('default') == 'current'
+
+                # send a response back
+                await websocket.send_json({
+                    'type': 'message',
+                    'channel': websocket_msg.get('message').get('__rchan'),
+                    'message': expected_return_value
+                })
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(client)
+                tg.start_soon(server)
+
+            async with _async_ws_connect(testclient, token) as second_websocket:
+                init = await second_websocket.receive_json()
+                second_var_value = None
+                async def second_server():
+                    nonlocal second_var_value
+                    second_var_value = await variable.get_current_value()
+
+                async def second_client():
+                    # get msg from server
+                    second_ws_message = await second_websocket.receive_json()
+
+                    # Assert that the request is correct
+                    assert second_ws_message.get('message').get('variable').get('__typename') == 'Variable'
+                    assert second_ws_message.get('message').get('variable').get('default') == 'current'
+
+                    # send a response back
+                    await second_websocket.send_json({
+                        'type': 'message',
+                        'channel': second_ws_message.get('message').get('__rchan'),
+                        'message': NOT_REGISTERED
+                    })
+
+                async with anyio.create_task_group() as tg_second:
+                    tg_second.start_soon(client)
+                    tg_second.start_soon(second_client)
+                    tg_second.start_soon(second_server)
+                
+                # Assert that the second variable is correctly set based on the original value as the second value is not registered
+                assert second_var_value == expected_return_value
+
+            # Assert that the first value remains unaffected by the second value
+            assert var_value == expected_return_value
+
+
+async def test_two_websockets_only_one_with_value_return_exact():
+    app, token = setup_two_websocket_tests()
+
+    async with AsyncTestClient(app) as testclient:
+        async with _async_ws_connect(testclient, token) as websocket:
+            init = await websocket.receive_json()
+            variable = Variable(default='current')
+            expected_return_value = 'return_value'
+            var_value = None
+
+            async def server():
+                nonlocal var_value
+                var_value = await variable.get_current_value()
+
+            async def client():
+                # get msg from server
+                websocket_msg = await websocket.receive_json()
+
+                # Assert that the request is correct
+                assert websocket_msg.get('message').get('variable').get('__typename') == 'Variable'
+                assert websocket_msg.get('message').get('variable').get('default') == 'current'
+
+                # send a response back
+                await websocket.send_json({
+                    'type': 'message',
+                    'channel': websocket_msg.get('message').get('__rchan'),
+                    'message': expected_return_value
+                })
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(client)
+                tg.start_soon(server)
+
+            async with _async_ws_connect(testclient, token) as second_websocket:
+                second_init = await second_websocket.receive_json()
+                second_var_value = None
+                async def second_server():
+                    nonlocal second_var_value
+                    second_var_value = await variable.get_current_value()
+
+                ## Make sure the websocket channel is set correctly
+                WS_CHANNEL.set(second_init.get('message').get('channel'))
+
+                async def second_client():
+                    # get msg from server
+                    second_ws_message = await second_websocket.receive_json()
+
+                    # Assert that the request is correct
+                    assert second_ws_message.get('message').get('variable').get('__typename') == 'Variable'
+                    assert second_ws_message.get('message').get('variable').get('default') == 'current'
+
+                    # send a response back
+                    await second_websocket.send_json({
+                        'type': 'message',
+                        'channel': second_ws_message.get('message').get('__rchan'),
+                        'message': NOT_REGISTERED
+                    })
+
+                async with anyio.create_task_group() as tg_second:
+                    tg_second.start_soon(client)
+                    tg_second.start_soon(second_client)
+                    tg_second.start_soon(second_server)
+                
+                # Assert that the second variable is none -- this is due to the fact that we specified the channel and it should pull value in that channel
+                assert second_var_value is None
+
+            # Assert that the first value remains unaffected by the second value
+            assert var_value == expected_return_value
+
+            
+
+def setup_two_websocket_tests():
+    builder = ConfigurationBuilder()
+
+    basic_auth = BasicAuthConfig(username='test', password='test')
+    
+    config = create_app(builder)
+    config.auth_config = basic_auth
+    app = _start_application(config)
+
+    # Login the user and set the session registry
+    token = basic_auth.get_token(SessionRequestBody(username="test", password='test')).get('token');
+    basic_auth.verify_token(token);
+
+    return app, token
+
+

--- a/packages/dara-core/tests/python/test_websocket.py
+++ b/packages/dara-core/tests/python/test_websocket.py
@@ -4,10 +4,9 @@ from uuid import uuid4
 import anyio
 
 
-from dara.core.interactivity.any_variable import NOT_REGISTERED, get_current_value
+from dara.core.interactivity.any_variable import NOT_REGISTERED
 from dara.core.auth import BasicAuthConfig
 from dara.core.auth.definitions import SessionRequestBody
-from exceptiongroup import BaseExceptionGroup
 
 import pytest
 from async_asgi_testclient import TestClient as AsyncTestClient
@@ -336,7 +335,6 @@ async def test_two_websockets_only_one_with_value():
             # Assert that the first value remains unaffected by the second value
             assert var_value == expected_return_value
 
-
 async def test_two_websockets_only_one_with_value_return_exact():
     app, token = setup_two_websocket_tests()
 
@@ -405,8 +403,6 @@ async def test_two_websockets_only_one_with_value_return_exact():
 
             # Assert that the first value remains unaffected by the second value
             assert var_value == expected_return_value
-
-            
 
 def setup_two_websocket_tests():
     builder = ConfigurationBuilder()


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Currently, we treat web socket channels as a one-to-one relationship with the session. This works okay for most cases, but if we have two web socket channels for the same session(i.e. a different tab) values of the variables are lost as they are tied to the web socket channel.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
- Added a `WS_CHANNEL` context var to websocket -- this is setup to get the actual variable on the actual channel
- Added functionality on `get_current_value` to get the current value on the channel if the channel is provided, otherwise, we get the value from all the channels.
- Changed the session_channel list to be a `Set` since one session can have multiple channels
- Trickled down session error to all channels

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
N/A
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally and also by unit tests.
## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->