### PR TITLE
Fix: DOS-1010 Fix the websocket reconnection so this.socket is correct

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,24 +2,6 @@
 title: Changelog
 ---
 
-## NEXT
-
--   Updated AnnotatedAction to have a `loading` property that is automatically set to be a Variable[bool] instance tracking the loading state of the action. The example below shows how you can disable a button whilst the action it triggers is running.
-
-```python
-from dara.core import action
-from dara.components import Button
-
-@action
-def on_click(ctx: action.Ctx):
-    # Do Something...
-
-on_click_action = on_click()
-Button('Click Me', onclick=on_click_action, disabled=on_click_action.loading)
-```
-
--   On the JS Api side the `useAction` hook has been changed to only return the action function rather than a tuple of `[action_fn, isLoading]`. To retrieve the loading state a new hook `useActionIsLoading` now returns the isLoading state of the action as a piece of react state that will trigger redraws when its value changes.
-
 ## 1.8.6
 
 -   Fixed an issue where `Chat` button looked off centre on different base font size apps.

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Further fix for the websocket reconnection logic that meant the socket class wasn't updated after re-initialization which meant that message sends were routed to the old socket rather than the new one.
+
 ## 1.8.5
 
 -   Internal (JS): add `EventBus` events for resolving data variables

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -5,6 +5,21 @@ title: Changelog
 ## NEXT
 
 -   Further fix for the websocket reconnection logic that meant the socket class wasn't updated after re-initialization which meant that message sends were routed to the old socket rather than the new one.
+-   Updated AnnotatedAction to have a `loading` property that is automatically set to be a Variable[bool] instance tracking the loading state of the action. The example below shows how you can disable a button whilst the action it triggers is running.
+
+```python
+from dara.core import action
+from dara.components import Button
+
+@action
+def on_click(ctx: action.Ctx):
+    # Do Something...
+
+on_click_action = on_click()
+Button('Click Me', onclick=on_click_action, disabled=on_click_action.loading)
+```
+
+-   On the JS Api side the `useAction` hook has been changed to only return the action function rather than a tuple of `[action_fn, isLoading]`. To retrieve the loading state a new hook `useActionIsLoading` now returns the isLoading state of the action as a piece of react state that will trigger redraws when its value changes.
 
 ## 1.8.5
 

--- a/packages/dara-core/js/api/websocket.tsx
+++ b/packages/dara-core/js/api/websocket.tsx
@@ -267,7 +267,7 @@ export class WebSocketClient implements WebSocketClientInterface {
                 if (document.visibilityState === 'visible') {
                     // Reset the retry loop and attempt to initialize the socket again
                     this.#reconnectCount = 0;
-                    this.initialize();
+                    this.socket = this.initialize();
 
                     // Remove the visibility change listener after we enter the retry loop again
                     document.removeEventListener('visibilitychange', handler);
@@ -278,7 +278,7 @@ export class WebSocketClient implements WebSocketClientInterface {
         }
         setTimeout(() => {
             this.#reconnectCount++;
-            this.initialize(true);
+            this.socket = this.initialize(true);
         }, interAttemptTimeout);
     }
 

--- a/packages/dara-core/tests/js/websocket.spec.tsx
+++ b/packages/dara-core/tests/js/websocket.spec.tsx
@@ -100,6 +100,16 @@ describe('WebsocketClient', () => {
 
         // Check that the client has reconnected
         expect(await client.channel).toEqual('test_1');
+
+        const messagePromise = serverNew.nextMessage;
+
+        // Check that we can still send messages
+        client.sendMessage({ message: 'test' }, 'channel');
+
+        // Check that the message was received
+        expect(await messagePromise).toEqual(
+            '{"channel":"channel","chunk_count":null,"message":{"message":"test"},"type":"message"}'
+        );
     });
 
     it('should attempt to reconnect to the server multiple times if the initial one fails', async () => {


### PR DESCRIPTION
## Motivation and Context
* Found more bugs with the reconnection logic that reconnected the streams properly, but no messages could be sent back which broke most things.

## Implementation Description
* Previous change was refactored late on to have initialize return the new socket rather than setting it. This was not properly applied in the reconnect logic so we ended up with the stale socket on the class so no messages could be sent.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Unit test extended to cover it

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.
