### PR TITLE
Fix: DOS-764 Allow async startup functions to be registered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ BEARER_CONFIG := ./bearer.yml
 bearer:
 	@if [ ! -f "$(LOCAL_BEARER)" ]; then \
 		echo "Installing Bearer"; \
-		curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- v1.22.0; \
+		curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- v1.39.0; \
 	fi
 
 	@for package in $(shell ls packages) ; do \

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Added the ability to pass an asynchronous function to `ConfigurationBuilder.on_startup(...)`.
+
 ## 1.7.3
 
 -   Implement `FileBackend` for `BackendStore` in `dara.core.persistence` to allow for persistent file-based storage of `Variable` state in a JSON file
@@ -52,7 +56,7 @@ value = await store.read()
 
 ## 1.6.5
 
-- **Backported** Resolve an issue with a previous fix to reconnect the websocket that prevented it from working on the 2nd/3rd/... times that the websocket was disconnected.
+-   **Backported** Resolve an issue with a previous fix to reconnect the websocket that prevented it from working on the 2nd/3rd/... times that the websocket was disconnected.
 
 ## 1.6.3
 

--- a/packages/dara-core/tests/python/test_main.py
+++ b/packages/dara-core/tests/python/test_main.py
@@ -3,7 +3,7 @@ import datetime
 import json
 import os
 from typing import Any, Coroutine, Union
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import anyio
 import jwt
@@ -36,7 +36,12 @@ from dara.core.configuration import ConfigurationBuilder
 from dara.core.defaults import default_template
 from dara.core.definitions import ComponentInstance
 from dara.core.http import get
-from dara.core.interactivity.actions import ACTION_CONTEXT, NavigateTo, UpdateVariable, UpdateVariableImpl
+from dara.core.interactivity.actions import (
+    ACTION_CONTEXT,
+    NavigateTo,
+    UpdateVariable,
+    UpdateVariableImpl,
+)
 from dara.core.internal.tasks import Task
 from dara.core.internal.websocket import WebsocketManager
 from dara.core.main import _start_application
@@ -2079,3 +2084,41 @@ async def test_add_custom_middlewares():
     async with AsyncClient(app) as client:
         await client.get('/api/core/config', headers=AUTH_HEADERS)
         assert side_effect == 2
+
+async def test_startup_function():
+    """Check the components route returns the dict of components"""
+
+    # Define a mock function to be run on startup
+    mock_startup = MagicMock(return_value=True)
+
+    config.startup_functions.append(mock_startup)
+
+    # Start the app and fetch config to make sure everything is executed
+    app = _start_application(config)
+    async with AsyncClient(app) as client:
+        await client.get('/api/core/config', headers=AUTH_HEADERS)
+
+    mock_startup.assert_called_once()
+
+
+async def test_async_startup_function():
+    """Check the components route returns the dict of components"""
+    a = 1
+
+    async def side_effect():
+        nonlocal a
+        await asyncio.sleep(0.1)
+        a = 2
+
+    # Define a mock function to be run on startup
+    mock_startup = AsyncMock(side_effect=side_effect)
+
+    config.startup_functions.append(mock_startup)
+
+    # Start the app and fetch config to make sure everything is executed
+    app = _start_application(config)
+    async with AsyncClient(app) as client:
+        await client.get('/api/core/config', headers=AUTH_HEADERS)
+
+    mock_startup.assert_called_once()
+    assert a == 2


### PR DESCRIPTION
## Motivation and Context
* Needed an async startup function for an internal project

## Implementation Description
* Moves the execution of startup functions to be part of the app lifecycle so we can make allow async function. Detects coroutines being returned and then awaits them.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
Unit tests added

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->