### PR TITLE
Improvement: DO-2465 zerolinecolor on plotly theme should be grey 3 by default appears white

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Added `zeroline` default color to `Plotly` theme
+
 ## 1.6.0
 
 **Graphs**

--- a/packages/dara-components/dara/components/plotting/plotly/themes.py
+++ b/packages/dara-components/dara/components/plotting/plotly/themes.py
@@ -34,6 +34,7 @@ light_theme = {
             'color': light_colors.text,
         },
         'xaxis': {
+            'zerolinecolor': light_colors.grey3,
             'gridcolor': light_colors.grey2,
             'title': {
                 'font': {
@@ -44,6 +45,7 @@ light_theme = {
             },
         },
         'yaxis': {
+            'zerolinecolor': light_colors.grey3,
             'gridcolor': light_colors.grey2,
             'title': {
                 'font': {
@@ -92,6 +94,7 @@ dark_theme = {
             'color': dark_colors.text,
         },
         'xaxis': {
+            'zerolinecolor': dark_colors.grey3,
             'gridcolor': dark_colors.grey2,
             'title': {
                 'font': {
@@ -102,6 +105,7 @@ dark_theme = {
             },
         },
         'yaxis': {
+            'zerolinecolor': dark_colors.grey3,
             'gridcolor': dark_colors.grey2,
             'title': {
                 'font': {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
x=0 and y=0 lines on Plotly had no color by default which could look weird

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Added a default zeroline color to our Plotly theme of grey3 of our palette

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on light and dark themes

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
Light theme
<img width="1411" alt="Screenshot 2024-02-09 at 10 39 59" src="https://github.com/causalens/dara/assets/104359539/2061cf28-e803-4498-a16d-15b4504b612f">
Dark theme
<img width="1411" alt="Screenshot 2024-02-09 at 10 39 43" src="https://github.com/causalens/dara/assets/104359539/4b5bd8ba-2a45-4b74-b9fd-ad8799867dd4">
