### PR TITLE
Fix: DO-2510 DerivedDataVariable get_current_value not working

### DIFF
--- a/packages/dara-core/js/shared/interactivity/store.tsx
+++ b/packages/dara-core/js/shared/interactivity/store.tsx
@@ -1,8 +1,7 @@
-import { RecoilState, RecoilValue } from 'recoil';
-
 import { RequestExtrasSerializable } from '@/api/http';
 import { getUniqueIdentifier } from '@/shared/utils/hashing';
 import { AnyVariable, isVariable } from '@/types';
+import { RecoilState, RecoilValue } from 'recoil';
 
 /**
  * Selector family type which constructs a selector from a given set of extras.
@@ -124,7 +123,7 @@ export function isRegistered<T>(variable: AnyVariable<T>): boolean {
 
         case 'DerivedDataVariable': {
             const key = getRegistryKey(variable, 'selector');
-            return selectorRegistry.has(key);
+            return selectorFamilyRegistry.has(key);
         }
 
         default:

--- a/packages/dara-core/js/shared/interactivity/store.tsx
+++ b/packages/dara-core/js/shared/interactivity/store.tsx
@@ -1,7 +1,8 @@
+import { RecoilState, RecoilValue } from 'recoil';
+
 import { RequestExtrasSerializable } from '@/api/http';
 import { getUniqueIdentifier } from '@/shared/utils/hashing';
 import { AnyVariable, isVariable } from '@/types';
-import { RecoilState, RecoilValue } from 'recoil';
 
 /**
  * Selector family type which constructs a selector from a given set of extras.


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
DerivedDataVariable get_current_value function can't not find the uid.

## Implementation Description
Check if key exists in selectorFamilyRegistry.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Locally tested

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->