### PR TITLE
Fix: DO-4169 Add icon display to dropdown items

### DIFF
--- a/packages/ui-components/src/multiselect/multiselect.spec.tsx
+++ b/packages/ui-components/src/multiselect/multiselect.spec.tsx
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ThemeProvider, theme } from '@darajs/styled-components';
@@ -175,7 +175,8 @@ describe('MultiSelect', () => {
 
         userEvent.clear(input);
 
-        userEvent.selectOptions(options, sampleItems[0].label);
+        // Using fireEvent here as selectOption doesn't work
+        fireEvent.click(options.children[0]);
         expect(multiselect.parentElement).toHaveTextContent(sampleItems[0].label);
     });
 

--- a/packages/ui-components/src/select/select.stories.tsx
+++ b/packages/ui-components/src/select/select.stories.tsx
@@ -17,6 +17,8 @@
 import { Meta } from '@storybook/react';
 import * as React from 'react';
 
+import { AddressBook } from '@darajs/ui-icons';
+
 import { Item } from '../types';
 import { default as SelectComponent, SelectProps } from './select';
 
@@ -43,7 +45,8 @@ const simpleItems: Item[] = [
         value: 4,
     },
     {
-        label: 'Fifth',
+        icon: <AddressBook />,
+        label: 'Fifth with Icon',
         value: 5,
     },
     {

--- a/packages/ui-components/src/select/select.stories.tsx
+++ b/packages/ui-components/src/select/select.stories.tsx
@@ -50,7 +50,8 @@ const simpleItems: Item[] = [
         value: 5,
     },
     {
-        label: 'Sixth',
+        icon: <AddressBook />,
+        label: 'Sixth with Icon and too long message',
         value: 6,
     },
     {

--- a/packages/ui-components/src/shared/dropdown-list.tsx
+++ b/packages/ui-components/src/shared/dropdown-list.tsx
@@ -98,6 +98,7 @@ const DropdownList = React.forwardRef<any, Props>(
                                 isSelected={isSelected}
                             >
                                 {item.label}
+                                {item.icon}
                             </ListItem>;
                 })
             :   <NoItemsLabel>No Items</NoItemsLabel>}

--- a/packages/ui-components/src/shared/dropdown-list.tsx
+++ b/packages/ui-components/src/shared/dropdown-list.tsx
@@ -14,6 +14,13 @@ const StyledDropdownList = styled(List)`
     box-shadow: ${(props) => props.theme.shadow.light};
 `;
 
+const InnerItem = styled.span`
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
 type Props = {
     /** Array of items to display in the dropdown */
     items: Item[];
@@ -97,7 +104,7 @@ const DropdownList = React.forwardRef<any, Props>(
                                 isHighlighted={isOpen && kbdHighlightIdx !== undefined && kbdHighlightIdx === index}
                                 isSelected={isSelected}
                             >
-                                {item.label}
+                                <InnerItem>{item.label}</InnerItem>
                                 {item.icon}
                             </ListItem>;
                 })

--- a/packages/ui-components/src/shared/list-item.tsx
+++ b/packages/ui-components/src/shared/list-item.tsx
@@ -17,6 +17,9 @@ export const StyledListItem = styled.span<ListItemProps>`
 
     overflow: hidden;
 
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     width: 100%;
     min-height: 2rem;
     padding: 0.25rem 1rem;

--- a/packages/ui-components/src/types.tsx
+++ b/packages/ui-components/src/types.tsx
@@ -27,6 +27,7 @@ export interface ItemBadge {
 export interface Item {
     badge?: ItemBadge;
     image?: string;
+    icon?: JSX.Element;
     label: string;
     onClick?: () => void | Promise<void>;
     value: any;


### PR DESCRIPTION
## Motivation and Context
* Add the display of icons to dropdown list items (see screenshot below)

## Implementation Description
Display the icon at the end of the row if it's present, expects any JSX element.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Locally in storybook

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<img width="1025" alt="Screenshot 2024-11-22 at 15 30 00" src="https://github.com/user-attachments/assets/baa3a857-3aa5-41dd-98a7-e5982ebe71b8">

