### PR TITLE
Fix: DO-3828 table showing wrong dates

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,9 @@
 title: Changelog
 ---
 
+## NEXT
+-   Fixes an issue where `Table` would sometimes convert timestamps in seconds as if they were in milliseconds.
+
 ## 1.12.3
 
 -   Fixed an issue where `Table` filters and column sorting would not work correctly due to a prefix in column names.

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -450,7 +450,15 @@ function Table(props: TableProps): JSX.Element {
                     for (const val of datetimeColumns) {
                         // Format datetime timestamps to dates
                         if (typeof row[val] === 'number') {
-                            row[val] = formatISO(row[val]);
+                            let timestamp = row[val];
+                            if (timestamp < 1e12) {
+                                // Likely in seconds 
+                                timestamp = timestamp * 1_000;  // Convert to milliseconds
+                            } else if (timestamp > 1e15) {
+                                // Likely in nanoseconds
+                                timestamp = timestamp / 1_000_000;  // Convert to milliseconds
+                            }
+                            row[val] = formatISO(new Date(timestamp));
                         }
                     }
 
@@ -570,7 +578,7 @@ function Table(props: TableProps): JSX.Element {
                     })),
                     combinator: 'OR',
                 }
-            :   null;
+                : null;
 
         debouncedSetSearchQuery(newSearchQuery);
     };

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -452,11 +452,11 @@ function Table(props: TableProps): JSX.Element {
                         if (typeof row[val] === 'number') {
                             let timestamp = row[val];
                             if (timestamp < 1e12) {
-                                // Likely in seconds 
-                                timestamp = timestamp * 1_000;  // Convert to milliseconds
+                                // Likely in seconds
+                                timestamp *= 1_000; // Convert to milliseconds
                             } else if (timestamp > 1e15) {
                                 // Likely in nanoseconds
-                                timestamp = timestamp / 1_000_000;  // Convert to milliseconds
+                                timestamp /= 1_000_000; // Convert to milliseconds
                             }
                             row[val] = formatISO(new Date(timestamp));
                         }
@@ -578,7 +578,7 @@ function Table(props: TableProps): JSX.Element {
                     })),
                     combinator: 'OR',
                 }
-                : null;
+            :   null;
 
         debouncedSetSearchQuery(newSearchQuery);
     };


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
User found that with their dataset the timestamp column showed with dates in 1970s whereas when printing with pandas these were correctly inferred to be in 2023.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
It seems that in this case the column had timestamps in seconds. When we tried to get the corresponding dates with `formatISO` we assumed the timestamp is given in ms. I have updated this to now consider that the timestamp might be in seconds or nanoseconds and convert accordingly.

Limitations with this approach:
- If dates go beyond the year 33658 then dates would be wrongly inferred as ms will reach 1e15 and seconds reach the ms range. This seems unlikely for vast majority of what might be fed to the table component, so seemed like an ok assumption.

- We also don't take into account microseconds. I don't think it is that commonly used, but can add if we think it might be.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally with some test data

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->