### PR TITLE
Fix: DO-2535 use non-private fields for backendstore

### DIFF
--- a/packages/dara-core/dara/core/persistence.py
+++ b/packages/dara-core/dara/core/persistence.py
@@ -167,7 +167,7 @@ class BackendStore(PersistenceStore):
         :param scope: the scope for the store; if 'global' a single value is stored for all users,
             if 'user' a value is stored per user
         """
-        kwargs = {}
+        kwargs: Dict[str, Any] = {}
         if backend:
             kwargs['backend'] = backend
 

--- a/packages/dara-core/tests/python/test_persistence.py
+++ b/packages/dara-core/tests/python/test_persistence.py
@@ -237,6 +237,19 @@ async def test_init_with_default(backend_store):
     ), 'The store should be initialized with the default value if it was empty.'
 
 
+async def test_init_with_default_user(user_backend_store):
+    USER.set(USER_1)
+    # Simulate the initialization with a default value
+    class MockVariable:
+        default = 'default_value'
+
+    await user_backend_store.init(MockVariable())
+    # Verify the store now contains the default value
+    assert (
+        await user_backend_store.read() == 'default_value'
+    ), 'The store should be initialized with the default value if it was empty.'
+
+
 async def test_notify_on_write(backend_store, mock_ws_mgr):
     # Write a value and check if _notify was called
     await backend_store.write('test_value')


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

When testing the store more locally I noticed the default value is not applying correctly. It is an unexpected behaviour as the tests are passing in that regard; tracking down the issue with logs revealed that somehow modifying the store `_default_value` in the init phase was not 'saved' in the model state and later default values were set as `None`.

I tried switching the `PrivateAttr` to a normal `Field` and the bug went away, though I also had to remove the underscore prefix from the field names. Not sure why it worked that way but it might be a Pydantic quirk.


## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Added a custom constructor to prevent the fields from being initialized or showing up in the inspection.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->