### PR TITLE
Fix: DO-2768 checkbox group and radio group docs

### DIFF
--- a/packages/dara-components/dara/components/common/checkbox_group.py
+++ b/packages/dara-components/dara/components/common/checkbox_group.py
@@ -50,7 +50,7 @@ class CheckboxGroup(FormComponent):
 
     ```python
     from dara.core import Variable
-    from dara.components.common import CheckboxGroup
+    from dara.components.common import CheckboxGroup, Item
 
     CheckboxGroup(
         items=[Item(label='first',value=1), Item(label='second',value=2)],

--- a/packages/dara-components/dara/components/common/checkbox_group.py
+++ b/packages/dara-components/dara/components/common/checkbox_group.py
@@ -46,6 +46,18 @@ class CheckboxGroup(FormComponent):
     )
     ```
 
+    CheckboxGroup with items with custom labels and values:
+
+    ```python
+    from dara.core import Variable
+    from dara.components.common import CheckboxGroup
+
+    CheckboxGroup(
+        items=[Item(label='first',value=1), Item(label='second',value=2)],
+        value=Variable(1),
+    )
+    ```
+
     CheckboxGroup component with at most two values selectable at a time:
 
     ```python

--- a/packages/dara-components/dara/components/common/radio_group.py
+++ b/packages/dara-components/dara/components/common/radio_group.py
@@ -48,7 +48,7 @@ class RadioGroup(FormComponent):
     # or as an `Item` list
     RadioGroup(
         items=[Item(label='first',value=1), Item(label='second',value=2)],
-        value=Variable('first'),
+        value=Variable(1),
     )
     ```
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

It's been reported that CheckboxGroup does not work properly in a following scenario:

```python
from dara.core import Variable
from dara.components.common import CheckboxGroup
from dara.components import Item

item1 = Item(value=1, label='foo')
item2 = Item(value=2, label='bar')

CheckboxGroup(
    items=[item1, item2],
    value=Variable([item1]),
)
```

It turns out this example works if we change the following:

```
CheckboxGroup(
    items=[item1, item2],
-    value=Variable([item1]),
+    value=Variable([1]),
)
```

This is a matter of a missing example in the docstring. The behaviour is consistent with other Select and Radio components - the `value` prop keeps track of the `value` selected, not the entire item. 

This PR fixes the CheckboxGroup and RadioGroup docs to correctly show this behaviour in examples.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested the behaviour locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->