### PR TITLE
Fix: DOS-649 Properly recreate the websocket client when it is closed

### DIFF
--- a/packages/dara-core/js/shared/template-root/template-root.tsx
+++ b/packages/dara-core/js/shared/template-root/template-root.tsx
@@ -86,7 +86,7 @@ function TemplateRoot(): JSX.Element {
                 setWsClient(setupWebsocket(token, config.live_reload));
             };
         }
-    }, [token, config.live_reload, wsClient]);
+    }, [token, config?.live_reload, wsClient]);
 
     if (templateLoading || actionsLoading || componentsLoading) {
         return null;

--- a/packages/dara-core/js/shared/template-root/template-root.tsx
+++ b/packages/dara-core/js/shared/template-root/template-root.tsx
@@ -78,16 +78,6 @@ function TemplateRoot(): JSX.Element {
         };
     }, [token, config?.live_reload]);
 
-    // Effect that registers an onclose event handler on the newly created websocket each time its remade. It will then
-    // call setState to trigger an update of the client to all subscribing components so they have the new connection
-    useEffect(() => {
-        if (wsClient) {
-            wsClient.socket.onclose = () => {
-                setWsClient(setupWebsocket(token, config.live_reload));
-            };
-        }
-    }, [token, config?.live_reload, wsClient]);
-
     if (templateLoading || actionsLoading || componentsLoading) {
         return null;
     }

--- a/packages/dara-core/js/shared/template-root/template-root.tsx
+++ b/packages/dara-core/js/shared/template-root/template-root.tsx
@@ -78,6 +78,16 @@ function TemplateRoot(): JSX.Element {
         };
     }, [token, config?.live_reload]);
 
+    // Effect that registers an onclose event handler on the newly created websocket each time its remade. It will then
+    // call setState to trigger an update of the client to all subscribing components so they have the new connection
+    useEffect(() => {
+        if (wsClient) {
+            wsClient.socket.onclose = () => {
+                setWsClient(setupWebsocket(token, config.live_reload));
+            };
+        }
+    }, [token, config.live_reload, wsClient]);
+
     if (templateLoading || actionsLoading || componentsLoading) {
         return null;
     }


### PR DESCRIPTION
## Motivation and Context
Found this issue whilst debugging studio being unresponsive after being left for a while on another tab.

## Implementation Description
* If the websocket client is closed for some external reason, e.g. browser going to sleep or a crash being thrown down it then the newly created websocket client is now properly reconnected to all the relevant streams and channels.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Tested Locally in a running studio instance

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.