### PR TITLE
Fix: DOS-913 Websocket Reconnection Refactor

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,11 +2,15 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed websocket reconnection logic so that it correctly retries for 10 seconds before bailing out and then retries the connection if the document becomes visible again.
+
 ## 1.8.1
 
 -   Added missing interface definition to the WebsocketClientInterface in the ui code
 -   Fix an issue where internal requests did not handle auth errors properly so users would not immediately
-be logged out when their session expired
+    be logged out when their session expired
 
 ## 1.7.7
 
@@ -18,9 +22,9 @@ be logged out when their session expired
 
 -   Added the ability to pass an asynchronous function to `ConfigurationBuilder.on_startup(...)`.
 -   Fix an issue where `get_settings` would crash when attempting to generate a missing `.env` file. It now
-instead warns and falls back to using an in-memory set of default settings.
+    instead warns and falls back to using an in-memory set of default settings.
 -   Fix an issue where the `BackendStore` would not respect existing value and overwrite it with the variable default,
-e.g. when an existing JSON file was present on disk with the `FileBackend`
+    e.g. when an existing JSON file was present on disk with the `FileBackend`
 
 ## 1.7.3
 

--- a/packages/dara-core/package.json
+++ b/packages/dara-core/package.json
@@ -65,6 +65,7 @@
     "jest": "^29.5.0",
     "jest-css-modules": "^2.1.0",
     "jest-environment-jsdom": "^29.5.0",
+    "jest-websocket-mock": "^2.5.0",
     "msw": "1.0.1",
     "postcss": "^8.4.35",
     "prettier": "^3.0.0",

