### PR TITLE
Fix: DO-2715 respect existing values in BackendStore backend 

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -7,6 +7,8 @@ title: Changelog
 -   Added the ability to pass an asynchronous function to `ConfigurationBuilder.on_startup(...)`.
 -   Fix an issue where `get_settings` would crash when attempting to generate a missing `.env` file. It now
 instead warns and falls back to using an in-memory set of default settings.
+-   Fix an issue where the `BackendStore` would not respect existing value and overwrite it with the variable default,
+e.g. when an existing JSON file was present on disk with the `FileBackend`
 
 ## 1.7.3
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Issue discovered with the persistence feature - the store did not respect a preexisting value in the backend.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Initialization logic checks if there is already a value in the store, and only performs a `write` if `has` returned `False`.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests added

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->