### PR TITLE
Fix: DO-3494: Fix race conditon in registry entry registration

### DIFF
--- a/packages/dara-core/dara/core/internal/registry_lookup.py
+++ b/packages/dara-core/dara/core/internal/registry_lookup.py
@@ -55,6 +55,9 @@ class RegistryLookup:
             if registry.name in self.handlers:
                 func = self.handlers[registry.name]  # type: ignore
                 entry = await func(uid)
+                # If something else registered the entry while we were waiting, return that
+                if registry.has(uid):
+                    return registry.get(uid)
                 registry.register(uid, entry)
                 return entry
             raise ValueError(


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
When an entry is not found in the registry, we execute the handler to get the result and register it. While we execute the handler, something else might already register that specific entry, so before explicitly registering it again and getting an error we check it and only register it if it's still missing. Since registry is a dict, both `.get` and `.register` are atomic.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->