### PR TITLE
Fix: DO-4274 fix a couple of issues in the token refresh logic around websockets

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue with websocket token updates during an SSO driven token refresh. Tokens are now correctly updated in the websocket handler and in the UI.
+
 ## 1.14.2
 
 -   Internal (JS): remove redundant body from the token refresh request

--- a/packages/dara-core/js/api/websocket.tsx
+++ b/packages/dara-core/js/api/websocket.tsx
@@ -469,6 +469,7 @@ export class WebSocketClient implements WebSocketClientInterface {
                     type: 'token_update',
                 })
             );
+            this.token = newToken;
         }
     }
 

--- a/packages/dara-core/js/shared/template-root/template-root.tsx
+++ b/packages/dara-core/js/shared/template-root/template-root.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import styled, { ThemeProvider } from '@darajs/styled-components';
 
@@ -56,6 +56,7 @@ const RootWrapper = styled.div`
  */
 function TemplateRoot(): JSX.Element {
     const token = useSessionToken();
+    const tokenRef = useRef(token);
     const { data: config } = useConfig();
     const { data: template, isLoading: templateLoading } = useTemplate(config?.template);
 
@@ -74,6 +75,7 @@ function TemplateRoot(): JSX.Element {
 
         // subscribe to token changes and notify the live WS connection
         return onTokenChange((newToken) => {
+            tokenRef.current = newToken;
             wsClient.updateToken(newToken);
         });
     }, [wsClient]);
@@ -86,13 +88,13 @@ function TemplateRoot(): JSX.Element {
 
     useEffect(() => {
         if (config) {
-            setWsClient(setupWebsocket(token, config.live_reload));
+            setWsClient(setupWebsocket(tokenRef.current, config.live_reload));
         }
 
         return () => {
             wsClient?.close();
         };
-    }, [token, config?.live_reload]);
+    }, [tokenRef, config?.live_reload]);
 
     if (templateLoading || actionsLoading || componentsLoading) {
         return null;

--- a/packages/dara-core/js/shared/template-root/template-root.tsx
+++ b/packages/dara-core/js/shared/template-root/template-root.tsx
@@ -49,12 +49,17 @@ const RootWrapper = styled.div`
     }
 `;
 
+interface TemplateRootProps {
+    // An initialWebsocketClient, only used for testing
+    initialWebsocketClient?: WebSocketClient;
+}
+
 /**
  * The TemplateRoot component is rendered at the root of every application and is responsible for loading the config and
  * template for the application. It provides the Template context down to it's children and also renders the root
  * component of the template
  */
-function TemplateRoot(): JSX.Element {
+function TemplateRoot(props: TemplateRootProps): JSX.Element {
     const token = useSessionToken();
     const tokenRef = useRef(token);
     const { data: config } = useConfig();
@@ -62,7 +67,7 @@ function TemplateRoot(): JSX.Element {
 
     const { data: actions, isLoading: actionsLoading } = useActions();
     const { data: components, isLoading: componentsLoading, refetch: refetchComponents } = useComponents();
-    const [wsClient, setWsClient] = useState<WebSocketClient>();
+    const [wsClient, setWsClient] = useState<WebSocketClient>(props.initialWebsocketClient);
 
     useEffect(() => {
         cleanSessionCache(token);

--- a/packages/dara-core/tests/js/template-root.spec.tsx
+++ b/packages/dara-core/tests/js/template-root.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from '@testing-library/dom';
+import { waitFor } from '@testing-library/dom';
 import { act } from '@testing-library/react';
 import React from 'react';
 
@@ -6,7 +6,7 @@ import { setSessionToken } from '@/auth/use-session-token';
 import globalStore from '@/shared/global-state-store';
 import { getSessionKey } from '@/shared/interactivity/persistence';
 
-import { DARA_JWT_TOKEN, TemplateRoot, WebSocketCtx } from '../../js/shared';
+import { DARA_JWT_TOKEN, TemplateRoot } from '../../js/shared';
 import { MockWebSocketClient, server, wrappedRender } from './utils';
 import { mockLocalStorage } from './utils/mock-storage';
 

--- a/packages/dara-core/tests/js/utils/mock-storage.tsx
+++ b/packages/dara-core/tests/js/utils/mock-storage.tsx
@@ -1,5 +1,7 @@
-export class MockStorage {
+export class MockStorage implements Storage {
     storage = new Map<string, string>();
+
+    length = 0;
 
     getItem(key: string): string {
         return this.storage.get(key);

--- a/packages/dara-core/tests/js/utils/mock-web-socket-client.tsx
+++ b/packages/dara-core/tests/js/utils/mock-web-socket-client.tsx
@@ -108,4 +108,14 @@ export default class MockWebSocketClient implements MockWebSocketClientInterface
     sendVariable(value: any, channel: string): void {
         // Do nothing
     }
+
+    // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+    updateToken(newToken: string): void {
+        // Do Nothing
+    }
+
+    // eslint-disable-next-line
+    close(): void {
+        // Do Nothing
+    }
 }


### PR DESCRIPTION
## Motivation and Context
Issues seen in local dev with the messaging locking up, changes to the websocket client not getting propogated after a token refresh. This change also resolves the stale token issue on websockets where when there was a single tab the context var was set incorrectly.

## Implementation Description
* There was a misunderstanding in how the storage event worked that led to single open tabs not correctly refreshing their tokens when required. This is due to the event only being fired when storage is changed from another document. This meant that the session token in the useSessionToken hook was not correctly updated in the current tab.
* To address this the local subscribers field is now used again (it was left in a broken state, but not completely removed) and correctly pushes out updates to a key to all local subscribers immediately.
* Secondly, as we now have a new token update method for an existing websocket connection there is no longer a need to completely reconnect the websocket in such cases, we only need to update the token within. This is now the primary way for updating the token on the websocket client rather than recreating the whole connection each time we need to update the token.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Will try to add unit tests on Monday.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.
