### PR TITLE
Fix: DO-2938 DF deserialise with default index

### DIFF
--- a/packages/dara-core/tests/python/test_encoders.py
+++ b/packages/dara-core/tests/python/test_encoders.py
@@ -20,7 +20,7 @@ df_with_multiple_index = pandas.DataFrame({('F','>50'): {('A', 'a'): 1, ('A', 'b
  ('M','>50'): {('A', 'a'): 3, ('A', 'b'): 8, ('B', 'a'): 4, ('B', 'b'): 9},
  ('M','<50'): {('A', 'a'): 4, ('A', 'b'): 9, ('B', 'a'): 5, ('B', 'b'): 10},
 })
-
+df_with_default_index = pandas.DataFrame({('A', 'mean'): [1, 2, 3], ('A', 'std'): [4, 5, 6]})
 pytestmark = pytest.mark.anyio
 
 @pytest.mark.parametrize(
@@ -79,6 +79,7 @@ pytestmark = pytest.mark.anyio
         (pandas.Timestamp, pandas.Timestamp('2023-10-04'), False),
         (pandas.DataFrame, df_with_datetime_index, False),
         (pandas.DataFrame, df_with_multiple_index, False),
+        (pandas.DataFrame, df_with_default_index, False),
     ],
 )
 def test_serialization_deserialization(type_, value, raise_):
@@ -96,7 +97,7 @@ def test_serialization_deserialization(type_, value, raise_):
     if value is df_with_datetime_index:
         # DF with datetime index like 2023-10-04 will be encoded and decoded to 2023-10-04T00:00:00
         pass
-    elif isinstance(value, pandas.Series) or isinstance(value, pandas.Index) :
+    elif isinstance(value, pandas.Series) or isinstance(value, pandas.Index) or isinstance(value, pandas.DataFrame) :
         assert value.equals(deserialized)
     # Handle pandas arrays
     elif isinstance(value, ExtensionArray):

--- a/packages/dara-core/tests/python/test_variable.py
+++ b/packages/dara-core/tests/python/test_variable.py
@@ -104,4 +104,5 @@ async def test_derived_variables_with_df_nan():
             client, derived, {'is_data_variable': False, 'values': [0], 'ws_channel': 'test_channel', 'force': False}
         )
         assert response.status_code == 200
-        assert response.json()['value'] == {'a': {'0': 1.0, '1': None, '2': None}, 'b': {'0': 2.0, '1': None, '2': None}}
+        assert response.json()['value']['idx_type'] == 'RangeIndex'
+        assert response.json()['value']['df'] == {'a': {'0': 1.0, '1': None, '2': None}, 'b': {'0': 2.0, '1': None, '2': None}}


### PR DESCRIPTION
## Motivation and Context
deserializing a df from a dict will create a array like index which is different from the original range type

## Implementation Description
Add a index type info when serialising. 

## Any new dependencies Introduced
No

## How Has This Been Tested?
Unit test

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.