### PR TITLE
Fix: DO-2407 make import discovery re-use the same ignorelist to not consider a given symbol more than once

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+# NEXT
+
+-   Fixed an issue where import discovery would consider the same symbols repeatedly causing it to run much longer than necessary
+
 ## 1.5.3
 
 -  Fixed an issue where the websocket channel would fail to be set correctly when using get_current_value after the user has reconnected their browser on a different websocket channel.

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -63,7 +63,7 @@ from dara.core.internal.registry_lookup import RegistryLookup
 from dara.core.internal.settings import get_settings
 from dara.core.internal.tasks import TaskManager, TaskManagerError
 from dara.core.internal.utils import get_cache_scope
-from dara.core.internal.websocket import ws_handler, WS_CHANNEL
+from dara.core.internal.websocket import WS_CHANNEL, ws_handler
 from dara.core.logging import dev_logger
 from dara.core.visual.dynamic_component import CURRENT_COMPONENT_ID, PyComponentDef
 

--- a/packages/dara-core/dara/core/internal/websocket.py
+++ b/packages/dara-core/dara/core/internal/websocket.py
@@ -15,9 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from contextvars import ContextVar
 import math
 import uuid
+from contextvars import ContextVar
 from typing import Any, Dict, Literal, Optional, Tuple, Union
 from uuid import uuid4
 
@@ -110,6 +110,7 @@ LoosePayload = Union[ServerPayload, dict]
 ServerMessage = Union[DaraServerMessage, CustomServerMessage]
 
 WS_CHANNEL: ContextVar[Optional[str]] = ContextVar('ws_channel', default=None)
