### PR TITLE
Fix: DO-3172 numeric input none value is inconsistent

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where `Input` of type number would return `NaN` instead of `None` within actions.
+
 ## 1.10.3
 
 -   Fixed an issue where `onchange` would not fire for `Input` and `Textarea` components in some cases

--- a/packages/dara-components/js/common/input/input.tsx
+++ b/packages/dara-components/js/common/input/input.tsx
@@ -47,12 +47,12 @@ function Input(props: InputProps): JSX.Element {
         if (props.type === 'number') {
             newValue = getNumericValue(newValue);
         }
-        // Immmediately update internal state
+        // Immediately update internal state
         setInternalValue(newValue);
         // Debounce the update to the variable and the form to prevent multiple updates being fired at once
         debouncedSetValue(newValue);
-        debouncedAction(val);
-        debouncedUpdateForm(val);
+        debouncedAction(newValue);
+        debouncedUpdateForm(newValue);
     }
 
     useEffect(() => {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Issue was found when emptying a numeric input. Its value as stored in the variable was `None`, whereas in an action `ctx.input` returned `NaN`. 

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
We convert the value based on whether the input is numeric, however we were not passing this new value to the action

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->