### PR TITLE
Fix: DOS-625 fix the test that became flaky on CI after recent change to action execution

### DIFF
--- a/packages/dara-core/tests/python/test_data_variable.py
+++ b/packages/dara-core/tests/python/test_data_variable.py
@@ -9,8 +9,8 @@ import pytest
 from async_asgi_testclient import TestClient as AsyncClient
 from pandas import DataFrame
 
-from dara.core.auth.definitions import JWT_ALGO
 from dara.core.auth.basic import BasicAuthConfig
+from dara.core.auth.definitions import JWT_ALGO
 from dara.core.base_definitions import Action, CacheType
 from dara.core.configuration import ConfigurationBuilder
 from dara.core.definitions import ComponentInstance
@@ -32,6 +32,7 @@ from tests.python.utils import (
     _get_py_component,
     _get_template,
     get_action_results,
+    wait_assert,
 )
 
 pytestmark = pytest.mark.anyio
@@ -283,7 +284,7 @@ async def test_update_variable_session_data_variable(_uid1, _uid2):
             },
         )
         assert response.status_code == 200
-        assert call_count == 1
+        await wait_assert(lambda: call_count == 1)
 
         # Check variable is updated for session1
         response = await client.post(
@@ -380,7 +381,7 @@ async def test_update_variable_user_data_variable(_uid1, _uid2):
             },
         )
         assert response.status_code == 200
-        assert call_count == 1
+        await wait_assert(lambda: call_count == 1)
 
         # Check variable is updated for user1
         response = await client.post(


### PR DESCRIPTION
## Motivation and Context
Address the flaky test when running in CI

## Implementation Description
Use wait_assert to wait for the call to be processed rather than expecting it to be called immediately.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Needs to be tested in CI as it passed everytime locally.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.