### PR TITLE
Fix: DO-5476  Plotly component disappearing in vertical stacks when overriding `align-items`

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where `Plotly` component would shrink to zero width in a vertical flex container with `align-items` set to any value other than `stretch`
+
 ## 1.14.8
 
 -  Clarified `Variable` usage in the docs of some components.

--- a/packages/dara-components/js/plotting/plotly/plotly.tsx
+++ b/packages/dara-components/js/plotting/plotly/plotly.tsx
@@ -329,6 +329,7 @@ function Plotly(props: PlotlyProps): JSX.Element {
             style={{
                 flex: '1 1 auto',
                 minHeight: '350px',
+                minWidth: '350px',
                 height: figure.layout?.height,
                 width: figure.layout?.width,
                 ...style,


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Similar to our previous Plotly issues (e.g. https://github.com/causalens/dara/pull/140).
When putting it into a Stack without setting an explicit size, it tries to fill its parent using the AutoSizer and following flex rules. When using an `align-items` property on its flex parent other than `stretch` (the default), the component shrinks to its minimum size.

For horizontal Stacks, we had a `minHeight` set to 350 by default to prevent it disappearing completely.
The component was missing a matching `minWidth` which was causing it to disappear in a vertical stack with align other than `stretch`.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Added default min-width. It can be overridden by the user just like the height.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in a test app. See behaviour of different alignments of the parent flex:

Vertical:

https://github.com/user-attachments/assets/2fc5aa38-ddbf-4c45-a30b-37c6e23b383d

Horizontal:

https://github.com/user-attachments/assets/35db1f60-2ff9-4722-ad8d-df7e32934a60


## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->