### PR TITLE
Fix: DO-2781: Dara serialization: MultiIndex on a pandas.DataFrame

### DIFF
--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 # pylint: disable=unnecessary-lambda
-import ast
 from inspect import Parameter, isclass
 from typing import (
     Any,
@@ -96,7 +95,7 @@ def _tuple_key_deserialize(d):
     """
     encoded_dict = {}
     for key, value in d.items():
-        encoded_key = ast.literal_eval(key[9:]) if isinstance(key, str) and key.startswith('__tuple__') else key
+        encoded_key = tuple(key[10:-1].split(',')) if isinstance(key, str) and key.startswith('__tuple__') else key
         encoded_value = _tuple_key_deserialize(value) if isinstance(value, dict) else value
         encoded_dict[encoded_key] = encoded_value
     return encoded_dict

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -72,6 +72,13 @@ def _get_pandas_array_encoder(array_type: Type[Any], dtype: Any, raise_: bool = 
 
 
 def _tuple_key_serialize(d):
+    """
+    A helper function to recursively check if a dict have a tuple key type and turn it into a string with "__tuple__" prefix.
+    The reason for this is jsonable_encoder will turn tuple into list, but list is not hashable.
+    Hence we serialize tuple key by our side.
+
+    :param d: the dict where tuple key to be serialized
+    """
     encoded_dict = {}
     for key, value in d.items():
         encoded_key = '__tuple__' + str(key) if isinstance(key, tuple) else key

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -71,28 +71,13 @@ def _get_pandas_array_encoder(array_type: Type[Any], dtype: Any, raise_: bool = 
     )
 
 
-def _df_encoder(df: pandas.DataFrame):
-    """
-    Convert a DataFrame to json format
-
-    :param df: The DataFrame to be encoded
-    """
-    # If a df have multiple index
-    if df.index.nlevels > 1 or df.columns.nlevels > 1:
-        stack_list = [i for i in range(0, df.columns.nlevels)]
-        # flatten the df
-        data = df.stack(stack_list).to_dict()
-        # construct the dict
-        df_dict = {}
-        for t, v in data.items():
-            e = df_dict.setdefault(t[0], {})
-            for k in t[1:-1]:
-                e = e.setdefault(k, {})
-            e[t[-1]] = v
-
-    else:
-        df_dict = df.to_dict(orient='dict')
-    return jsonable_encoder(df_dict)
+def _tuple_key_serialize(d):
+    encoded_dict = {}
+    for key, value in d.items():
+        encoded_key = '__tuple__' + str(key) if isinstance(key, tuple) else key
+        encoded_value = _tuple_key_serialize(value) if isinstance(value, dict) else value
+        encoded_dict[encoded_key] = encoded_value
+    return encoded_dict
 
 
 # A encoder_registry to handle serialization/deserialization for numpy/pandas type
@@ -158,7 +143,7 @@ encoder_registry: MutableMapping[Type[Any], Encoder] = {
     pandas.Index: Encoder(serialize=lambda x: x.to_list(), deserialize=lambda x: pandas.Index(x)),
     pandas.Timestamp: Encoder(serialize=lambda x: x.isoformat(), deserialize=lambda x: pandas.Timestamp(x)),
     pandas.DataFrame: Encoder(
-        serialize=lambda x: _df_encoder(x),
+        serialize=lambda x: jsonable_encoder(_tuple_key_serialize(x.to_dict(orient='dict'))),
         deserialize=lambda x: x if isinstance(x, pandas.DataFrame) else _not_implemented(x, pandas.DataFrame),
     ),
 }

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -77,8 +77,8 @@ pytestmark = pytest.mark.anyio
         (pandas.Series, pandas.Series([1, 2, 3]), False),
         (pandas.Index, pandas.Index([1, 2, 3]), False),
         (pandas.Timestamp, pandas.Timestamp('2023-10-04'), False),
-        (pandas.DataFrame, df_with_datetime_index, True),
-        (pandas.DataFrame, df_with_multiple_index, True),
+        (pandas.DataFrame, df_with_datetime_index, False),
+        (pandas.DataFrame, df_with_multiple_index, False),
     ],
 )
 def test_serialization_deserialization(type_, value, raise_):
@@ -93,8 +93,10 @@ def test_serialization_deserialization(type_, value, raise_):
     deserialized = encoder['deserialize'](json.loads(serialized))
 
     # If it's a pandas type use built-in equality
-    if isinstance(value, pandas.Series) or isinstance(value, pandas.Index):
+    if isinstance(value, pandas.Series) or isinstance(value, pandas.Index) :
         assert value.equals(deserialized)
+    elif isinstance(value, pandas.DataFrame):
+        value.eq(deserialized)
     # Handle pandas arrays
     elif isinstance(value, ExtensionArray):
         assert numpy.array_equal(value, deserialized)

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -15,6 +15,11 @@ from dara.core.internal.encoder_registry import deserialize, encoder_registry
 dates = pandas.date_range(start='2021-01-01', end='2021-01-02', freq='D')
 timestamp = pandas.Timestamp('2023-10-04')
 df_with_datetime_index = pandas.DataFrame({'col1': [1.0, numpy.nan], 'col2': [timestamp, timestamp]}, index=dates)
+df_with_multiple_index = pandas.DataFrame({('F','>50'): {('A', 'a'): 1, ('A', 'b'): 6, ('B', 'a'): 2, ('B', 'b'): 7},
+ ('F','<50'): {('A', 'a'): 2, ('A', 'b'): 7, ('B', 'a'): 3, ('B', 'b'): 8},
+ ('M','>50'): {('A', 'a'): 3, ('A', 'b'): 8, ('B', 'a'): 4, ('B', 'b'): 9},
+ ('M','<50'): {('A', 'a'): 4, ('A', 'b'): 9, ('B', 'a'): 5, ('B', 'b'): 10},
+})
 
 pytestmark = pytest.mark.anyio
 
@@ -73,6 +78,7 @@ pytestmark = pytest.mark.anyio
         (pandas.Index, pandas.Index([1, 2, 3]), False),
         (pandas.Timestamp, pandas.Timestamp('2023-10-04'), False),
         (pandas.DataFrame, df_with_datetime_index, True),
+        (pandas.DataFrame, df_with_multiple_index, True),
     ],
 )
 def test_serialization_deserialization(type_, value, raise_):


### PR DESCRIPTION
## Motivation and Context
This bug happens when a `Variable` have a DataFrame and the DataFrame is multi-indexed.

The root reason is that when a df have multiple index, `to_dict()` will use tuple type as key.
However, tuple is not jsonable, hence, jsonable_enocder will turn it into a list. List can't not be used as a key of dict.

## Implementation Description
To avoid this, when serializing a df, will iterate the dict. If it has a tuple type key, will turn it into a string with a __tuple__ prefix. So the whole dict is jsonable.

However, this require user to  deserialise it, by doing
```
def _tuple_key_deserialize(d):
    encoded_dict = {}
    for key,value in d.items():
        encoded_key = ast.literal_eval(key[9:])if isinstance(key,str)and key.startswith('__tuple__') else key
        encoded_value = _tuple_key_deserialize(value) if isinstance(value,dict) else value
        encoded_dict[encoded_key] = encoded_value
    return encoded_dict 
preds_df = pandas.DataFrame(_tuple_key_deserialize(d))
```
Happy to discuss if there's better solution.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Locally tested

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->