### PR TITLE
Fix: DOS-625 Address action execution blocking new requests

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Address action execution blocking new requests due to an issue around BackgroundTask processing in starlette
+
 ## 1.6.0
 
 -   Fixed an issue where import discovery would consider the same symbols repeatedly causing it to run much longer than necessary

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -22,16 +22,7 @@ from importlib.metadata import version
 from typing import Any, Callable, List, Mapping, Optional
 
 import pandas
-from fastapi import (
-    APIRouter,
-    BackgroundTasks,
-    Depends,
-    File,
-    Form,
-    HTTPException,
-    Response,
-    UploadFile,
-)
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
 from fastapi.responses import StreamingResponse
 from pandas import DataFrame
 from pydantic import BaseModel

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -128,9 +128,7 @@ def create_router(config: Configuration):
         """Execution id, unique to this request"""
 
     @core_api_router.post('/action/{uid}', dependencies=[Depends(verify_session)])
-    async def get_action(
-        uid: str, body: ActionRequestBody, bg_tasks: BackgroundTasks
-    ):  # pylint: disable=unused-variable
+    async def get_action(uid: str, body: ActionRequestBody):  # pylint: disable=unused-variable
         store: CacheStore = utils_registry.get('Store')
         task_mgr: TaskManager = utils_registry.get('TaskManager')
         registry_mgr: RegistryLookup = utils_registry.get('RegistryLookup')
@@ -147,7 +145,7 @@ def create_router(config: Configuration):
 
         # Execute the action - kick off a background task to run the handler
         response = await action_def.execute_action(
-            action_def, body.input, values, static_kwargs, body.execution_id, body.ws_channel, store, task_mgr, bg_tasks
+            action_def, body.input, values, static_kwargs, body.execution_id, body.ws_channel, store, task_mgr
         )
 
         if isinstance(response, BaseTask):


### PR DESCRIPTION
## Motivation and Context
* An internal project was stalling requests when multiple actions were in flight that led to the app appearing broken for a time until the first action completed.

## Implementation Description
* The usage of BackgroundTasks in the new execute_action code was found to be causing blockages of new requests being picked up by the event loop. I think this maybe a reccurance of https://github.com/encode/starlette/issues/919 which they claim is resolved, but still doesn't appear to be working for us. It may be due to one of our middlewares behaving in a particular way that causes this, but the fix applied here appears to be the simplest fix for now.
* In this instance we have replaced the usage of background_tasks.add_task with asyncio.create_task that will run the task in the loop without worrying about its result.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Should be covered by existing unit tests

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

Reproduction Code (in a dara app): 
```python
@action
async def test_action(ctx):
    print(f'running action {ctx}')
    for i in range(20):
        await anyio.sleep(0.2)
    print(f'finished action {ctx}')

config.add_page('action bug', Stack(*[Button(f'action-{x}', onclick=test_action(x)) for x in range(10)]))
```

Behaviour Before: 
https://github.com/causalens/dara/assets/58470795/8ac1fef4-4505-4a39-a911-30fe8f794b7d

Behaviour After: 
https://github.com/causalens/dara/assets/58470795/bd65f4b2-dc28-4669-8bbd-5b0827fe4f62