### PR TITLE
Fix: DO-4864 Resolve websocket not reconnecting correctly.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install system deps
         run: sudo apt update && sudo apt install wget -y
       - name: Install and cache APT Cypress deps
-        uses: awalsh128/cache-apt-pkgs-action@v1.4.1
+        uses: awalsh128/cache-apt-pkgs-action@v1.4.3
         with:
           packages: libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
           version: cypress-${{ runner.os }}-${{ steps.set-cypress.outputs.cypress }}
@@ -111,18 +111,18 @@ jobs:
           name: screenshots
           path: packages/dara-core/cypress/screenshots
           retention-days: 30
-      # - uses: 8398a7/action-slack@v3
-      #   with:
-      #     status: custom
-      #     fields: workflow,job,commit,repo,ref,author,took
-      #     custom_payload: |
-      #       {
-      #         username: 'action-slack',
-      #         attachments: [{
-      #           color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-      #           text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
-      #         }]
-      #       }
-      #   env:
-      #     SLACK_WEBHOOK_URL: "${{ secrets.SLACK_BUILD_CHANNEL_WEBHOOK }}"
-      #   if: ${{ github.actor != 'dependabot[bot]' }}
+      - uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+              username: 'action-slack',
+              attachments: [{
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: "${{ secrets.SLACK_BUILD_CHANNEL_WEBHOOK }}"
+        if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,22 +33,22 @@ jobs:
         id: cached-poetry-dependencies
         uses: actions/cache@v4
         with:
-            path: .venv
-            key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install Python venv if cache was not found
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry anthology install
         env:
-            POETRY_HTTP_BASIC_CAUSALENS_USERNAME: '${{ secrets.GAR_USERNAME }}'
-            POETRY_HTTP_BASIC_CAUSALENS_PASSWORD: '${{ secrets.GAR_KEY }}'
+          POETRY_HTTP_BASIC_CAUSALENS_USERNAME: "${{ secrets.GAR_USERNAME }}"
+          POETRY_HTTP_BASIC_CAUSALENS_PASSWORD: "${{ secrets.GAR_KEY }}"
       - name: Link venvs if cache was hit
         if: steps.cached-poetry-dependencies.outputs.cache-hit == 'true'
         run: make link
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-            version: 9
+          version: 9
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash
@@ -111,18 +111,18 @@ jobs:
           name: screenshots
           path: packages/dara-core/cypress/screenshots
           retention-days: 30
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: custom
-          fields: workflow,job,commit,repo,ref,author,took
-          custom_payload: |
-            {
-              username: 'action-slack',
-              attachments: [{
-                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
-                text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
-              }]
-            }
-        env:
-          SLACK_WEBHOOK_URL: "${{ secrets.SLACK_BUILD_CHANNEL_WEBHOOK }}"
-        if: ${{ github.actor != 'dependabot[bot]' }}
+      # - uses: 8398a7/action-slack@v3
+      #   with:
+      #     status: custom
+      #     fields: workflow,job,commit,repo,ref,author,took
+      #     custom_payload: |
+      #       {
+      #         username: 'action-slack',
+      #         attachments: [{
+      #           color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+      #           text: `${process.env.AS_WORKFLOW}\n${process.env.AS_JOB} (${process.env.AS_COMMIT}) of ${process.env.AS_REPO}@${process.env.AS_REF} by ${process.env.AS_AUTHOR} ${{ job.status }} in ${process.env.AS_TOOK}`,
+      #         }]
+      #       }
+      #   env:
+      #     SLACK_WEBHOOK_URL: "${{ secrets.SLACK_BUILD_CHANNEL_WEBHOOK }}"
+      #   if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: poetry self add anthology
       - name: Setup cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
             path: .venv
             key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -66,7 +66,7 @@ jobs:
         id: set-cypress
         run: echo "::set-output name=cypress::$(tooling/get-cypress-version/main.js)"
       - name: Cache Cypress binary
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         # This attempts to restore cached Cypress; if not found and job is successful, creates new cache
         with:
           path: ~/.cache/Cypress

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fix a bug in the websocket token refresh logic that caused it to get stuck in a repeating failure state.
+
 ## 1.14.8
 
 -   Fix a bug in the fastapi_vite_dara dependency that broke HMR mode for local development of custom JS packages


### PR DESCRIPTION
## Motivation and Context
Address Studio being broken after coming back to it after leaving the tab for a while.

## Implementation Description
* There were two issues causing this. The first was that we were raising HTTPExceptions rather than Websocket exceptions during the handshake and upgrade from http request to websocket. This caused the error to be swallowed and replaced with a generic error log and handshake failed response.
* Switching to using WebsocketException now gets properly handled and the logs now correctly show the 403 exception and logged detail rather than swallowing everything.
* The second part of the issue was that the websocket client on the JS side was getting stuck with a stale token if this happened whilst the computer was sleeping / tab sleeping. I suspect this was caused by updateToken trying to send a message on the disconnected socket and erroring out before updating the token on the class.
* To address this, the token on the class is now set first regardless of the state of the websocket connection. During initialization we also pull the latest token from the globalStore to ensure it's up to date if for some reason the token does get out of sync.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Tested in a local studio

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [ ] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.