### PR TITLE
Fix: DO-3050 DerivedDataVariable leaking PendingValue to userspace

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where in some cases a `DerivedDataVariable` would be invoked with an internal `PendingValue`
+
 ## 1.9.1
 
 -   Fixed an issue where desired pathname + search params were not retained when redirected to the login page and then back to the original page


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

It's been reported that in some cases DerivedDataVariable (DDV) can be invoked with a `PendingValue`, an internal Dara store value which represents a started computation. Upon investigation, this could happen in a scenario such as:
- a DDV computation is invoked and finished, resolving to a cache key to query data from
- another computation is invoked for the same set of inputs
- while the second computation is ongoing, a query for the data is made against the cache key

This caused the data query to retrieve a `PendingValue` from the store which was inserted there by the second computation. 

The fix was to handle that case and await the computation resolution.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

As part of the investigation I spotted another issue where a cache eviction could get 'inbetween' the derived and query parts of the DDV, causing the DDV to resolve to None and error. I've added a `pin` to the derived part of the query which should ensure the cache entry won't be evicted at the very least until the data is read back.

There can still be rare edge cases where multiple subsequent queries and recomputations can cause an eviction of a data point which is being queried. They should be minor enough that I decided not to look into them too deeply for now. A potential solution would involve tying in the Data and Derived parts of the caching in some way. Perhaps a rework of the DataVariable APIs (which has been in plans, longer term) can solve it in a different way.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added two unit tests, recreating the scenarios which broke beforehand.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->