### PR TITLE
Fix: DO-3956 causal graph viewer not updating nodes when graph is updated

### DIFF
--- a/packages/ui-causal-graph-editor/changelog.md
+++ b/packages/ui-causal-graph-editor/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fixed an issue where nodes and edges would sometimes not show in `CausalGraphEditor`
+
 ## 1.13.0
 
 -   Added a `min-width` to `CausalGraphEditor`.

--- a/packages/ui-causal-graph-editor/src/shared/rendering/edge/edge-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/edge/edge-object.tsx
@@ -101,6 +101,7 @@ export class EdgeObject extends PIXI.EventEmitter<(typeof MOUSE_EVENTS)[number]>
      */
     private createEdgeSymbols(): PIXI.Container<PIXI.Container> {
         const edgeSymbolsGfx = new PIXI.Container();
+        edgeSymbolsGfx.cullable = true;
 
         if (!this.temporary) {
             edgeSymbolsGfx.interactive = true;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -1861,7 +1861,9 @@ export class Engine extends PIXI.EventEmitter<EngineEvents> {
             // which fires events so just in case fire one here
             this.onLayoutComputationDoneBound();
 
-            // Without this in some instances when the graph resizes or nodes are added they can be culled making them invisible
+            // Force re-render to ensure nodes are positioned correctly within the frame
+            // after a new node is added or the graph is resized. This prevents nodes
+            // from being culled prematurely by ensuring the latest frame is used for culling.
             setTimeout(() => {
                 this.viewport.dirty = true;
             }, 300);

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -1860,6 +1860,11 @@ export class Engine extends PIXI.EventEmitter<EngineEvents> {
             // ensure the callback is invoked - the layout might be custom/not go through the worker
             // which fires events so just in case fire one here
             this.onLayoutComputationDoneBound();
+
+            // Without this in some instances when the graph resizes or nodes are added they can be culled making them invisible
+            setTimeout(() => {
+                this.viewport.dirty = true;
+            }, 300);
         }
     }
 

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -578,7 +578,7 @@ export class Engine extends PIXI.EventEmitter<EngineEvents> {
             // be culled completely making it invisible
             setTimeout(() => {
                 this.viewport.dirty = true;
-            }, 300);
+            }, 100);
         }
     }
 
@@ -1866,7 +1866,7 @@ export class Engine extends PIXI.EventEmitter<EngineEvents> {
             // from being culled prematurely by ensuring the latest frame is used for culling.
             setTimeout(() => {
                 this.viewport.dirty = true;
-            }, 300);
+            }, 100);
         }
     }
 

--- a/packages/ui-causal-graph-editor/src/shared/rendering/node/node-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/node/node-object.tsx
@@ -111,6 +111,7 @@ export class NodeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         const nodeLabelGfx = new PIXI.Container();
         nodeLabelGfx.interactive = true;
         nodeLabelGfx.cursor = 'pointer';
+        nodeLabelGfx.cullable = true;
 
         // send mouse events up
         MOUSE_EVENTS.forEach((eventName) => {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Multiple users reported that sometimes the nodes and edges of their graph would disappear. But after interacting with the graph they magically appeared again.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
The issue was found to be related to [this issue](https://github.com/pixijs/pixijs/issues/10735) on Pixijs.

When a node was added or the graph was resized, the node could temporarily be positioned outside the visible frame. This occurred either because a newly created node did not yet have a defined position or because resizing the graph to a smaller size pushed existing nodes outside the frame. As a result, the nodes were being prematurely culled and rendered invisible before reaching their final render state.

The fix was added to `updateLayout`, as this method is called in both scenarios where the issue occurred. The solution forces a re-render, ensuring the latest frame is used for culling. 

This PR also adds edge symbols and labels to be culled. 

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on storybook and with the example in which this was initially spotted with.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->
BEFORE:
![before node fix](https://github.com/user-attachments/assets/759f6c37-1498-4da7-ba32-f59105892ec0)

AFTER:
![node fix](https://github.com/user-attachments/assets/18ea31a7-bfb6-4858-aa83-a155a886d045)

