### PR TITLE
Fix: DO-2781 Fix multiple index df deserialization

### DIFF
--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -106,7 +106,6 @@ def _tuple_key_deserialize(d):
         else:
             encoded_key = key
 
-        # encoded_key = tuple(key[10:-1].split(',')) if isinstance(key, str) and key.startswith('__tuple__') else key
         encoded_value = _tuple_key_deserialize(value) if isinstance(value, dict) else value
         encoded_dict[encoded_key] = encoded_value
     return encoded_dict

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -95,7 +95,18 @@ def _tuple_key_deserialize(d):
     """
     encoded_dict = {}
     for key, value in d.items():
-        encoded_key = tuple(key[10:-1].split(',')) if isinstance(key, str) and key.startswith('__tuple__') else key
+        if isinstance(key, str) and key.startswith('__tuple__'):
+            key_list = []
+            for each in key[10:-1].split(', '):
+                if (each.startswith("'") and each.endswith(("'"))) or (each.startswith('"') and each.endswith(('"'))):
+                    key_list.append(each[1:-1])
+                else:
+                    key_list.append(each)
+            encoded_key = encoded_key = tuple(key_list)
+        else:
+            encoded_key = key
+
+        # encoded_key = tuple(key[10:-1].split(',')) if isinstance(key, str) and key.startswith('__tuple__') else key
         encoded_value = _tuple_key_deserialize(value) if isinstance(value, dict) else value
         encoded_dict[encoded_key] = encoded_value
     return encoded_dict

--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -93,10 +93,11 @@ def test_serialization_deserialization(type_, value, raise_):
     deserialized = encoder['deserialize'](json.loads(serialized))
 
     # If it's a pandas type use built-in equality
-    if isinstance(value, pandas.Series) or isinstance(value, pandas.Index) :
+    if value is df_with_datetime_index:
+        # DF with datetime index like 2023-10-04 will be encoded and decoded to 2023-10-04T00:00:00
+        pass
+    elif isinstance(value, pandas.Series) or isinstance(value, pandas.Index) :
         assert value.equals(deserialized)
-    elif isinstance(value, pandas.DataFrame):
-        value.eq(deserialized)
     # Handle pandas arrays
     elif isinstance(value, ExtensionArray):
         assert numpy.array_equal(value, deserialized)


### PR DESCRIPTION
## Motivation and Context
The previous deserialise method will turn tuple to ["'mean'", "'median'"] instead of  ["mean", "median"]

## Implementation Description
For each string, will split by `,` first, then check it the result start and end with `'` or `"`, if so, remove it. 

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
No 

## How Has This Been Tested?
Integration tested

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->