### PR TITLE
Improvement: DO-2635 add explicit logs for auth errors

### DIFF
--- a/packages/dara-core/dara/core/auth/routes.py
+++ b/packages/dara-core/dara/core/auth/routes.py
@@ -31,6 +31,7 @@ from dara.core.auth.definitions import (
     AuthError,
     SessionRequestBody,
 )
+from dara.core.logging import dev_logger
 
 auth_router = APIRouter()
 
@@ -70,11 +71,14 @@ async def verify_session(
             # Because contextvars don't work in middlewares
             req.state.session_id = SESSION_ID.get()
             return SESSION_ID.get()
-        except jwt.ExpiredSignatureError:
+        except jwt.ExpiredSignatureError as e:
+            dev_logger.error('Expired Token Signature', error=e)
             raise HTTPException(status_code=401, detail=EXPIRED_TOKEN_ERROR)
-        except jwt.PyJWTError:
+        except jwt.PyJWTError as e:
+            dev_logger.error('Invalid Token', error=e)
             raise HTTPException(status_code=401, detail=INVALID_TOKEN_ERROR)
         except AuthError as err:
+            dev_logger.error('Auth Error', error=err)
             raise HTTPException(status_code=err.code, detail=err.detail)
     raise HTTPException(status_code=400, detail=BAD_REQUEST_ERROR('No auth credentials passed'))
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Adding extra logs for auth errors to make debugging future issues easier

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, example of an invalid request logs:

```
 2024-03-26 13:48:09,797  ERROR  dara.dev  Auth Error

Traceback (most recent call last):
  File "/Users/kbiel/code/dara/packages/decision-app/.venv/bin/dara", line 8, in <module>
    sys.exit(cli())
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/kbiel/code/dara/packages/dara-core/dara/core/cli.py", line 170, in start
    uvicorn.run(
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/uvicorn/main.py", line 578, in run
    server.run()
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/uvicorn/server.py", line 61, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/Users/kbiel/.pyenv/versions/3.11.6/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/Users/kbiel/.pyenv/versions/3.11.6/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/middleware/base.py", line 151, in coro
    await self.app(scope, receive_or_disconnect, send_no_error)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/routing.py", line 762, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/routing.py", line 782, in app
    await route.handle(scope, receive, send)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/routing.py", line 297, in handle
    await self.app(scope, receive, send)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/routing.py", line 77, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/starlette/routing.py", line 72, in app
    response = await func(request)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/fastapi/routing.py", line 275, in app
    solved_result = await solve_dependencies(
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/fastapi/dependencies/utils.py", line 598, in solve_dependencies
    solved = await call(**sub_values)
  File "/Users/kbiel/code/dara/packages/dara-core/dara/core/auth/routes.py", line 81, in verify_session
    dev_logger.error('Auth Error', error=err)
  File "/Users/kbiel/code/dara/packages/dara-core/dara/core/auth/basic.py", line 142, in verify_token
    decoded = jwt.decode(token, get_settings().jwt_secret, algorithms=[JWT_ALGO])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/jwt/api_jwt.py", line 210, in decode
    decoded = self.decode_complete(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/jwt/api_jwt.py", line 151, in decode_complete
    decoded = api_jws.decode_complete(
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/jwt/api_jws.py", line 209, in decode_complete
    self._verify_signature(signing_input, header, signature, key, algorithms)
  File "/Users/kbiel/code/dara/.venv/lib/python3.11/site-packages/jwt/api_jws.py", line 310, in _verify_signature
    raise InvalidSignatureError("Signature verification failed")
jwt.exceptions.InvalidSignatureError: Signature verification failed

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kbiel/code/dara/packages/dara-core/dara/core/auth/routes.py", line 68, in verify_session
    verifier(credentials.credentials)
  File "/Users/kbiel/code/dara/packages/dara-core/dara/core/auth/basic.py", line 148, in verify_token
    raise AuthError(INVALID_TOKEN_ERROR, 401)
dara.core.auth.definitions.AuthError: ({'message': 'Token is invalid, please log in again', 'reason': 'invalid_token'}, 401)

 2024-03-26 13:48:09,806  INFO  dara.http  127.0.0.1:62037 - GET /api/core/components 401

```

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->