### PR TITLE
Fix: DO-2522 skip Node check if `--skip-jsbuild` is used

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fix an issue where `Node` is required even if the JS build is skipped explicitly via `--skip-jsbuild` flag
+
 ## 1.6.1
 
 -  Address action execution blocking new requests due to an issue around BackgroundTask processing in starlette

--- a/packages/dara-core/dara/core/cli.py
+++ b/packages/dara-core/dara/core/cli.py
@@ -127,8 +127,8 @@ def start(
     if skip_jsbuild:
         os.environ['SKIP_JSBUILD'] = 'TRUE'
 
-    # Check that if production/dev mode is set, node is installed - unless we're in docker mode
-    if not docker and (production or enable_hmr):
+    # Check that if production/dev mode is set, node is installed - unless we're in docker mode, or explicitly skipping jsbuild
+    if not docker and not skip_jsbuild and (production or enable_hmr):
         exit_code = os.system('node -v')
 
         if exit_code > 0:


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Currently Dara makes a rudimentary check if `Node.js` is installed if it knows it will be required later, e.g. in `production` mode.
Recently we introduced an explicit `--skip-jsbuild` flag which assumes assets are prebuilt. There was an oversight that even with that flag on, Node was still required

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Skipped Node version check if `--skip-jsbuild` was passed.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually verified correct behaviour locally

![Screenshot 2024-02-08 at 11 45 53](https://github.com/causalens/dara/assets/87647189/d357154a-4a43-4611-afc6-ba530de28c6e)
![Screenshot 2024-02-08 at 11 46 05](https://github.com/causalens/dara/assets/87647189/afcdbc30-c7c6-4093-9529-cb36e3808123)

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->