+
 
 class WebSocketHandler:
     """

--- a/packages/dara-core/tests/python/test_import_discovery.py
+++ b/packages/dara-core/tests/python/test_import_discovery.py
@@ -1,9 +1,13 @@
+import inspect
 import sys
 from importlib.util import module_from_spec, spec_from_loader
 from types import ModuleType
+from typing import List
+from unittest.mock import patch
 
 import pytest
 
+from dara.core.definitions import ComponentInstance
 from dara.core.internal.import_discovery import run_discovery
 
 dynamic_modules = []
@@ -262,3 +266,74 @@ from outside.module import func_component
     assert len(components) == 1
     component_names = [(c.__name__, c.__module__) for c in components]
     assert ('NotImported', 'outside.module') in component_names
+
+
+def test_shared_ignore_list():
+    """
+    Test that ignore list is shared between recursive calls and we don't unnecessarily consider
+    the same symbols.
+    Note that this test is a bit fragile as it relies on the order of the discovered modules
+    and mocking a helper function to inspect the ignore list at the time.
+    """
+    create_module(
+        'tests.component_discovery.SubModule1',
+        """\
+# Module definition with SymbolA
+from dara.core.definitions import ComponentInstance
+
+class SymbolA(ComponentInstance):
+    pass
+            """,
+    )
+
+    create_module(
+        'tests.component_discovery.SubModule2',
+        """\
+# Module definition with SymbolB and importing SymbolA
+from dara.core.definitions import ComponentInstance
+from tests.component_discovery.SubModule1 import SymbolA
+
+class SymbolB(ComponentInstance):
+    pass
+            """,
+    )
+
+    main_module = create_module(
+        'tests.component_discovery.MainModule',
+        """\
+# Main module importing from both submodules
+from tests.component_discovery.SubModule1 import SymbolA
+from tests.component_discovery.SubModule2 import SymbolB
+            """,
+    )
+
+    with patch('dara.core.internal.import_discovery.is_ignored') as mock_is_ignored:
+        encountered_ignore_lists = []
+
+        def mock_is_ignored_impl(symbol, ignore_symbols: List):
+            # Take copy of ignore list at the time
+            if inspect.isclass(symbol) and symbol.__name__ == 'SymbolA':
+                encountered_ignore_lists.append(ignore_symbols.copy())
+            return symbol in ignore_symbols
+
+        mock_is_ignored.side_effect = mock_is_ignored_impl
+
+        components, actions = run_discovery(main_module)
+
+        # Check component is picked up
+        assert len(components) == 2
+        component_names = [(c.__name__, c.__module__) for c in components]
+        assert ('SymbolA', 'tests.component_discovery.SubModule1') in component_names
+        assert ('SymbolB', 'tests.component_discovery.SubModule2') in component_names
+        assert len(actions) == 0
+
+        # Check it was considered 3 times
+        assert len(encountered_ignore_lists) == 3
+        # The first time in MainModule directly, no ignore list was present
+        assert encountered_ignore_lists[0] == []
+        # The second time in SubModule1, the ignore list was [SymbolA]
+        assert len(encountered_ignore_lists[1]) == 1
+        assert encountered_ignore_lists[1][0].__name__ == 'SymbolA'
+        # The third time in SubModule2, the ignore list was [SymbolB, SymbolA]
+        assert len(encountered_ignore_lists[2]) == 2
+        assert set([s.__name__ for s in encountered_ignore_lists[2]]) == set(['SymbolA', 'SymbolB'])


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

It was reported that import discovery can take a long time (20s+) to resolve the imports.

Initial investigation found that the same modules were repeatedly recursed into which caused unnecessary work to be done.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

The discovery is a recursive process which avoids infinite recursion by keeping a list of already encountered symbols. 

To illustrate the issue consider the following scenario:
Let's consider three modules: `MainModule`, `SubModule1`, and `SubModule2`. Assume that `SubModule1` defines `SymbolA` component, and `SubModule2` defines `SymbolB` component and also imports `SymbolA`. Both components from sub-modules are imported into `MainModule`. 

Previously, separate ignore lists are created for each `run_discovery` call, leading to `SymbolA` being processed multiple times (diagrams focus no SymbolA):

```
MainModule
   |
   +---> run_discovery (ignore list: [])
   |       |
   |       +---> encounter SymbolA, process
   |       |        |
   |       |        +---> run_discovery (SubModule1, ignore list: [SymbolA])
   |       |                 |
   |       |                 +---> SymbolA is already in ignore list, skipped
   |       |
   |       +---> encounter SymbolB, process
   |                |
   |                +---> run_discovery (SubModule2, ignore list: [])
   |                         |
   |                         +---> encounter SymbolA, recurse into SubModule1 again...
   |
   +---> Other operations...

```

The fix was to keep a reference to one ignore list instance. Since a single mutable ignore list is used across all calls, `SymbolA` is processed only once.

```
MainModule
   |
   +---> run_discovery (ignore list: [])
   |       |
   |       +---> encounter SymbolA, process
   |       |        |
   |       |        +---> run_discovery (SubModule1, ignore list: [SymbolA])
   |       |                 |
   |       |                 +---> SymbolA is already in ignore list, skipped
   |       |
   |       +---> encounter SymbolB, process
   |                |
   |                +---> run_discovery (SubModule2, ignore list: [SymbolA])
   |                         |
   |                         +---> SymbolA is already in ignore list, skipped
   |
   +---> Other operations...

```

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually in an internal project, made discovery 100x faster locally (for reference the discovery processed 100+ symbols and uncovered ~25+ components)

Before:
![Screenshot 2024-01-25 at 17 45 46](https://github.com/causalens/dara/assets/87647189/fe071e8d-4a85-4caf-aeeb-1e76664c8323)

After:
![Screenshot 2024-01-25 at 17 43 49](https://github.com/causalens/dara/assets/87647189/6ba3f152-c43c-4aba-9365-af03524fef00)

Verified the same components and actions were discovered in both cases.

Unit tests passing. 

Making a regression test was difficult since behaviour/output is identical. I added a (frankly a bit fragile) test, mocking an `is_ignored` helper to inspect the ignore list at the time it was called. Verified the test failed previously, passes with the fix implemented. If it proves to be flaky/problematic we can revisit/remove the test in the future.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->