### PR TITLE
Fix: DOS-577 Address failure of get_current_value

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where the websocket channel would fail to be set correctly when using get_current_value after the user has reconnected their browser on a different websocket channel.
+
 ## 1.5.1
 
 -   Fixed an issue where Local storage was not being cleared between sessions

--- a/packages/dara-core/dara/core/interactivity/any_variable.py
+++ b/packages/dara-core/dara/core/interactivity/any_variable.py
@@ -142,9 +142,8 @@ async def get_current_value(variable: dict, timeout: float = 3, raw: bool = Fals
             if websocket_registry.has(sid):
                 ws_channels = websocket_registry.get(sid)
                 # If saved websocket channel is not none, then only save the session of that channel
-                if saved_ws_channel is not None:
-                    if saved_ws_channel in ws_channels:
-                        session_channels[sid] = {saved_ws_channel}
+                if saved_ws_channel is not None and saved_ws_channel in ws_channels:
+                    session_channels[sid] = {saved_ws_channel}
                 else:
                     session_channels[sid] = ws_channels
 

--- a/packages/dara-core/tests/python/test_websocket.py
+++ b/packages/dara-core/tests/python/test_websocket.py
@@ -263,7 +263,6 @@ async def test_two_websockets_both_with_values_with_set_ws_channel():
 
             # Assert that the first value remains unaffected by the second value
             assert var_value == expected_return_value
-            assert False == True
 
 
 async def test_two_websockets_both_with_values_with_stale_ws_channel():


### PR DESCRIPTION
## Motivation and Context
Resolves an issue that caused variables to break when fetching their current value after the user navigates away and back to the application.

## Implementation Description
* Address the websocket session not being configured correctly in get_current_value after navigating away and back to a running kernel
* The double if block ended up with a situation where the sessions could be empty even though a session existed which lead to the request failing even though there was a connection to use.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Tested Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->