### PR TITLE
Fix: DO-2958: chat icon off center for different base rem

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `Chat` button looked off centre on different base font size apps.
+
 ## 1.8.5
 
 -   Internal (JS): Updated `Markdown` to use `dara-ui`'s component.

--- a/packages/dara-components/js/smart/chat/chat.tsx
+++ b/packages/dara-components/js/smart/chat/chat.tsx
@@ -44,12 +44,12 @@ const ThreadWrapper = styled.div`
 
 const ChatButton = styled.button`
     position: absolute;
-    right: 1rem;
-    bottom: 1rem;
+    right: 0.5rem;
+    bottom: 0.5rem;
 
-    width: 2rem;
-    height: 2rem;
-    padding-top: 0.45rem;
+    width: 32px;
+    height: 32px;
+    padding: 7px 6px;
 
     color: ${(props) => props.theme.colors.background};
 
@@ -222,7 +222,7 @@ function Chat(props: ChatProps): JSX.Element {
                 </ThreadWrapper>
             )}
             <ChatButton onClick={onClickChatButton}>
-                <svg fill="none" height="32" viewBox="0 0 52 52" width="32" xmlns="http://www.w3.org/2000/svg">
+                <svg fill="none" height="20" viewBox="0 0 32 32" width="20" xmlns="http://www.w3.org/2000/svg">
                     <rect fill="none" height="24" rx="3" width="30" x="1" y="1.33594" />
                     <rect
                         height="24"


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
On an app that had 14px base font size instead of the default 16px, the chat icon appeared off centre

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue was that the svg of the icon was in px size, whereas the height/width and padding of the button used rem. That meant that it causeed it to appear off centre.

Being a fixed icon button I thought it made more sense to make it all px, so the values have been updated accordingly.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on apps of both 16px and 14px base font sizes

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
<img width="88" alt="Screenshot 2024-05-02 at 10 12 34" src="https://github.com/causalens/dara/assets/104359539/11ea4108-a4e4-4aae-a91a-dd23381e5d66">
