### PR TITLE
Fix: DO-2651 settings .env file generation failure

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -5,6 +5,8 @@ title: Changelog
 ## NEXT
 
 -   Added the ability to pass an asynchronous function to `ConfigurationBuilder.on_startup(...)`.
+-   Fix an issue where `get_settings` would crash when attempting to generate a missing `.env` file. It now
+instead warns and falls back to using an in-memory set of default settings.
 
 ## 1.7.3
 

--- a/packages/dara-core/dara/core/internal/settings.py
+++ b/packages/dara-core/dara/core/internal/settings.py
@@ -95,7 +95,7 @@ def get_settings():
         try:
             generate_env_file()
         except Exception as e:
-            dev_logger.error(f'Failed to generate .env file, falling back to default settings', error=e)
+            dev_logger.error('Failed to generate .env file, falling back to default settings', error=e)
             env_error = True
 
     settings_kwargs = {}

--- a/packages/dara-core/dara/core/internal/settings.py
+++ b/packages/dara-core/dara/core/internal/settings.py
@@ -82,22 +82,35 @@ def get_settings():
     Get a cached instance of the settings, loading values from the .env if present.
     If .env is not present, prints a warning and generates one for the user.
     """
-    # Generate .env file if it's missing
-    if not os.path.isfile(os.path.join(os.getcwd(), '.env')):
-        dev_logger.debug('.env file not found, generating the file...')
-        generate_env_file()
 
     # Test purposes - if DARA_TEST_FLAG is set then override env with .env.test
     if os.environ.get('DARA_TEST_FLAG', None) is not None:
         return Settings(**dotenv_values('.env.test'))
 
+    env_error = False
+
+    # Generate .env file if it's missing
+    if not os.path.isfile(os.path.join(os.getcwd(), '.env')):
+        dev_logger.debug('.env file not found, generating the file...')
+        try:
+            generate_env_file()
+        except Exception as e:
+            dev_logger.error(f'Failed to generate .env file, falling back to default settings', error=e)
+            env_error = True
+
+    settings_kwargs = {}
+    if env_error:
+        settings_kwargs['_env_file'] = None
+
     # If AUDIENCE sso env variants are provided, use them and force verify audience to True
     # SSO_VERIFY_AUDIENCE can be set explicitly to False to override this behavior.
-    dotenv_vals = dotenv_values(os.path.join(os.getcwd(), '.env'))
+    dotenv_vals = dotenv_values(os.path.join(os.getcwd(), '.env')) if not env_error else {}
     audience_id = os.environ.get('SSO_AUDIENCE_CLIENT_ID', dotenv_vals.get('SSO_AUDIENCE_CLIENT_ID'))
     audience_secret = os.environ.get('SSO_AUDIENCE_CLIENT_SECRET', dotenv_vals.get('SSO_AUDIENCE_CLIENT_SECRET'))
     enable_audience_check = os.environ.get('SSO_VERIFY_AUDIENCE', dotenv_vals.get('SSO_VERIFY_AUDIENCE'))
     if enable_audience_check != 'False' and audience_id is not None and audience_secret is not None:
-        return Settings(sso_client_id=audience_id, sso_client_secret=audience_secret, sso_verify_audience=True)
+        return Settings(
+            sso_client_id=audience_id, sso_client_secret=audience_secret, sso_verify_audience=True, **settings_kwargs
+        )
 
-    return Settings()
+    return Settings(**settings_kwargs)

--- a/packages/dara-core/tests/python/test_settings.py
+++ b/packages/dara-core/tests/python/test_settings.py
@@ -1,0 +1,57 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
+
+@contextmanager
+def unset_test_flag():
+    """
+    Context manager to unset the DARA_TEST_FLAG environment variable
+    """
+    import os
+
+    try:
+        os.environ.pop('DARA_TEST_FLAG')
+        yield
+    finally:
+        os.environ['DARA_TEST_FLAG'] = '1'
+
+
+@contextmanager
+def unset_env_file():
+    """
+    Context manager to remove the .env file
+    """
+    import os
+
+    env_content = None
+
+    try:
+        # load existing content of cwd/.env
+        if os.path.exists('.env'):
+            with open('.env', 'r', encoding='utf-8') as f:
+                env_content = f.read()
+            os.remove('.env')
+        yield
+    finally:
+        if env_content:
+            with open('.env', 'w', encoding='utf-8') as f:
+                f.write(env_content)
+
+
+@patch('dara.core.internal.settings.generate_env_file', side_effect=Exception('Failed to generate .env file'))
+def test_settings_error_generate_env(mock_generate_env_file):
+    """
+    Test get_settings() can recover from a failed .env file generation
+    """
+    from dara.core.internal.settings import get_settings
+
+    get_settings.cache_clear()
+
+    # unsetting test flag to test the proper flow rather than .env.test file
+    with unset_test_flag():
+        # unsetting .env file to force the function to attempt generating env file
+        with unset_env_file():
+            settings = get_settings()
+            assert settings.jwt_secret is not None
+            # make sure we actually tried to generate the file
+            mock_generate_env_file.assert_called_once()

--- a/packages/dara-core/tests/python/test_settings.py
+++ b/packages/dara-core/tests/python/test_settings.py
@@ -13,7 +13,7 @@ def unset_test_flag():
         os.environ.pop('DARA_TEST_FLAG')
         yield
     finally:
-        os.environ['DARA_TEST_FLAG'] = '1'
+        os.environ['DARA_TEST_FLAG'] = 'true'
 
 
 @contextmanager


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Currently in Dara when an .env file is missing when attempting to read from environment variables, it attempts to generate one in the CWD. In some cases this directory is not writable. 

This PR changes the behaviour to instead fall back to using in-memory secrets rather than the `.env` file in addition to logging the error.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Try/except added on the env generation logic. In case of failure `_env_file=None` is passed to the `Settings` class as per [Pydantic docs](https://docs.pydantic.dev/1.10/usage/settings/#dotenv-env-support) to make it not attempt to load any files.

The Settings class already as defaults set up for crucial envs like jwt_secret.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a unit test to cover the scenario

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->