### PR TITLE
Fix: DO-3014 multiselect value outside of items

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -6,6 +6,7 @@ title: Changelog
 
 -   Fixed an issue with `Card` where its content would render with zero height in some scenarios due to a missing `flex-grow` property.
 -   Clarified docs for `CausalGraphViewer`'s `editor_mode` prop.
+-   Fixed an issue where `value` of `Select(multiselect=True, ...)` value would not be displayed even when it's outside the items list.
 
 ## 1.8.6
 

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -159,7 +159,7 @@ function Select(props: SelectProps): JSX.Element {
     const itemArray = formattedItems as Array<Item>;
 
     if (props.multiselect) {
-        const explicitValues = useMemo(() => isArray(value) ? value.map(toItem) : value, [value]);
+        const explicitValues = useMemo(() => (isArray(value) ? value.map(toItem) : value), [value]);
         const foundItems = getMultiselectItems(value, itemArray);
         const [selectedItems, setSelectedItems] = useState(isEmpty(foundItems) ? explicitValues : foundItems);
         const onSelect = useCallback(
@@ -177,7 +177,7 @@ function Select(props: SelectProps): JSX.Element {
         // the race condition and respect the main value if it is updated elsewhere.
         useEffect(() => {
             const found = getMultiselectItems(value, itemArray);
-            setSelectedItems(isEmpty(found) ? (explicitValues ?? null) : found);
+            setSelectedItems(isEmpty(found) ? explicitValues ?? null : found);
         }, [formattedItems, value]);
         return (
             <StyledMultiSelect

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -157,8 +157,9 @@ function Select(props: SelectProps): JSX.Element {
 
     // We need to redefine items as the type is not known at this point
     const itemArray = formattedItems as Array<Item>;
+
     if (props.multiselect) {
-        const explicitValues = isArray(value) ? value.map(toItem) : value;
+        const explicitValues = useMemo(() => isArray(value) ? value.map(toItem) : value, [value]);
         const foundItems = getMultiselectItems(value, itemArray);
         const [selectedItems, setSelectedItems] = useState(isEmpty(foundItems) ? explicitValues : foundItems);
         const onSelect = useCallback(
@@ -175,7 +176,8 @@ function Select(props: SelectProps): JSX.Element {
         // it fail to update the value sometimes. By keeping a local copy of the value and updating it like this we fix
         // the race condition and respect the main value if it is updated elsewhere.
         useEffect(() => {
-            setSelectedItems(getMultiselectItems(value, itemArray));
+            const found = getMultiselectItems(value, itemArray);
+            setSelectedItems(isEmpty(found) ? explicitValues : found);
         }, [formattedItems, value]);
         return (
             <StyledMultiSelect

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -177,7 +177,7 @@ function Select(props: SelectProps): JSX.Element {
         // the race condition and respect the main value if it is updated elsewhere.
         useEffect(() => {
             const found = getMultiselectItems(value, itemArray);
-            setSelectedItems(isEmpty(found) ? explicitValues : found);
+            setSelectedItems(isEmpty(found) ? (explicitValues ?? null) : found);
         }, [formattedItems, value]);
         return (
             <StyledMultiSelect


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Just like `Select`, it was intended that select with `multiselect=True` should display its `value` as a fallback even when the items are not in the `items` list.

There was a minor bug which caused the effect to wipe the selected items after the initial render.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

```py
config.add_page('test', Select(multiselect=True, items=Variable([]), value=Variable(['one'])))
```


https://github.com/causalens/dara/assets/87647189/72971883-0f52-4c56-9eee-f3992bb56997



## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->