### PR TITLE
Improvement: DO-2402 add min height to bokeh component

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -7,6 +7,7 @@ title: Changelog
 -   Added support for tiered layout in `FcoseLayout`, `PlanarLayout`, `SpringLayout` and `MarketingLayout`. It allows for nodes to be placed on tiers following some hierarchy and to further define requirements of nodes positions within that tier.
 -   If `TimeSeriesCausalGraph` object is passed to `CausalGraphViewer` and no tiers are defines, it will use `time_lag` and `variable_name` to define the `order_nodes_by` and `group` respectively. 
 -   Added `simultaneous_edge_node_selection` to `CausalGraphViewer`, when set to True, the selected node will not be reset when an edge is chosen and vice versa.
+-   Set `Bokeh` default `min-height` and `min-width` to `350px`.
 
 ## 1.5.2
 

--- a/packages/dara-components/dara/components/plotting/bokeh/bokeh.py
+++ b/packages/dara-components/dara/components/plotting/bokeh/bokeh.py
@@ -43,6 +43,9 @@ class Bokeh(StyledComponentInstance):
     already associated the figure with a document (e.g. by calling show(figure)). If you need access to the Document
     then it is accessible as the document property of an instance of the Bokeh component. If you already have a document
     then you can instantiate the class with that, by passing it as the document argument to instantiate the class.
+
+    By default the component has a minimum height and width of 350px, this can be overwritten by passing the min_height and
+    min_width props to the component.
     """
 
     js_module = '@darajs/components'

--- a/packages/dara-components/js/plotting/bokeh/bokeh.tsx
+++ b/packages/dara-components/js/plotting/bokeh/bokeh.tsx
@@ -149,7 +149,12 @@ function Bokeh(props: BokehProps): JSX.Element {
     }, [docJson]);
 
     return (
-        <BokehRoot $rawCss={css} data-root-id={rootId} id={id} style={style}>
+        <BokehRoot
+            $rawCss={css}
+            data-root-id={rootId}
+            id={id}
+            style={{ minHeight: '350px', minWidth: '350px', ...style }}
+        >
             {isLoading && (
                 <DefaultFallback
                     style={{


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
When container surround `Bokeh` had `hug` set to `True` and figure had `sizing_mode` set to `scale_both` or similar then the plot would not be visible.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Updated so that `Bokeh` will have `min-height` and `min-width` set in line with `Plotly` in those scenarios.
By default if the user does not do anything with `Bokeh` it will have a fixed size on the page, as figure does.
If they set any other height within the figure that will still be respected, but if that value is smaller than the `min_height` of 350px the user would have some leftover space unless they updated this value on the `Bokeh` component itself and not the figure.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on a test app

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->