### PR TITLE
Fix: DOS-1003 Address performance issues with useAction

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -14,7 +14,8 @@ from dara.components import Button
 def on_click(ctx: action.Ctx):
     # Do Something...
 
-Button('Click Me', onclick=on_click, disabled=on_click.loading)
+on_click_action = on_click()
+Button('Click Me', onclick=on_click_action, disabled=on_click_action.loading)
 ```
 
 -   On the JS Api side the `useAction` hook has been changed to only return the action function rather than a tuple of `[action_fn, isLoading]`. To retrieve the loading state a new hook `useActionIsLoading` now returns the isLoading state of the action as a piece of react state that will trigger redraws when its value changes.

--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,23 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Updated AnnotatedAction to have a `loading` property that is automatically set to be a Variable[bool] instance tracking the loading state of the action. The example below shows how you can disable a button whilst the action it triggers is running.
+
+```python
+from dara.core import action
+from dara.components import Button
+
+@action
+def on_click(ctx: action.Ctx):
+    # Do Something...
+
+Button('Click Me', onclick=on_click, disabled=on_click.loading)
+```
+
+-   On the JS Api side the `useAction` hook has been changed to only return the action function rather than a tuple of `[action_fn, isLoading]`. To retrieve the loading state a new hook `useActionIsLoading` now returns the isLoading state of the action as a piece of react state that will trigger redraws when its value changes.
+
 ## 1.8.6
 
 -   Fixed an issue where `Chat` button looked off centre on different base font size apps.
@@ -19,7 +36,7 @@ title: Changelog
 
 -   `CausalGraphViewer` now only recalculates its layout on resize of the graph window if the graph is not in focus.
 -   Fixed an issue where `Select(..., multiselect=True)` would cause excessive rerenders and degrade performance when
-then number of items in the select was large.
+    then number of items in the select was large.
 
 ## 1.8.2
 
@@ -96,15 +113,18 @@ config.add_configuration(ChatConfig(on_new_message=example_callback))
 ## 1.6.0
 
 **Graphs**
+
 -   Added support for tiered layout in `FcoseLayout`, `PlanarLayout`, `SpringLayout` and `MarketingLayout`. It allows for nodes to be placed on tiers following some hierarchy and to further define requirements of nodes positions within that tier.
 -   If `TimeSeriesCausalGraph` object is passed to `CausalGraphViewer` and no tiers are defines, it will use `time_lag` and `variable_name` to define the `order_nodes_by` and `group` respectively.
 -   Added `simultaneous_edge_node_selection` to `CausalGraphViewer`, when set to True, the selected node will not be reset when an edge is chosen and vice versa.
 -   Added `layering_algorithm` prop to `PlanarLayout`. This allows users to choose between `LayeringAlgorithm.SIMPLEX` and `LayeringAlgorithm.LONGEST_PATH` for the layering step of the d3-dag sugyiama algorithm.
 
 **Plotting**
+
 -   Set `Bokeh` default `min-height` and `min-width` to `350px`.
 
 **Common**
+
 -   **Renamed:** `align-items` to `align` in `Grid.Column` to be more consistent with other layout components.
 -   Added `justify` and `align` shortcut props to `Card`, `Modal`, `Form`, `Grid`, `Grid.Row`, `Grid.Column`.
 -   Fixed an issue where if setting an initial number value to `Select` and it had a list of `Item`s, then the value showed was the number instead of the corresponding label to that value.

--- a/packages/dara-components/js/common/accordion/accordion.tsx
+++ b/packages/dara-components/js/common/accordion/accordion.tsx
@@ -59,7 +59,7 @@ interface AccordionProps extends StyledComponentProps {
 function Accordion(props: AccordionProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const [value, setValue] = useVariable(props.value);
-    const [onCarouselAction] = useAction(props.onchange);
+    const onCarouselAction = useAction(props.onchange);
 
     function handleChange(val: number): void {
         setValue(val);

--- a/packages/dara-components/js/common/button-bar/button-bar.tsx
+++ b/packages/dara-components/js/common/button-bar/button-bar.tsx
@@ -30,7 +30,7 @@ function ButtonBar(props: ButtonBarProps): JSX.Element {
     const formCtx = useFormContext(props);
     const [style, css] = useComponentStyles(props);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue(props.items[0].value));
-    const [onChangeAction] = useAction(props.onchange);
+    const onChangeAction = useAction(props.onchange);
 
     const onSelect = useCallback(
         (item: Item) => {

--- a/packages/dara-components/js/common/button/button.tsx
+++ b/packages/dara-components/js/common/button/button.tsx
@@ -9,6 +9,7 @@ import {
     getIcon,
     injectCss,
     useAction,
+    useActionIsLoading,
     useComponentStyles,
     useVariable,
 } from '@darajs/core';
@@ -69,7 +70,8 @@ const StyledButton = injectCss(styled(UiButton)<StyledButtonProps>`
  */
 function Button(props: ButtonProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
-    const [onClick, loading] = useAction(props.onclick);
+    const onClick = useAction(props.onclick);
+    const loading = useActionIsLoading(props.onclick.loading);
     const disabled = useConditionOrVariable(props.disabled);
 
     // Extract icon and grab color from first child if it has it

--- a/packages/dara-components/js/common/button/button.tsx
+++ b/packages/dara-components/js/common/button/button.tsx
@@ -71,7 +71,7 @@ const StyledButton = injectCss(styled(UiButton)<StyledButtonProps>`
 function Button(props: ButtonProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const onClick = useAction(props.onclick);
-    const loading = useActionIsLoading(props.onclick.loading);
+    const loading = useActionIsLoading(props.onclick);
     const disabled = useConditionOrVariable(props.disabled);
 
     // Extract icon and grab color from first child if it has it

--- a/packages/dara-components/js/common/carousel/carousel.tsx
+++ b/packages/dara-components/js/common/carousel/carousel.tsx
@@ -41,7 +41,7 @@ const StyledCarousel = injectCss(UICarousel);
 function Carousel(props: CarouselProps): JSX.Element {
     const [items] = useVariable(props.items);
     const [value, setValue] = useVariable(props.value);
-    const [onCarouselAction] = useAction(props.onchange);
+    const onCarouselAction = useAction(props.onchange);
 
     function handleChange(val: number): void {
         setValue(val);

--- a/packages/dara-components/js/common/checkbox-group/checkbox-group.tsx
+++ b/packages/dara-components/js/common/checkbox-group/checkbox-group.tsx
@@ -35,7 +35,7 @@ function CheckboxGroup(props: CheckboxGroupProps): JSX.Element {
     const [items] = useVariable(props.items);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue([]));
     const [style, css] = useComponentStyles(props);
-    const [onChangeAction] = useAction(props.onchange);
+    const onChangeAction = useAction(props.onchange);
 
     const onChange = useCallback(
         (values: Item | Array<Item>) => {

--- a/packages/dara-components/js/common/component-select-list/component-select-list.tsx
+++ b/packages/dara-components/js/common/component-select-list/component-select-list.tsx
@@ -39,7 +39,7 @@ const StyledComponentSelectList = injectCss(UIComponentSelectList);
 function ComponentSelectList(props: ComponentSelectListProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const [selectedItems, setSelectedItems] = useVariable(props.selected_items);
-    const [onSelect] = useAction(props.on_select);
+    const onSelect = useAction(props.on_select);
 
     const updateSelectedItems = useCallback(
         (items: Array<string>): void => {

--- a/packages/dara-components/js/common/datepicker/datepicker.tsx
+++ b/packages/dara-components/js/common/datepicker/datepicker.tsx
@@ -61,7 +61,7 @@ function Datepicker(props: DatepickerProps): JSX.Element {
     const formCtx = useFormContext(props);
     const [style, css] = useComponentStyles(props);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue());
-    const [onChangeAction] = useAction(props.onchange);
+    const onChangeAction = useAction(props.onchange);
     const isFirstRender = useRef(true);
 
     const onChange = (date: Date | [Date, Date]): void => {

--- a/packages/dara-components/js/common/dropzone/dropzone.tsx
+++ b/packages/dara-components/js/common/dropzone/dropzone.tsx
@@ -94,7 +94,7 @@ function UploadDropzone(props: DropzoneProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const [currentStatus, setCurrentStatus] = useState(status.INITIALIZED);
     const [errorMessage, setErrorMessage] = useState<string>();
-    const [onFileDrop] = useAction(props.on_drop);
+    const onFileDrop = useAction(props.on_drop);
     const extras = useRequestExtras();
 
     const onDrop = async (acceptedFiles: Array<File>): Promise<void> => {

--- a/packages/dara-components/js/common/form/form.tsx
+++ b/packages/dara-components/js/common/form/form.tsx
@@ -50,7 +50,7 @@ const StyledForm = injectCss('div');
 function Form(props: FormProps): JSX.Element {
     const [formState, setFormState] = useVariable<VariablesMap>(props.value);
 
-    const [onSubmit] = useAction(props.onsubmit);
+    const onSubmit = useAction(props.onsubmit);
     const [style, css] = useComponentStyles(props);
 
     const updateForm = useCallback(

--- a/packages/dara-components/js/common/input/input.tsx
+++ b/packages/dara-components/js/common/input/input.tsx
@@ -36,7 +36,7 @@ function Input(props: InputProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue());
     const [internalValue, setInternalValue] = useState(value);
-    const [onInputAction] = useAction(props.onchange);
+    const onInputAction = useAction(props.onchange);
 
     const debouncedAction = useMemo(() => _debounce(onInputAction, 500), [onInputAction]);
     const debouncedSetValue = useMemo(() => _debounce(setValue, 500), [setValue]);

--- a/packages/dara-components/js/common/radio-group/radio-group.tsx
+++ b/packages/dara-components/js/common/radio-group/radio-group.tsx
@@ -32,7 +32,7 @@ function RadioGroup(props: RadioGroupProps): JSX.Element {
     const [items] = useVariable(props.items);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue([]));
     const [style, css] = useComponentStyles(props);
-    const [onChangeAction] = useAction(props.onchange);
+    const onChangeAction = useAction(props.onchange);
 
     const onChange = useCallback(
         (values: Item) => {

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -111,7 +111,7 @@ function Select(props: SelectProps): JSX.Element {
         return typeof val === 'string' || typeof val === 'number' ? { label: String(val), val } : val;
     };
 
-    const [onChangeAction] = useAction(props.onchange);
+    const onChangeAction = useAction(props.onchange);
 
     //  if someone were to update the component rule of Hooks could be broken if items switched from having sections to not, so we use a ref for this to be only run once
     const itemHasListSection = useRef(null);

--- a/packages/dara-components/js/common/slider/slider.tsx
+++ b/packages/dara-components/js/common/slider/slider.tsx
@@ -39,7 +39,7 @@ function Slider(props: SliderProps): JSX.Element {
     const formCtx = useFormContext(props);
     const [style, css] = useComponentStyles(props);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue(props.domain[0]));
-    const [onTrack] = useAction(props.onchange);
+    const onTrack = useAction(props.onchange);
 
     const debouncedSetValue = useMemo(() => _debounce(setValue, 300), [setValue]);
     const debouncedOnTrack = useMemo(() => _debounce(onTrack, 300), [onTrack]);

--- a/packages/dara-components/js/common/switch/switch.tsx
+++ b/packages/dara-components/js/common/switch/switch.tsx
@@ -27,7 +27,7 @@ function Switch(props: SwitchProps): JSX.Element {
     const formCtx = useFormContext(props);
     const [style, css] = useComponentStyles(props);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue());
-    const [onChangeAction] = useAction(props.onchange);
+    const onChangeAction = useAction(props.onchange);
 
     function onChange(enabled: boolean): void {
         setValue(enabled);

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -427,7 +427,7 @@ function Table(props: TableProps): JSX.Element {
     }, [getData]);
 
     const [style, css] = useComponentStyles(props);
-    const [onClickRow] = useAction(props.onclick_row);
+    const onClickRow = useAction(props.onclick_row);
 
     const columns = useMemo(() => {
         const mappedCols = mapColumns(resolvedColumns);

--- a/packages/dara-components/js/common/textarea/textarea.tsx
+++ b/packages/dara-components/js/common/textarea/textarea.tsx
@@ -31,7 +31,7 @@ function Textarea(props: TextareaProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const [value, setValue] = useVariable(formCtx.resolveInitialValue());
     const [internalValue, setInternalValue] = useState(value);
-    const [onInputAction] = useAction(props.onchange);
+    const onInputAction = useAction(props.onchange);
 
     const debouncedAction = useMemo(() => _debounce(onInputAction, 500), [onInputAction]);
     const debouncedSetValue = useMemo(() => _debounce(setValue, 500), [setValue]);

--- a/packages/dara-components/js/graphs/causal-graph-viewer.tsx
+++ b/packages/dara-components/js/graphs/causal-graph-viewer.tsx
@@ -80,9 +80,9 @@ function CausalGraphViewer(props: CausalGraphViewerProps): JSX.Element {
     const theme = useTheme();
 
     const [graphData, setCausalGraphVariable] = useVariable(props.causal_graph);
-    const [onClickNode] = useAction(props.on_click_node);
-    const [onClickEdge] = useAction(props.on_click_edge);
-    const [onUpdate] = useAction(props.on_update);
+    const onClickNode = useAction(props.on_click_node);
+    const onClickEdge = useAction(props.on_click_edge);
+    const onUpdate = useAction(props.on_update);
 
     const graphLayout = useMemo(() => parseLayoutDefinition(props.graph_layout), [props.graph_layout]);
 

--- a/packages/dara-components/js/graphs/node-hierarchy-builder.tsx
+++ b/packages/dara-components/js/graphs/node-hierarchy-builder.tsx
@@ -38,7 +38,7 @@ function NodeHierarchyBuilder(props: NodeHierarchyBuilderProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const mounted = useRef(false);
     const [nodes, setNodes] = useVariable(props.nodes);
-    const [updateHandler] = useAction(props.on_update);
+    const updateHandler = useAction(props.on_update);
 
     if (mounted.current === false) {
         /**

--- a/packages/dara-components/js/graphs/visual-edge-encoder.tsx
+++ b/packages/dara-components/js/graphs/visual-edge-encoder.tsx
@@ -117,9 +117,9 @@ function VisualEdgeEncoder(props: VisualEdgeEncoderProps): JSX.Element {
 
     const graphLayout = useMemo(() => parseLayoutDefinition(props.graph_layout), []);
 
-    const [onClickEdge] = useAction(props.on_click_edge);
-    const [onClickNode] = useAction(props.on_click_node);
-    const [onUpdate] = useAction(props.on_update);
+    const onClickEdge = useAction(props.on_click_edge);
+    const onClickNode = useAction(props.on_click_node);
+    const onUpdate = useAction(props.on_update);
 
     const formattedDefaultLegends = useMemo(() => {
         return Object.fromEntries(

--- a/packages/dara-components/js/plotting/bokeh/bokeh.tsx
+++ b/packages/dara-components/js/plotting/bokeh/bokeh.tsx
@@ -58,7 +58,7 @@ function Bokeh(props: BokehProps): JSX.Element {
 
     const events: [string, (...args: any) => any][] = [];
 
-    const eventActions: [string, [(value: any) => Promise<void>, boolean]][] = [];
+    const eventActions: [string, (value: any) => Promise<void>][] = [];
 
     if (props.events) {
         for (let i = 0; i < props.events.length; i++) {
@@ -113,7 +113,7 @@ function Bokeh(props: BokehProps): JSX.Element {
             document.removeEventListener(ev, handler);
         });
 
-        eventActions.forEach(([name, [action]]) => {
+        eventActions.forEach(([name, action]) => {
             const handler: EventListener = (e: CustomEvent) => {
                 action(e.detail);
             };

--- a/packages/dara-components/js/plotting/plotly/plotly.tsx
+++ b/packages/dara-components/js/plotting/plotly/plotly.tsx
@@ -304,7 +304,7 @@ function Plotly(props: PlotlyProps): JSX.Element {
             const actions = new Array<ActionEvent>();
             event?.actions.forEach((action) => {
                 // eslint-disable-next-line react-hooks/rules-of-hooks
-                const [actionHandler] = useAction(action);
+                const actionHandler = useAction(action);
                 actions.push({ custom_js: event.custom_js, handler: actionHandler });
             });
             const currentActions = eventActions.get(event.event_name) ?? [];

--- a/packages/dara-components/js/smart/filter-status-button/filter-status-button.tsx
+++ b/packages/dara-components/js/smart/filter-status-button/filter-status-button.tsx
@@ -54,7 +54,7 @@ interface FilterStatusButtonProps {
 
 function FilterStatusButton(props: FilterStatusButtonProps): JSX.Element {
     const [filterStats] = useVariable(props.filter_stats);
-    const [onClick] = useAction(props.on_click);
+    const onClick = useAction(props.on_click);
 
     function clickHandler(): void {
         onClick(null);

--- a/packages/dara-components/js/smart/hierarchy-viewer/hierarchy-viewer.tsx
+++ b/packages/dara-components/js/smart/hierarchy-viewer/hierarchy-viewer.tsx
@@ -18,7 +18,7 @@ const StyledHierarchyViewer = injectCss(UiHierarchyViewer);
 function HierarchyViewer(props: HierarchyViewerProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const hierarchy = useVariable(props.hierarchy)[0];
-    const [onClick] = useAction(props.on_click_node);
+    const onClick = useAction(props.on_click_node);
 
     return (
         <StyledHierarchyViewer

--- a/packages/dara-core/dara/core/base_definitions.py
+++ b/packages/dara-core/dara/core/base_definitions.py
@@ -423,6 +423,17 @@ class AnnotatedAction(BaseModel):
     dynamic_kwargs: Mapping[str, Any]
     """Dynamic kwargs of the action; uid -> variable instance"""
 
+    loading: 'Variable'
+    """Loading Variable instance"""
+
+    def __init__(self, **data):
+        # Resolve the circular dependency to add a loading Variable to the model upon creation
+        # pylint: disable-next=import-error, import-outside-toplevel
+        from dara.core.interactivity.plain_variable import Variable
+
+        self.update_forward_refs(Variable=Variable)
+        super().__init__(**data, loading=Variable(False))
+
 
 class ActionImpl(DaraBaseModel):
     """

--- a/packages/dara-core/dara/core/base_definitions.py
+++ b/packages/dara-core/dara/core/base_definitions.py
@@ -423,7 +423,7 @@ class AnnotatedAction(BaseModel):
     dynamic_kwargs: Mapping[str, Any]
     """Dynamic kwargs of the action; uid -> variable instance"""
 
-    loading: 'Variable'
+    loading: 'Variable' # type: ignore
     """Loading Variable instance"""
 
     def __init__(self, **data):

--- a/packages/dara-core/dara/core/base_definitions.py
+++ b/packages/dara-core/dara/core/base_definitions.py
@@ -423,7 +423,7 @@ class AnnotatedAction(BaseModel):
     dynamic_kwargs: Mapping[str, Any]
     """Dynamic kwargs of the action; uid -> variable instance"""
 
-    loading: 'Variable' # type: ignore
+    loading: 'Variable'   # type: ignore
     """Loading Variable instance"""
 
     def __init__(self, **data):

--- a/packages/dara-core/js/index.tsx
+++ b/packages/dara-core/js/index.tsx
@@ -96,6 +96,7 @@ export {
     DynamicComponent,
     Center,
     useAction,
+    useActionIsLoading,
     useVariable,
     getIcon,
     useDataVariable,

--- a/packages/dara-core/js/shared/index.tsx
+++ b/packages/dara-core/js/shared/index.tsx
@@ -19,6 +19,7 @@ export {
     isJsComponent,
     resolveTheme,
     useAction,
+    useActionIsLoading,
     useComponentRegistry,
     useWindowTitle,
     getIcon,

--- a/packages/dara-core/js/shared/private-route/private-route.tsx
+++ b/packages/dara-core/js/shared/private-route/private-route.tsx
@@ -4,7 +4,7 @@ import { Redirect } from 'react-router-dom';
 
 import { useSessionToken } from '@/auth/auth-context';
 import DefaultFallback from '@/components/fallback/default';
-import useAction from '@/shared/utils/use-action';
+import useAction, { useActionIsLoading } from '@/shared/utils/use-action';
 import useWindowTitle from '@/shared/utils/use-window-title';
 import { Action } from '@/types';
 
@@ -25,7 +25,8 @@ interface PrivateRouteProps {
  */
 function PrivateRoute({ children, on_load, name }: PrivateRouteProps): ReactNode {
     const token = useSessionToken();
-    const [onLoad, isLoading] = useAction(on_load);
+    const onLoad = useAction(on_load);
+    const isLoading = useActionIsLoading(on_load);
 
     useWindowTitle(name);
 

--- a/packages/dara-core/js/shared/utils/index.tsx
+++ b/packages/dara-core/js/shared/utils/index.tsx
@@ -4,7 +4,7 @@ export { default as cleanSessionCache } from './clean-session-cache';
 export { getToken, getTokenKey, DARA_JWT_TOKEN } from './embed';
 export { default as isJsComponent } from './is-js-component';
 export { default as resolveTheme } from './resolve-theme';
-export { default as useAction } from './use-action';
+export { default as useAction, useActionIsLoading } from './use-action';
 export { default as useDeferLoadable } from './use-defer-loadable';
 export { default as useComponentRegistry } from './use-component-registry';
 export { default as useInterval } from './use-interval';

--- a/packages/dara-core/js/shared/utils/use-action.tsx
+++ b/packages/dara-core/js/shared/utils/use-action.tsx
@@ -272,7 +272,7 @@ export function useActionIsLoading(action: Action): boolean {
     // component lifetime. As ActionImpls have no loading variable we return false. As we expect to deprecate array's
     // of actions in the near future as all the functionality then we return false as well due to the complexity of
     // extracting potentially multiple annotated actions out of the array and resolving all their loading states
-    if (isActionImpl(action) || Array.isArray(action)) {
+    if (!action || isActionImpl(action) || Array.isArray(action)) {
         return false;
     }
     return useVariable(action.loading)[0];

--- a/packages/dara-core/js/shared/utils/use-action.tsx
+++ b/packages/dara-core/js/shared/utils/use-action.tsx
@@ -15,6 +15,8 @@ import { Action, ActionHandler } from '@/types';
 import { ActionContext, ActionDef, ActionImpl, AnnotatedAction } from '@/types/core';
 import { isActionImpl } from '@/types/utils';
 
+import { useVariable } from '../interactivity';
+import { getOrRegisterPlainVariable } from '../interactivity/plain-variable';
 import { resolveVariable } from '../interactivity/resolve-variable';
 import { normalizeRequest } from './normalization';
 import useActionRegistry from './use-action-registry';
@@ -257,6 +259,25 @@ async function executeAction(
 
 const noop = (): Promise<void> => Promise.resolve();
 
+/**
+ * The useActionIsLoading hook returns a boolean indicating whether the action is currently in progress. This is
+ * currently only supported for single AnnotatedAction instances of actions and will return false in all other cases
+ * due to the lack of loading variable to use as a source of truth.
+ *
+ * @param action - the action to check the loading state of
+ * @returns the loading state of the action
+ */
+export function useActionIsLoading(action: Action): boolean {
+    // We allow conditional logic with hooks here under the assumption that the action will never change during the
+    // component lifetime. As ActionImpls have no loading variable we return false. As we expect to deprecate array's
+    // of actions in the near future as all the functionality then we return false as well due to the complexity of
+    // extracting potentially multiple annotated actions out of the array and resolving all their loading states
+    if (isActionImpl(action) || Array.isArray(action)) {
+        return false;
+    }
+    return useVariable(action.loading)[0];
+}
+
 interface UseActionOptions {
     /**
      * Callback to invoke when an unhandled action is encountered.
@@ -274,10 +295,7 @@ interface UseActionOptions {
  * @param action the action passed in
  * @param options optional extra options for the hook
  */
-export default function useAction(
-    action: Action,
-    options?: UseActionOptions
-): [(input?: any) => Promise<void>, boolean] {
+export default function useAction(action: Action, options?: UseActionOptions): (input?: any) => Promise<void> {
     const { client: wsClient } = useContext(WebSocketCtx);
     const importers = useContext(ImportersCtx);
     const { get: getAction } = useActionRegistry();
@@ -286,7 +304,6 @@ export default function useAction(
     const history = useHistory();
     const taskCtx = useTaskContext();
     const location = useLocation();
-    const [isLoading, setIsLoading] = useState(false);
 
     // keep actionCtx in a ref to avoid re-creating the callbacks
     const actionCtx = useRef<Omit<ActionContext, keyof CallbackInterface | 'input'>>();
@@ -304,12 +321,19 @@ export default function useAction(
 
     const callback = useRecoilCallback(
         (cbInterface) => async (input: any) => {
-            setIsLoading(true);
-
             const actionsToExecute = Array.isArray(action) ? action : [action];
 
             // execute actions sequentially
             for (const actionToExecute of actionsToExecute) {
+                const loadingVariable =
+                    !isActionImpl(actionToExecute) ?
+                        getOrRegisterPlainVariable(actionToExecute.loading, wsClient, taskCtx, extras)
+                    :   null;
+
+                if (loadingVariable) {
+                    cbInterface.set(loadingVariable, true);
+                }
+
                 // this is redefined for each action to have up-to-date snapshot
                 const fullActionContext: ActionContext = {
                     ...actionCtx.current,
@@ -346,17 +370,19 @@ export default function useAction(
                         title: 'Error executing action',
                     });
                 }
-            }
 
-            setIsLoading(false);
+                if (loadingVariable) {
+                    cbInterface.set(loadingVariable, false);
+                }
+            }
         },
         [action, getAction, importers]
     );
 
     // return a noop if no action is passed
     if (!action) {
-        return [noop, false];
+        return noop;
     }
 
-    return [callback, isLoading];
+    return callback;
 }

--- a/packages/dara-core/js/shared/utils/use-action.tsx
+++ b/packages/dara-core/js/shared/utils/use-action.tsx
@@ -1,4 +1,4 @@
-import { useContext, useRef, useState } from 'react';
+import { useContext, useRef } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { CallbackInterface, useRecoilCallback } from 'recoil';
 import { Subscription } from 'rxjs';
@@ -275,6 +275,7 @@ export function useActionIsLoading(action: Action): boolean {
     if (!action || isActionImpl(action) || Array.isArray(action)) {
         return false;
     }
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     return useVariable(action.loading)[0];
 }
 

--- a/packages/dara-core/js/types/core.tsx
+++ b/packages/dara-core/js/types/core.tsx
@@ -434,6 +434,10 @@ export interface AnnotatedAction {
      * Dynamic kwargs passed to the action
      */
     dynamic_kwargs: Record<string, AnyVariable<any>>;
+    /**
+     * Loading Variable instance so we can update listening components when the action is running.
+     */
+    loading: SingleVariable<boolean>;
 }
 
 export type Action = AnnotatedAction | ActionImpl | Array<AnnotatedAction | ActionImpl>;

--- a/packages/dara-core/tests/js/dynamic-component.spec.tsx
+++ b/packages/dara-core/tests/js/dynamic-component.spec.tsx
@@ -148,7 +148,7 @@ describe('DynamicComponent', () => {
                 props: {
                     content: value,
                 },
-            }
+            },
         });
     });
 
@@ -486,7 +486,7 @@ describe('DynamicComponent', () => {
         const MockComponent = (props: { action: Action; varA: Variable<any>; varB: Variable<any> }): JSX.Element => {
             const [a, setA] = useVariable<number>(props.varA);
             const [b, setB] = useVariable<number>(props.varB);
-            const [callAction] = useAction(props.action);
+            const callAction = useAction(props.action);
 
             return (
                 <>
@@ -595,7 +595,7 @@ describe('DynamicComponent', () => {
         // Custom mock component version
         const MockComponentTrigger = (props: { action: Action; variableA: Variable<any> }): JSX.Element => {
             const [a, setA] = useVariable<number>(props.variableA);
-            const [callAction] = useAction(props.action);
+            const callAction = useAction(props.action);
 
             return (
                 <>
@@ -1118,7 +1118,7 @@ describe('DynamicComponent', () => {
         const MockComponent = (props: { action: Action; varA: Variable<any>; varB: Variable<any> }): JSX.Element => {
             const [a, setA] = useVariable<number>(props.varA);
             const [b, setB] = useVariable<number>(props.varB);
-            const [callAction] = useAction(props.action);
+            const callAction = useAction(props.action);
 
             return (
                 <>

--- a/packages/dara-core/tests/js/use-action.spec.tsx
+++ b/packages/dara-core/tests/js/use-action.spec.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 import { INPUT, TOGGLE } from '@/actions/update-variable';
 import { clearRegistries_TEST } from '@/shared/interactivity/store';
-import { clearActionHandlerCache_TEST } from '@/shared/utils/use-action';
+import { clearActionHandlerCache_TEST, useActionIsLoading } from '@/shared/utils/use-action';
 
 import { useAction, useVariable } from '../../js/shared';
 import {
@@ -22,6 +22,13 @@ import {
     Variable,
 } from '../../js/types/core';
 import { MockWebSocketClient, Wrapper, server, wrappedRender } from './utils';
+
+const LOADING_VARIABLE: SingleVariable<boolean> = {
+    __typename: 'Variable',
+    default: false,
+    nested: [],
+    uid: 'loading_uid',
+};
 
 describe('useAction', () => {
     beforeEach(() => {
@@ -52,8 +59,7 @@ describe('useAction', () => {
         );
 
         await waitFor(() => {
-            expect(result.current[0]).toBeInstanceOf(Function);
-            expect(result.current[1]).toEqual(false);
+            expect(result.current).toBeInstanceOf(Function);
         });
     });
 
@@ -72,11 +78,11 @@ describe('useAction', () => {
             { wrapper: ({ children }) => <Wrapper history={history}>{children}</Wrapper> }
         );
         await waitFor(() => {
-            expect(result.current[0]).toBeInstanceOf(Function);
+            expect(result.current).toBeInstanceOf(Function);
         });
 
         act(() => {
-            result.current[0](null);
+            result.current(null);
         });
         await waitFor(() => expect(history.location.pathname).toBe('/simple/url'));
     });
@@ -98,7 +104,7 @@ describe('useAction', () => {
 
         const MockComponent = (props: { action: Action; var: Variable<any> }): JSX.Element => {
             const [a] = useVariable(props.var);
-            const [update] = useAction(props.action);
+            const update = useAction(props.action);
 
             return (
                 <>
@@ -148,7 +154,8 @@ describe('useAction', () => {
         };
 
         const MockComponent = (props: { action: Action }): JSX.Element => {
-            const [update, loading] = useAction(props.action);
+            const update = useAction(props.action);
+            const loading = useActionIsLoading(props.action);
             const [renderVariable, setRenderVariable] = useState(false);
 
             return (
@@ -223,8 +230,8 @@ describe('useAction', () => {
 
         const MockComponent = (): JSX.Element => {
             const [a] = useVariable(variable);
-            const [updateNested] = useAction(actionNested);
-            const [updateInnerNested] = useAction(actionInnerNested);
+            const updateNested = useAction(actionNested);
+            const updateInnerNested = useAction(actionInnerNested);
 
             return (
                 <>
@@ -284,7 +291,7 @@ describe('useAction', () => {
 
         const MockComponent = (): JSX.Element => {
             const [a] = useVariable(variable);
-            const [update] = useAction(action);
+            const update = useAction(action);
 
             return (
                 <>
@@ -350,8 +357,8 @@ describe('useAction', () => {
 
         const MockComponent = (): JSX.Element => {
             const [a] = useVariable(variable);
-            const [updateNested] = useAction(actionNested);
-            const [updateInnerNested] = useAction(actionInnerNested);
+            const updateNested = useAction(actionNested);
+            const updateInnerNested = useAction(actionInnerNested);
 
             return (
                 <>
@@ -409,7 +416,7 @@ describe('useAction', () => {
 
         const MockComponent = (): JSX.Element => {
             const [a] = useVariable(variable);
-            const [update] = useAction(action);
+            const update = useAction(action);
 
             return (
                 <>
@@ -475,8 +482,8 @@ describe('useAction', () => {
 
         const MockComponent = (): JSX.Element => {
             const [a] = useVariable(variable);
-            const [updateNested] = useAction(actionNested);
-            const [updateInnerNested] = useAction(actionInnerNested);
+            const updateNested = useAction(actionNested);
+            const updateInnerNested = useAction(actionInnerNested);
 
             return (
                 <>
@@ -537,7 +544,7 @@ describe('useAction', () => {
 
         const MockComponent = (props: { action: Action; var: Variable<any> }): JSX.Element => {
             const [a] = useVariable(props.var);
-            const [update] = useAction(props.action);
+            const update = useAction(props.action);
 
             return (
                 <>
@@ -597,7 +604,7 @@ describe('useAction', () => {
         const MockComponent = (props: { action: Action; var1: Variable<any>; var2: Variable<any> }): JSX.Element => {
             const [a] = useVariable(props.var1);
             const [b] = useVariable(props.var2);
-            const [update] = useAction(props.action);
+            const update = useAction(props.action);
 
             return (
                 <>
@@ -676,12 +683,13 @@ describe('useAction', () => {
                 var: variableResult,
                 var2: dataVariableResult,
             },
+            loading: LOADING_VARIABLE,
             uid: 'uid',
         };
 
         const MockComponent = (props: { action: Action; var: Variable<any> }): JSX.Element => {
             const [a] = useVariable(props.var);
-            const [update] = useAction(props.action);
+            const update = useAction(props.action);
 
             return (
                 <>
@@ -796,8 +804,8 @@ describe('useAction', () => {
             var: Variable<any>;
         }): JSX.Element => {
             const [a] = useVariable(props.var);
-            const [reset] = useAction(props.resetAction);
-            const [update] = useAction(props.updateAction);
+            const reset = useAction(props.resetAction);
+            const update = useAction(props.updateAction);
 
             return (
                 <>
@@ -868,13 +876,12 @@ describe('useAction', () => {
         );
 
         await waitFor(() => {
-            expect(result.current[0]).toBeInstanceOf(Function);
-            expect(result.current[1]).toEqual(false);
+            expect(result.current).toBeInstanceOf(Function);
         });
 
         // Call the action handler
         await act(async () => {
-            await result.current[0]('input');
+            await result.current('input');
         });
 
         // There should be two calls to onUnhandledAction
@@ -930,6 +937,7 @@ describe('useAction', () => {
             dynamic_kwargs: {
                 foo: variable,
             },
+            loading: LOADING_VARIABLE,
             uid: 'uid',
         };
 
@@ -938,10 +946,13 @@ describe('useAction', () => {
         const wsClient = new MockWebSocketClient('uid');
 
         const { result } = renderHook(
-            () =>
-                useAction(annotated, {
+            (): [(input?: any) => Promise<void>, boolean] => {
+                const action = useAction(annotated, {
                     onUnhandledAction,
-                }),
+                });
+                const isLoading = useActionIsLoading(annotated);
+                return [action, isLoading];
+            },
             { wrapper: ({ children }) => <Wrapper client={wsClient}>{children}</Wrapper> }
         );
 

--- a/packages/dara-core/tests/js/use-variable.spec.tsx
+++ b/packages/dara-core/tests/js/use-variable.spec.tsx
@@ -658,7 +658,7 @@ describe('useVariable', () => {
             } satisfies DerivedVariable;
             const receivedData: Array<DaraEventMap['DERIVED_VARIABLE_LOADED']> = [];
 
-            const { result} = renderHook(() => useVariable<string>(variable), {
+            const { result } = renderHook(() => useVariable<string>(variable), {
                 wrapper: (props) => (
                     <EventCapturer
                         onEvent={(ev) => {
@@ -677,7 +677,7 @@ describe('useVariable', () => {
             expect(receivedData[0].variable).toEqual(variable);
             expect(receivedData[0].value).toEqual({
                 value: result.current[0],
-                cache_key: expect.any(String)
+                cache_key: expect.any(String),
             });
         });
 
@@ -1154,7 +1154,7 @@ describe('useVariable', () => {
                 const [a, setA] = useVariable(props.variableA);
                 const [b, setB] = useVariable(props.variableB);
                 const [c] = useVariable(props.derivedVar);
-                const [callAction] = useAction(props.action);
+                const callAction = useAction(props.action);
 
                 return (
                     <div>
@@ -1263,7 +1263,7 @@ describe('useVariable', () => {
                 variableA: Variable<any>;
             }): JSX.Element => {
                 const [a, setA] = useVariable(props.variableA);
-                const [callAction] = useAction(props.action);
+                const callAction = useAction(props.action);
                 const [c] = useVariable(props.derivedVar);
 
                 return (


### PR DESCRIPTION
## Motivation and Context
* Whilst not a massive performance issue in itself, useAction had a loading state that would trigger the component consuming the action to redraw whenever the action was called. The issue is that in a lot of cases useAction could be consumed near the top of component trees and in react contexts. This would lead to large tree re-resolutions whenever actions were run.

## Implementation Description
* To address this, we've moved the loading state of the action to be a Variable. A second hook "useActionIsLoading" has then be added so that any component that really cares about the loading state can still consume it easily.
* The added benefit here is now that `action.loading` can be consumed on the python side to conditionally alter other elements without needing py_components or hooking into the JS.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Covered by existing unit tests. Modifications made to account for the new api in a couple of places.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
A couple of performance traces of before and after this change. There's more work to do on this, but this is a good start.

Before:
<img width="1004" alt="Screenshot 2024-05-07 at 16 25 36" src="https://github.com/causalens/dara/assets/58470795/f88d7494-7e05-4f47-a70c-e1bc81545d6c">

After (this one ran much more of the notebook in a similar time due to the speedup):
<img width="959" alt="Screenshot 2024-05-07 at 16 25 57" src="https://github.com/causalens/dara/assets/58470795/09869442-41b6-47b2-8afd-ddd14ed876e4">

