### PR TITLE
Fix: DOS-887 Add chunking of websocket messages

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Added the ability to handle chunked responses to internal dara messages used by the `WebsocketHandler.send_and_wait` method. The messages will be gathered into a list before being returned to the caller.
+
 ## 1.7.4
 
 -   Added the ability to pass an asynchronous function to `ConfigurationBuilder.on_startup(...)`.

--- a/packages/dara-core/js/api/websocket.tsx
+++ b/packages/dara-core/js/api/websocket.tsx
@@ -433,10 +433,22 @@ export class WebSocketClient implements WebSocketClientInterface {
      * @param channel return channel to identify the message
      */
     sendVariable(value: any, channel: string): void {
+        this.sendMessage(value, channel);
+    }
+
+    /**
+     * Send an internal message to the backend. This is used to respond to sendAndWait calls from the backend.
+     *
+     * @param value variable value to send
+     * @param channel return channel to identify the message
+     * @param chunkCount total number of chunks this message has been split into
+     */
+    sendMessage(value: any, channel: string, chunkCount?: number): void {
         if (this.socket.readyState === WebSocket.OPEN) {
             this.socket.send(
                 JSON.stringify({
                     channel,
+                    chunk_count: chunkCount ?? null,
                     message: value,
                     type: 'message',
                 })

--- a/packages/dara-core/tests/python/test_websocket.py
+++ b/packages/dara-core/tests/python/test_websocket.py
@@ -1,13 +1,18 @@
 import asyncio
 import os
-import token
-from uuid import uuid4
+from typing import Any, Callable
 
 import anyio
 import pytest
 from async_asgi_testclient import TestClient as AsyncTestClient
 from tests.python.tasks import exception_task
-from tests.python.utils import AUTH_HEADERS, _async_ws_connect, _call_action, create_app, get_ws_messages
+from tests.python.utils import (
+    AUTH_HEADERS,
+    _async_ws_connect,
+    _call_action,
+    create_app,
+    get_ws_messages,
+)
 
 from dara.core import DerivedVariable, UpdateVariable, Variable
 from dara.core.auth import BasicAuthConfig, MultiBasicAuthConfig
@@ -16,7 +21,13 @@ from dara.core.configuration import ConfigurationBuilder
 from dara.core.definitions import ComponentInstance
 from dara.core.interactivity.any_variable import NOT_REGISTERED
 from dara.core.internal.registries import utils_registry
-from dara.core.internal.websocket import WS_CHANNEL, WebsocketManager
+from dara.core.internal.websocket import (
+    WS_CHANNEL,
+    DaraClientMessage,
+    DaraServerMessage,
+    ServerMessagePayload,
+    WebsocketManager,
+)
 from dara.core.main import _start_application
 
 pytestmark = pytest.mark.anyio
@@ -34,6 +45,76 @@ config = create_app(builder)
 
 
 os.environ['DARA_DOCKER_MODE'] = 'TRUE'
+
+
+async def _await_for_condition(fn: Callable[..., Any]):
+    i = 0
+    while not fn():
+        await asyncio.sleep(0.1)
+        i += 1
+
+        # If we fail 20 times, ~2secs has expired so bail out
+        if i > 20:
+            raise Exception('Timeout')
+
+
+async def _send_task(handler, messages):
+    # First we wait for the first task to send the message in the first place
+    await _await_for_condition(lambda: len(handler.pending_responses) > 0)
+
+    msg_id = list(handler.pending_responses.keys())[0]
+
+    # Process the messages which should unblock the first task and allow it to complete
+    for message in messages:
+        msg = DaraClientMessage(
+            channel=msg_id,
+            message=message,
+            chunk_count=None if len(messages) == 1 else len(messages),
+        )
+        await handler.process_client_message(msg)
+
+
+async def test_websocket_send_and_wait():
+    """
+    Test that calling send_and_wait on a websocket handler will block until a response is received
+    """
+    result = {}
+    ws_mgr = WebsocketManager()
+    ws_handler = ws_mgr.create_handler('CHANNEL')
+
+    async def get_task():
+        nonlocal result
+        result = await ws_handler.send_and_wait(DaraServerMessage(message=ServerMessagePayload()))
+
+    # Run the two tasks concurrently
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_send_task, ws_handler, ['hello'])
+        tg.start_soon(get_task)
+
+    # Verify that a single doc was returned
+    assert result == 'hello'
+
+
+async def test_websocket_send_and_wait_with_chunks():
+    """
+    Test that calling send_and_wait on a websocket handler will block until a response is received even when the
+    response is sent in multiple chunks
+    """
+    result = {}
+    ws_mgr = WebsocketManager()
+    ws_handler = ws_mgr.create_handler('CHANNEL')
+
+    async def get_task():
+        nonlocal result
+        result = await ws_handler.send_and_wait(DaraServerMessage(message=ServerMessagePayload()))
+
+    # Run the two tasks concurrently
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_send_task, ws_handler, ['hello', 'world', '!!!'])
+        tg.start_soon(get_task)
+
+    # Verify that a single doc was returned
+    assert result == ['hello', 'world', '!!!']
 
 
 async def test_websocket_broadcast():


### PR DESCRIPTION
## Motivation and Context
* An internal project needs to send back a bunch of data in reponse to a websocket message and it doesn't all fit within a single response, so this change adds the ability to chunk responses.

## Implementation Description
* Adds the ability to pass a chunk_count parameter along with DaraClientMessages to denote that there are multiple parts to this message that will be sent separately.
* On the backend side we then wait for the specified number of messages to be received before setting the event to unblock the sendAndWait handler. We make no attempt to recombine the messages on the backend at this time as we don't know what format the response will be in on the framework side. It's left up to the calling code to know when chunked responses might be returned and handle the merging appropriately.
* A new api `sendMessage` has been added to the frontend's websocket client to allow non variable messages to be sent back with a chunkCount set.
* Lastly, there was an odd bug in the WebsocketHandler in that all handlers ended up using the same object for pending_responses as we were relying on the default value which is defined only once rather than on each instantiation of the class.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Unit tests to be added (already written on the internal project, just need transferring here)

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.
