### PR TITLE
Fix: DO-2551 edge case when registering Variable under different extras

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fix an edge case where `Variable` state would not be initialized properly if previously registered under a different set of `RequestExtras`
+
 ## 1.7.1
 
 -   Add defaults to `BackendStore` arguments - `uid` now defaults to a random UUID, `backend` defaults to `InMemoryBackend`

--- a/packages/dara-core/js/shared/interactivity/plain-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/plain-variable.tsx
@@ -59,15 +59,15 @@ class StateSynchronizer {
     }
 
     /**
-     * Get the current value for a given key
+     * Get the current state for a given key
      *
      * @param key key to get the current value for
      */
-    getCurrentValue(key: string): any {
+    getCurrentState(key: string): VariableUpdate {
         if (!this.isRegistered(key)) {
             return null;
         }
-        return this.#observers.get(key).getValue().value;
+        return this.#observers.get(key).getValue();
     }
 
     /**
@@ -103,7 +103,6 @@ class StateSynchronizer {
         if (!this.isRegistered(key)) {
             this.register(key, null);
         }
-
         this.#observers.get(key).next(update);
     }
 }
@@ -154,8 +153,14 @@ export function getOrRegisterPlainVariable<T>(
                         if (!StateSynchronizer.getInstance().isRegistered(variable.uid)) {
                             StateSynchronizer.getInstance().register(variable.uid, variable.default);
                         } else {
-                            // Otherwise synchronize the initial value
-                            setSelf(StateSynchronizer.getInstance().getCurrentValue(variable.uid));
+                            const currentState = StateSynchronizer.getInstance().getCurrentState(variable.uid);
+
+                            if (!isDefaultDerived || currentState?.type !== 'initial') {
+                                // Otherwise synchronize the initial value,
+                                // unless the default is a DerivedVariable and the current state is initial
+                                // because in that case the default will be linked to the selector which needs to be resolved
+                                setSelf(currentState?.value);
+                            }
                         }
 
                         // Synchronize changes across atoms of the same family

--- a/packages/dara-core/tests/js/persistence.spec.tsx
+++ b/packages/dara-core/tests/js/persistence.spec.tsx
@@ -456,5 +456,36 @@ describe('Variable Persistence', () => {
         await waitFor(() => {
             expect(result2.current[0]).toEqual('new1');
         });
+
+        // Create a new variable with different extras
+        const { result: result3 } = renderHook(
+            () =>
+                useVariable<any>({
+                    __typename: 'Variable',
+                    default: 'foo',
+                    nested: [],
+                    uid: 'session-test-1',
+                } as SingleVariable<any>),
+            {
+                wrapper: ({ children }) => (
+                    <Wrapper>
+                        <RequestExtrasProvider
+                            options={{
+                                headers: {
+                                    'X-Dara-Extras': 'bar',
+                                },
+                            }}
+                        >
+                            {children}
+                        </RequestExtrasProvider>
+                    </Wrapper>
+                ),
+            }
+        );
+
+        // The new variable should have the same value as the first one
+        await waitFor(() => {
+            expect(result3.current[0]).toEqual('new1');
+        });
     });
 });


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Edge case found when testing latest changes in an internal product.

Since the change in Dara 1.7, when a Variable is registered in a `useVariable` call, a new atom is created per unique set of request extras. This is to enable sending correct request data to BackendStore requests etc.

There was an issue spotted where if a Variable was first registered under a given set of extras, updated, and then registered again under a different set of extras, the second registration would create a new instance which would initialize with the Variable default value rather than the up-to-date value of the first registration.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Fixed by changing the `StateSynchronizer` to also perform an initial `setSelf` on the atom if already registered, using the latest value of a given variable uid.
Internally the Synchronizer now uses `BehaviourSubject`s rather than just lists of listeners so it's possible to keep track of the latest value.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Introduced unit tests covering the syncing behaviour, including the case where a variable is updated and then registered under a new set of extras

Verified manually that the fix makes the failing case in the internal product pass

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->