### PR TITLE
Improvement: DO-2342 inherit suspend_render setting

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 # NEXT
 
 -   Fixed an issue where import discovery would consider the same symbols repeatedly causing it to run much longer than necessary
+-   `suspend_render` setting on `fallback` provided to components is now inherited by all children of the component which the fallback is provided to, unless overriden by a different value.
 
 ## 1.5.3
 

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -207,6 +207,7 @@ function DynamicComponent(props: DynamicComponentProps): JSX.Element {
     const [component, setComponent] = useState<JSX.Element>();
     const { get: getComponent } = useComponentRegistry();
     const importers = useContext(ImportersCtx);
+    const fallbackCtx = useContext(FallbackCtx);
 
     const firstRender = useRef(true);
 
@@ -269,6 +270,12 @@ function DynamicComponent(props: DynamicComponentProps): JSX.Element {
         return null;
     }
 
+    // Compute the suspend setting for the component in order of precedence:
+    // 1) explicit suspend_render setting on the component
+    // 2) setting inherited from a parent component
+    // 3) default value of 200ms
+    const suspend = props.component?.props?.fallback?.props?.suspend_render ?? fallbackCtx?.suspend ?? 200;
+
     return (
         <ErrorBoundary
             fallbackRender={(fallbackProps) => (
@@ -276,7 +283,7 @@ function DynamicComponent(props: DynamicComponentProps): JSX.Element {
             )}
             onReset={onResetErrorBoundary}
         >
-            <FallbackCtx.Provider value={{ suspend: props.component?.props?.fallback?.props?.suspend_render ?? 200 }}>
+            <FallbackCtx.Provider value={{ suspend }}>
                 <VariableCtx.Provider value={{ variables }}>
                     <Suspense fallback={fallback}>{component}</Suspense>
                 </VariableCtx.Provider>

--- a/packages/dara-core/tests/js/dynamic-component.spec.tsx
+++ b/packages/dara-core/tests/js/dynamic-component.spec.tsx
@@ -467,7 +467,7 @@ describe('DynamicComponent', () => {
             );
         };
 
-        const { getByTestId } = wrappedRender(
+        const { getByTestId, queryByTestId } = wrappedRender(
             <MockComponent action={triggerAction} varA={variableA} varB={variableB} />
         );
 
@@ -483,6 +483,7 @@ describe('DynamicComponent', () => {
             const input = getByTestId('b');
             fireEvent.change(input, { target: { value: 5 } });
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         expect(getByTestId('dynamic-wrapper').innerHTML).toBe(
             'TestComponent2: {"uid":"uid","values":{"data":{"test":{"type":"derived","uid":"empty","values":[{"__ref":"Variable:a"},{"__ref":"Variable:b"}],"force":false}},"lookup":{"Variable:a":1,"Variable:b":2}},"ws_channel":"uid"}'
         );
@@ -492,6 +493,7 @@ describe('DynamicComponent', () => {
             const input = getByTestId('a');
             fireEvent.change(input, { target: { value: 5 } });
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         expect(getByTestId('dynamic-wrapper').innerHTML).toBe(
             'TestComponent2: {"uid":"uid","values":{"data":{"test":{"type":"derived","uid":"empty","values":[{"__ref":"Variable:a"},{"__ref":"Variable:b"}],"force":false}},"lookup":{"Variable:a":1,"Variable:b":2}},"ws_channel":"uid"}'
         );
@@ -500,6 +502,7 @@ describe('DynamicComponent', () => {
         act(() => {
             fireEvent.click(getByTestId('trigger'));
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         await waitFor(() =>
             expect(getByTestId('dynamic-wrapper').innerHTML).toBe(
                 'TestComponent2: {"uid":"uid","values":{"data":{"test":{"type":"derived","uid":"empty","values":[{"__ref":"Variable:a"},{"__ref":"Variable:b"}],"force":false}},"lookup":{"Variable:a":5,"Variable:b":5}},"ws_channel":"uid"}'
@@ -572,7 +575,9 @@ describe('DynamicComponent', () => {
             );
         };
 
-        const { getByTestId } = wrappedRender(<MockComponentTrigger action={triggerAction} variableA={variable} />);
+        const { getByTestId, queryByTestId } = wrappedRender(
+            <MockComponentTrigger action={triggerAction} variableA={variable} />
+        );
 
         await waitFor(() => expect(getByTestId('dynamic-wrapper').innerHTML).not.toBe(''));
         await waitForElementToBeRemoved(() => getByTestId('LOADING'));
@@ -586,6 +591,7 @@ describe('DynamicComponent', () => {
             const input = getByTestId('a');
             fireEvent.change(input, { target: { value: 10 } });
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         expect(getByTestId('dynamic-wrapper').innerHTML).toBe(
             'TestComponent2: {"uid":"uid","values":{"data":{"test":{"type":"derived","uid":"final_variable","values":[{"type":"derived","uid":"intermediate_variable","values":[{"__ref":"Variable:base_variable"}],"force":false}],"force":false}},"lookup":{"Variable:base_variable":5}},"ws_channel":"uid"}'
         );
@@ -594,6 +600,7 @@ describe('DynamicComponent', () => {
         act(() => {
             fireEvent.click(getByTestId('trigger'));
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         await waitFor(() =>
             expect(getByTestId('dynamic-wrapper').innerHTML).toBe(
                 'TestComponent2: {"uid":"uid","values":{"data":{"test":{"type":"derived","uid":"final_variable","values":[{"type":"derived","uid":"intermediate_variable","values":[{"__ref":"Variable:base_variable"}],"force":true}],"force":true}},"lookup":{"Variable:base_variable":10}},"ws_channel":"uid"}'
@@ -1092,7 +1099,7 @@ describe('DynamicComponent', () => {
             );
         };
 
-        const { getByTestId } = wrappedRender(
+        const { getByTestId, queryByTestId } = wrappedRender(
             <MockComponent action={triggerAction} varA={variableA} varB={variableB} />
         );
 
@@ -1128,6 +1135,7 @@ describe('DynamicComponent', () => {
             const input = getByTestId('b');
             fireEvent.change(input, { target: { value: 5 } });
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         expect(getContent()).toEqual({
             uid: 'uid',
             values: {
@@ -1154,6 +1162,7 @@ describe('DynamicComponent', () => {
             const input = getByTestId('a');
             fireEvent.change(input, { target: { value: 5 } });
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         expect(getContent()).toEqual({
             uid: 'uid',
             values: {
@@ -1179,6 +1188,7 @@ describe('DynamicComponent', () => {
         act(() => {
             fireEvent.click(getByTestId('trigger'));
         });
+        await waitFor(() => expect(queryByTestId('LOADING')).not.toBeInTheDocument());
         await waitFor(() =>
             expect(getContent()).toEqual({
                 uid: 'uid',


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Current behaviour of `suspend_render` was to only apply it to a specific component. This resulted in not-so-great DX as it often needed to be repeated on children of a given component when the behaviour was desired for the entire sub-tree.

The behaviour is now changed in that the setting is now inherited and applied "recursively" to an entire sub-tree, i.e. all children, grandchildren and so on of a given component. This is technically a change in behaviour but since it's a rather advanced feature and the new behaviour is more desirable, we can release it in a minor/patch as it shouldn't be breaking.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

This is implemented by hooking into the FallbackContext in DynamicComponent. The value provided to the context is now taken from the parent context value, if present and not overriden by the user.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally
Added unit test

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->