### PR TITLE
Feat: DO-2312 Add skip rebuild flag

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -7,6 +7,7 @@ title: Changelog
 -   Fixed an issue where Local storage was not being cleared between sessions
 -   Fixed an issue where the `@action` decorator would not work properly for instance methods, or class methods
 -   Changed the session tie up to websocket channels to allow a single session to be tied to multiple channels
+-   Add `--skip-jsbuild` cli flag, which skip the building JS assets process.
 
 ## 1.5.0
 

--- a/packages/dara-core/dara/core/cli.py
+++ b/packages/dara-core/dara/core/cli.py
@@ -59,7 +59,7 @@ def cli():
 @click.option('--debug', default=lambda: os.environ.get('DARA_DEBUG_LOG_LEVEL', None), help='Debug logger level to use')
 @click.option('--log', default=lambda: os.environ.get('DARA_DEV_LOG_LEVEL', None), help='Dev logger level to use')
 @click.option('--reload-dir', multiple=True, help='Directories to watch for reload')
-@click.option('--skip-jsbuild', is_flag=True, help='Directories to watch for reload')
+@click.option('--skip-jsbuild', is_flag=True, help='Whether to skip building the JS assets')
 def start(
     reload: bool,
     enable_hmr: bool,

--- a/packages/dara-core/dara/core/cli.py
+++ b/packages/dara-core/dara/core/cli.py
@@ -75,7 +75,7 @@ def start(
     debug: Optional[str],
     log: Optional[str],
     reload_dir: Optional[List[str]],
-    skip_jsbuild:bool,
+    skip_jsbuild: bool,
 ):
     if config is None:
         folder_name = os.path.basename(os.getcwd()).replace('-', '_')

--- a/packages/dara-core/dara/core/cli.py
+++ b/packages/dara-core/dara/core/cli.py
@@ -59,6 +59,7 @@ def cli():
 @click.option('--debug', default=lambda: os.environ.get('DARA_DEBUG_LOG_LEVEL', None), help='Debug logger level to use')
 @click.option('--log', default=lambda: os.environ.get('DARA_DEV_LOG_LEVEL', None), help='Dev logger level to use')
 @click.option('--reload-dir', multiple=True, help='Directories to watch for reload')
+@click.option('--skip-jsbuild', is_flag=True, help='Directories to watch for reload')
 def start(
     reload: bool,
     enable_hmr: bool,
@@ -74,6 +75,7 @@ def start(
     debug: Optional[str],
     log: Optional[str],
     reload_dir: Optional[List[str]],
+    skip_jsbuild:bool,
 ):
     if config is None:
         folder_name = os.path.basename(os.getcwd()).replace('-', '_')
@@ -120,6 +122,10 @@ def start(
     # Tell frontend to restart on WS reconnection
     if reload:
         os.environ['DARA_LIVE_RELOAD'] = 'TRUE'
+
+    # Skip rebuild js assets
+    if skip_jsbuild:
+        os.environ['SKIP_JSBUILD'] = 'TRUE'
 
     # Check that if production/dev mode is set, node is installed - unless we're in docker mode
     if not docker and (production or enable_hmr):

--- a/packages/dara-core/dara/core/js_tooling/js_utils.py
+++ b/packages/dara-core/dara/core/js_tooling/js_utils.py
@@ -423,6 +423,11 @@ def rebuild_js(build_cache: BuildCache, build_diff: BuildCacheDiff = BuildCacheD
         dev_logger.debug('Docker mode, skipping JS build')
         return
 
+    # Skip the JS build if the flag is set
+    if os.environ.get('SKIP_JSBUILD', 'FALSE') == 'TRUE':
+        dev_logger.debug('SKIP_JSBUILD mode, skipping JS build')
+        return
+
     # Explitily forced a full rebuild
     if os.environ.get('DARA_JS_REBUILD', 'FALSE') == 'TRUE':
         dev_logger.debug('JS rebuild forced explicitly')


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
In prod mode, sometimes we want to skip the JS building process as the js assets already exist.

## Implementation Description
Add skip-jsbuild flag, if user run `poetry run dara start xxx --skip-jsbuild`, will skip building js assets

## Any new dependencies Introduced
 No

## How Has This Been Tested?
locally tested

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->