### PR TITLE
Fix: DO-3869 input component bug

### DIFF
--- a/packages/ui-components/changelog.md
+++ b/packages/ui-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue with `NumericInput` where in controlled mode if number ended in `.` this could not be erased.
+
 ## 1.12.7
 
 -   Fix an issue where body's `line-height` was not consistent across packages.

--- a/packages/ui-components/src/numeric-input/numeric-input.spec.tsx
+++ b/packages/ui-components/src/numeric-input/numeric-input.spec.tsx
@@ -32,6 +32,16 @@ function RenderNumericInput(props: NumericInputProps): JSX.Element {
     );
 }
 
+const MockControlledNumericInput = (): JSX.Element => {
+    const [value, setValue] = React.useState();
+
+    const handleChange = (newValue): void => {
+        setValue(newValue);
+    };
+
+    return <RenderNumericInput value={value} onChange={handleChange} />;
+};
+
 describe('Numeric Input', () => {
     beforeEach(() => {
         jest.clearAllMocks();
@@ -93,6 +103,17 @@ describe('Numeric Input', () => {
 
         userEvent.click(stepUpButton);
         expect(input).toHaveValue('5');
+    });
+
+    it('should erase . if decimal value was not fully entered', async () => {
+        const { getByRole } = render(<MockControlledNumericInput />);
+        const input = getByRole('textbox', { hidden: true });
+
+        await userEvent.type(input, '10.', { delay: 1 });
+        expect(input).toHaveValue('10.');
+
+        userEvent.keyboard('{backspace}');
+        expect(input).toHaveValue('10');
     });
 
     it('should listen to changes to input', async () => {

--- a/packages/ui-components/src/numeric-input/numeric-input.stories.tsx
+++ b/packages/ui-components/src/numeric-input/numeric-input.stories.tsx
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 import { Meta } from '@storybook/react';
+import * as React from 'react';
 
 import { default as NumericInputComponent, NumericInputProps } from './numeric-input';
 
@@ -26,5 +27,17 @@ export default {
 export const NumericInput = (args: NumericInputProps): JSX.Element => <NumericInputComponent {...args} />;
 
 NumericInput.args = {
+    stepper: true,
+} as NumericInputProps;
+
+export const ControlledNumericInput = (args: NumericInputProps): JSX.Element => {
+    const [value, setValue] = React.useState<number | undefined>(undefined);
+    args.onChange = setValue;
+    args.value = value;
+
+    return <NumericInputComponent {...args} />;
+};
+
+ControlledNumericInput.args = {
     stepper: true,
 } as NumericInputProps;

--- a/packages/ui-components/src/numeric-input/numeric-input.tsx
+++ b/packages/ui-components/src/numeric-input/numeric-input.tsx
@@ -232,6 +232,9 @@ const NumericInput = React.forwardRef<HTMLInputElement, NumericInputProps>(
                     onChange?.(parsed, e);
                     return;
                 }
+                // In controlled mode, we need to take over the input updates whenever the value is not a valid number
+                // This way onchange is only called with valid number updates and not when user is still entering a valid number
+
                 // if the value ends with a period, don't call onChange as it's not yet a valid number
                 if (v.endsWith('.')) {
                     setInput(v);
@@ -247,10 +250,13 @@ const NumericInput = React.forwardRef<HTMLInputElement, NumericInputProps>(
                     setInput(v);
                     return;
                 }
+                // When the input ends with . and the user backspaces, we should update the input as the value won't have changed
+                if (input.endsWith('.')) {
+                    setInput(v);
+                }
                 onChange?.(parsed, e);
             },
-            // eslint-disable-next-line react-hooks/exhaustive-deps
-            [props.integerOnly, value, onChange]
+            [props.integerOnly, value, onChange, input]
         );
 
         useEffect(() => {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
User found that if they type `10.` and then tried to backspace, then it didn't go to `10`

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue was found that when we updated the input to `10.`, we keep the value at `10`, so when the backspace is pressed the value does go to `10`, but since the value hadn't changed then the useEffect was not triggered and so the input was not updated.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook and by adding a test

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->