### PR TITLE
Fix: DO-3894 native plotly plots cannot change size

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,7 +2,12 @@
 title: Changelog
 ---
 
+# NEXT
+
+-   Fixed an issue where `Plotly`'s figure native `height` and `width` were not obeyed by component.
+
 ## 1.13.1
+
 -   Fixed an issue where `Table` would sometimes convert timestamps in seconds as if they were in milliseconds.
 -   Fixed an issue where `CheckboxGroup` could not have an `undefined` value.
 -   Fixed an issue where `Plotly` in some cases would not pick up colors from dara theme by default.

--- a/packages/dara-components/js/plotting/plotly/plotly.tsx
+++ b/packages/dara-components/js/plotting/plotly/plotly.tsx
@@ -324,7 +324,16 @@ function Plotly(props: PlotlyProps): JSX.Element {
     }, {} as RequiredPlotParams);
 
     return (
-        <StyledPlotly $rawCss={css} style={{ flex: '1 1 auto', minHeight: '350px', ...style }}>
+        <StyledPlotly
+            $rawCss={css}
+            style={{
+                flex: '1 1 auto',
+                minHeight: '350px',
+                height: figure.layout?.height,
+                width: figure.layout?.width,
+                ...style,
+            }}
+        >
             <AutoSizer>
                 {({ height, width }) => (
                     <Plot


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Issue found in internal product where when setting height on a figure layout that the resulting plot did not have correct height.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->
Internal product uses dara's `Plotly` component under the hood. The fix was aimed at improving this for both dara apps and the internal product. 

Since dara uses an Autosizer around plotly any height set within the component was being ignored and the autosizer value replaced it. In order to improve the behaviour to be able to set `height` as both part of the figure layout and prop to the component, I added a style to check if figure has this set and if so to use it instead. The order of preference becomes:
1. Height/width set to Plotly component
2. Height/width set to Plotly figure
3. Use autosizer

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally on a dara app and by testing these changes in the internal product

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->