### PR TITLE
Fix: DOS-649 Catch errors thrown in the variable state provider

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fix and issue where an error being thrown when processing a get_current_value request would crash the stream and prevent all future requests from being handled.
+
 ## 1.6.2
 
 - Fix an issue where `Node` is required even if the JS build is skipped explicitly via `--skip-jsbuild` flag

--- a/packages/dara-core/js/shared/variable-state-provider/variable-state-provider.tsx
+++ b/packages/dara-core/js/shared/variable-state-provider/variable-state-provider.tsx
@@ -15,8 +15,15 @@ function VariableStateProvider(props: VariableStateProviderProps): JSX.Element {
 
     useEffect(() => {
         const sub = props.wsClient?.variableRequests$().subscribe((req) => {
-            const variableValue = getVariableState(req.message.variable);
-            props.wsClient.sendVariable(variableValue, req.message.__rchan);
+            // Catch any errors when fetching the variable value otherwise this takes down the stream and no further
+            // requests are processed.
+            try {
+                const variableValue = getVariableState(req.message.variable);
+                props.wsClient.sendVariable(variableValue, req.message.__rchan);
+            } catch (err) {
+                // eslint-disable-next-line no-console
+                console.warn(`Error when processing a getVariableValue request: ${err}`);
+            }
         });
 
         return () => {


### PR DESCRIPTION
## Motivation and Context
Tracing a bug that caused all the pick variables to break I discovered this issue with the VariableStateProvider component.

## Implementation Description
* If errors are not caught here then a single crash takes down this stream handling completely and no more requests for variable values are processed.
* As these requests can sometimes involve reaching out to a backend then this code should be resilient to faults and not break the behaviour of the app for subsequent requests.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Tested Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.