### PR TITLE
Fix: DOS-727 address the disconnect of the websocket on subsequent disconnects

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Resolve an issue with a previous fix to reconnect the websocket that prevented it from working on the 2nd/3rd/... times that the websocket was disconnected.
+
 ## 1.7.2
 
 -   Fix an edge case where `Variable` state would not be initialized properly if previously registered under a different set of `RequestExtras`
@@ -40,21 +44,22 @@ await store.write('new value')
 # Read the current value from the store
 value = await store.read()
 ```
+
 -   Deps: upgrade FastAPI to `0.109.0`, fixes security vulnerability in `starlette` dependency
 
 ## 1.6.3
 
-- Fix and issue where an error being thrown when processing a get_current_value request would crash the stream and prevent all future requests from being handled.
+-   Fix and issue where an error being thrown when processing a get_current_value request would crash the stream and prevent all future requests from being handled.
 
 ## 1.6.2
 
-- Fix an issue where `Node` is required even if the JS build is skipped explicitly via `--skip-jsbuild` flag
-- Fix an issue where the websocket connection was not properly recreated on reconnection
+-   Fix an issue where `Node` is required even if the JS build is skipped explicitly via `--skip-jsbuild` flag
+-   Fix an issue where the websocket connection was not properly recreated on reconnection
 
 ## 1.6.1
 
--  Address action execution blocking new requests due to an issue around BackgroundTask processing in starlette
--  Fix `get_current_value` not working for `DerivedDataVariable`
+-   Address action execution blocking new requests due to an issue around BackgroundTask processing in starlette
+-   Fix `get_current_value` not working for `DerivedDataVariable`
 
 ## 1.6.0
 
@@ -63,7 +68,7 @@ value = await store.read()
 
 ## 1.5.3
 
--  Fixed an issue where the websocket channel would fail to be set correctly when using get_current_value after the user has reconnected their browser on a different websocket channel.
+-   Fixed an issue where the websocket channel would fail to be set correctly when using get_current_value after the user has reconnected their browser on a different websocket channel.
 
 ## 1.5.1
 

--- a/packages/dara-core/js/api/websocket.tsx
+++ b/packages/dara-core/js/api/websocket.tsx
@@ -282,7 +282,7 @@ export class WebSocketClient implements WebSocketClientInterface {
                 }
             });
         });
-        // Rebind the close handler so this logic is re-applied on a subsequent disconnect
+        // Bind the close handler so the re-initialize logic is added every time
         this.socket.addEventListener('close', this.closeHandler);
     }
 

--- a/packages/dara-core/js/api/websocket.tsx
+++ b/packages/dara-core/js/api/websocket.tsx
@@ -302,6 +302,8 @@ export class WebSocketClient implements WebSocketClientInterface {
                 }
             });
         });
+        // Rebind the close handler so this logic is re-applied on a subsequent disconnect
+        this.socket.addEventListener('close', this.closeHandler);
     }
 
     /**

--- a/packages/dara-core/js/api/websocket.tsx
+++ b/packages/dara-core/js/api/websocket.tsx
@@ -262,32 +262,12 @@ export class WebSocketClient implements WebSocketClientInterface {
         this.token = _token;
         this.liveReload = _liveReload;
         this.messages$ = new Subject();
-        this.socket.addEventListener('message', (ev) => {
-            const msg = JSON.parse(ev.data) as WebSocketMessage;
-            this.messages$.next(msg);
-        });
-
-        // Add a one off listener for the init message to get the channel
-        this.channel = new Promise((resolve) => {
-            this.socket.addEventListener('message', (ev) => {
-                const msg = JSON.parse(ev.data) as WebSocketMessage;
-                if (msg.type === 'init') {
-                    this.messages$.next(msg);
-                    resolve(msg.message?.channel);
-                }
-            });
-        });
-
         this.closeHandler = this.onClose.bind(this);
-        this.socket.addEventListener('close', this.closeHandler);
+        this.initialize();
     }
 
-    /**
-     * Close handler to attempt to reconnect on WS closed
-     */
-    onClose(): void {
-        this.socket = onCloseWs(this.token, this.liveReload);
-        // Re-register the message event listener to restart the stream of messages and get the new channel
+    initialize(): void {
+        // Register the message event listener to start the stream of messages and get the new channel
         this.socket.addEventListener('message', (ev) => {
             const msg = JSON.parse(ev.data) as WebSocketMessage;
             this.messages$.next(msg);
@@ -304,6 +284,14 @@ export class WebSocketClient implements WebSocketClientInterface {
         });
         // Rebind the close handler so this logic is re-applied on a subsequent disconnect
         this.socket.addEventListener('close', this.closeHandler);
+    }
+
+    /**
+     * Close handler to attempt to reconnect on WS closed
+     */
+    onClose(): void {
+        this.socket = onCloseWs(this.token, this.liveReload);
+        this.initialize();
     }
 
     /**


### PR DESCRIPTION
## Motivation and Context
People were still seeing their instances hang up and after some investigation I found that this was occuring on the second disconnect of the websocket whilst the first recovered fine. This was found to be a small mistake in the previous fix I implemented.

## Implementation Description
* The previous fix forgot to readd the close handler to the new socket, so another disconnect would leave the socket in the same state as before.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Tested in a local instance of studio where a button was added to simulate multiple disconnect/reconnects in a row.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.