### PR TITLE
Fix: DO-3770 add min width to causal graph viewer

### DIFF
--- a/packages/ui-causal-graph-editor/changelog.md
+++ b/packages/ui-causal-graph-editor/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Added a `min-with` to `CausalGraphEditor`.
+
 ## 1.12.7
 
 -   Fix an issue where body's `line-height` was not consistent across packages.

--- a/packages/ui-causal-graph-editor/changelog.md
+++ b/packages/ui-causal-graph-editor/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## NEXT
 
--   Added a `min-with` to `CausalGraphEditor`.
+-   Added a `min-width` to `CausalGraphEditor`.
 
 ## 1.12.7
 

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -106,8 +106,9 @@ const GraphPane = styled.div<{ $hasFocus: boolean }>`
     flex: 1 1 auto;
     flex-direction: column;
 
-    /* We set a minHeight so that at least some of the graph will always appear within the container */
+    /* We set a minHeight/minWidth so that at least some of the graph will always appear within the container */
     min-height: 100px;
+    min-width: 100px;
 
     border: 2px solid transparent;
     border-color: ${(props) => (props.$hasFocus ? props.theme.colors.grey3 : 'transparent')};


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
In some cases where you had a `CausalGraphViewer` next to a `Card` it would render with 0 width, making it confusing for users to understand that it was there and how to fix it.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Similarly to how we do for height, added a `min-width` of `100px`, just so it renders with something, from there it is easy for a user to update this value if needed.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->