### PR TITLE
Fix: DO-3658: Fix Table non-unique index values, fix sorting by unnamed index

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed a crash in `Table` pagination where rows containing non-unique index values would cause a slicing error.
+-   Fixed an issue in `Table` where sorting by an unnamed index would not work.
+
 ## 1.12.6
 
 -   Fix an issue where LRU cache could result in a `KeyError`

--- a/packages/dara-core/dara/core/interactivity/filtering.py
+++ b/packages/dara-core/dara/core/interactivity/filtering.py
@@ -274,14 +274,16 @@ def apply_filters(
                 order_by = order_by[1:]
                 ascending = False
 
-            new_data = new_data.sort_values(
-                by=re.sub(COLUMN_PREFIX_REGEX, '', order_by), ascending=ascending, inplace=False
-            )
+            col = re.sub(COLUMN_PREFIX_REGEX, '', order_by)
+            if col == 'index':
+                new_data = new_data.sort_index(ascending=ascending, inplace=False)
+            else:
+                new_data = new_data.sort_values(by=col, ascending=ascending, inplace=False)
 
         # PAGINATE
         start_index = pagination.offset if pagination.offset is not None else 0
         stop_index = start_index + pagination.limit if pagination.limit is not None else total_count
 
-        new_data = new_data[start_index:stop_index]
+        new_data = new_data.iloc[start_index:stop_index]
 
     return new_data, total_count


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
-   Fixed a crash in `Table` pagination where rows containing non-unique index values would cause a slicing error, as rows were paginated by DataFrame index instead of `iloc` row ordering.
-   Fixed an issue in `Table` where sorting by an unnamed index would not work, as the default `__index__` unnamed index column does not exist in the original DataFrame.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->