--- a/packages/dara-core/tests/js/websocket.spec.tsx
+++ b/packages/dara-core/tests/js/websocket.spec.tsx
@@ -1,0 +1,196 @@
+import { waitFor } from '@testing-library/dom';
+import WS from 'jest-websocket-mock';
+import { firstValueFrom } from 'rxjs';
+
+import { WebSocketClient } from '@/api';
+
+/**
+ * Helper function to convert a json message to a string for the server to send
+ *
+ * @param type - the message type
+ * @param message - the message to send
+ * @returns the message as a string
+ */
+function toMsg(type: string, message: any): string {
+    return JSON.stringify({ type, message: message });
+}
+
+async function initialize(): Promise<[server: WS, client: WebSocketClient]> {
+    const server = new WS('ws://localhost:1234');
+    const client = new WebSocketClient('ws://localhost:1234', 'test', false);
+
+    await server.connected;
+    server.send(toMsg('init', { channel: 'test' }));
+
+    return [server, client];
+}
+
+describe('WebsocketClient', () => {
+    afterEach(() => {
+        WS.clean();
+    });
+
+    it('should initialize the websocket connection when the client is instantiated', async () => {
+        const [_, client] = await initialize();
+
+        expect(await client.channel).toEqual('test');
+    });
+
+    it('should push messages received onto the messages stream', async () => {
+        const [server, client] = await initialize();
+
+        // Wait for the client to connect fully
+        await client.channel;
+
+        // Setup a listener for the messages stream
+        const message = firstValueFrom(client.messages$);
+
+        // Send a message to the client
+        server.send(toMsg('custom', { message: 'test' }));
+
+        // Check that the message was received
+        expect(await message).toEqual({ type: 'custom', message: { message: 'test' } });
+    });
+
+    it('should allow the client to send messages to the server', async () => {
+        const [server, client] = await initialize();
+
+        // Wait for the client to connect fully
+        await client.channel;
+
+        client.sendMessage({ message: 'test' }, 'channel');
+
+        // Check that the message was received
+        await expect(server).toReceiveMessage(
+            '{"channel":"channel","chunk_count":null,"message":{"message":"test"},"type":"message"}'
+        );
+    });
+
+    it('should allow the client to send custom messages to the server', async () => {
+        const [server, client] = await initialize();
+
+        // Wait for the client to connect fully
+        await client.channel;
+
+        client.sendCustomMessage('test_custom', { message: 'test' });
+
+        // Check that the message was received
+        await expect(server).toReceiveMessage(
+            '{"message":{"data":{"message":"test"},"kind":"test_custom"},"type":"custom"}'
+        );
+    });
+
+    it('should attempt to reconnect to the websocket server if the connection is closed from the server side', async () => {
+        const [server, client] = await initialize();
+
+        // Wait for the client to connect fully
+        await client.channel;
+
+        const initializeSpy = jest.spyOn(client, 'initialize');
+
+        // Close the server connection and then create new one
+        server.close();
+        const serverNew = new WS('ws://localhost:1234');
+
+        await waitFor(() => expect(initializeSpy).toHaveBeenCalledTimes(1));
+
+        // Wait for the client to reconnect
+        await serverNew.connected;
+        serverNew.send(toMsg('init', { channel: 'test_1' }));
+
+        // Check that the client has reconnected
+        expect(await client.channel).toEqual('test_1');
+    });
+
+    it('should attempt to reconnect to the server multiple times if the initial one fails', async () => {
+        const [server, client] = await initialize();
+
+        // Wait for the client to connect fully
+        await client.channel;
+
+        const initializeSpy = jest.spyOn(client, 'initialize');
+
+        // Close the server connection
+        server.close();
+
+        // Wait for the reconnect attempts to hit 2
+        await waitFor(() => expect(initializeSpy).toHaveBeenCalledTimes(1));
+        initializeSpy.mockClear();
+        await waitFor(() => expect(initializeSpy).toHaveBeenCalledTimes(1));
+        initializeSpy.mockClear();
+
+        // The create a new server
+        const serverNew = new WS('ws://localhost:1234');
+
+        // Wait for the client to reconnect again and then respond
+        await waitFor(() => expect(initializeSpy).toHaveBeenCalledTimes(1));
+
+        // Wait for the client to reconnect
+        await serverNew.connected;
+        serverNew.send(toMsg('init', { channel: 'test_1' }));
+
+        // Check that the client has reconnected
+        expect(await client.channel).toEqual('test_1');
+    });
+
+    it('should stop retrying after max attempts has been reached', async () => {
+        const [server, client] = await initialize();
+
+        // Set the max attempts to 1 so it will retry once then fail
+        client._maxAttempts = 1;
+
+        // Wait for the client to connect fully
+        await client.channel;
+
+        const initializeSpy = jest.spyOn(client, 'initialize');
+        const consoleErrorSpy = jest.spyOn(console, 'error');
+
+        // Close the server connection
+        server.close();
+
+        // Wait for the reconnect attempts to hit 2
+        await waitFor(() => expect(initializeSpy).toHaveBeenCalledTimes(1));
+        initializeSpy.mockClear();
+
+        // Expect that the client will raise a console error and stop retrying
+        await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalledTimes(1));
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Could not reconnect the websocket to the server');
+    });
+
+    it('should start retrying again when the dom visibility changes', async () => {
+        const [server, client] = await initialize();
+
+        // Set the max attempts to 1 so it will retry once then fail
+        client._maxAttempts = 1;
+
+        // Wait for the client to connect fully
+        await client.channel;
+
+        const initializeSpy = jest.spyOn(client, 'initialize');
+        const consoleErrorSpy = jest.spyOn(console, 'error');
+
+        // Close the server connection
+        server.close();
+
+        // Wait for the reconnect attempts to hit 2
+        await waitFor(() => expect(initializeSpy).toHaveBeenCalledTimes(1));
+        initializeSpy.mockClear();
+
+        // Expect that the client will raise a console error and stop retrying
+        await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalledTimes(1));
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Could not reconnect the websocket to the server');
+
+        // Create a new server to connect to
+        const serverNew = new WS('ws://localhost:1234');
+
+        // Trigger the visibility change event
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        // Wait for the client to reconnect
+        await serverNew.connected;
+        serverNew.send(toMsg('init', { channel: 'test_1' }));
+
+        // Check that the client has reconnected
+        expect(await client.channel).toEqual('test_1');
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,7 @@ importers:
       jest: ^29.5.0
       jest-css-modules: ^2.1.0
       jest-environment-jsdom: ^29.5.0
+      jest-websocket-mock: ^2.5.0
       jwt-decode: ^3.1.2
       lodash: ^4.17.21
       msw: 1.0.1
@@ -258,6 +259,7 @@ importers:
       jest: 29.7.0_@types+node@18.19.5
       jest-css-modules: 2.1.0
       jest-environment-jsdom: 29.7.0
+      jest-websocket-mock: 2.5.0
       msw: 1.0.1_typescript@5.3.3
       postcss: 8.4.38
       prettier: 3.2.5
@@ -5823,6 +5825,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: false
 
   /chalk/4.1.1:
     resolution: {integrity: sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==}
@@ -10256,7 +10259,7 @@ packages:
     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      chalk: 4.1.0
+      chalk: 4.1.2
       diff-sequences: 29.6.3
       jest-get-type: 29.6.3
       pretty-format: 29.7.0
@@ -10544,6 +10547,13 @@ packages:
       emittery: 0.13.1
       jest-util: 29.7.0
       string-length: 4.0.2
+    dev: true
+
+  /jest-websocket-mock/2.5.0:
+    resolution: {integrity: sha512-a+UJGfowNIWvtIKIQBHoEWIUqRxxQHFx4CXT+R5KxxKBtEQ5rS3pPOV/5299sHzqbmeCzxxY5qE4+yfXePePig==}
+    dependencies:
+      jest-diff: 29.7.0
+      mock-socket: 9.3.1
     dev: true
 
   /jest-worker/29.7.0:
@@ -11952,6 +11962,11 @@ packages:
     dependencies:
       obliterator: 2.0.4
     dev: false
+
+  /mock-socket/9.3.1:
+    resolution: {integrity: sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==}
+    engines: {node: '>= 8'}
+    dev: true
 
   /modify-values/1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
@@ -13536,7 +13551,7 @@ packages:
     dependencies:
       object-assign: 4.1.1
       react: 18.2.0
-      react-is: 17.0.2
+      react-is: 18.2.0
     dev: true
 
   /react-table-sticky/1.1.3:


### PR DESCRIPTION
## Motivation and Context
* The existing logic for retrying when the websocket connection fails lead to it looping forever when trying to reconnect due to faulty logic that lead to multiple sockets being created and the number of attempts always being 0 so never hitting the max count.
* My previous changes had also not gone far enough in terms of updating the global socket variable that left this code in an odd state after a reconnection. For example, new connections did not get a proper heartbeat setup as this was done on the global level.

## Implementation Description
* To address this, I've moved all the socket connection logic to the initialize function, this is now where the socket is created and has all it's listeners attached. Calling this function will create a brand new socket everytime with all the correct handlers rather than the subset that was left after my previous changes.
* The logic around the onClose event of the websocket has been moved into the class itself and is no longer recursive. The reconnectCount is tracked on the class itself which makes it consistent across retries so the attempts correctly stop after 10seconds.
* The onClose logic now uses the revamped initialize function to ensure that the socket is setup in the exact same way on reconnect as it was before.
* The timeout is now properly respected between attempts and does not lead to an effective infinite loop of retry requests

## Any new dependencies Introduced
jest-websocket-mock

## How Has This Been Tested?
* A suite of unit tests around the client have been added using `jest-websocket-mock` that test all the reconnection and initialization logic work correctly.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.
