### PR TITLE
Fix: DO-5467 slider moving on its own

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where `Slider` component would not raise on invalid domain values where step was inferred.
+
 ## 1.15.3
 
 -  Fixed an issue where `Plotly` component would shrink to zero width in a vertical flex container with `align-items` set to any value other than `stretch`

--- a/packages/dara-components/dara/components/common/slider.py
+++ b/packages/dara-components/dara/components/common/slider.py
@@ -154,6 +154,10 @@ class Slider(FormComponent):
     @validator('step', always=True)
     @classmethod
     def step_valid(cls, v: Optional[float], values: Dict[str, Any]) -> Optional[float]:
+        # domain validation must have failed, skip
+        if 'domain' not in values:
+            return v
+
         # make sure step and domain are compatible
         # using Decimal to avoid floating point errors
         domain = values['domain']

--- a/packages/ui-components/src/slider/slider.tsx
+++ b/packages/ui-components/src/slider/slider.tsx
@@ -16,7 +16,7 @@
  */
 import isEqual from 'lodash/isEqual';
 import round from 'lodash/round';
-import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Handles, Slider as RCSlider, Rail, Ticks, Tracks } from 'react-compound-slider';
 
 import styled from '@darajs/styled-components';
@@ -249,15 +249,13 @@ function BaseSlider<T extends string | number | React.ReactNode>({
 
         return computeStep(domain[1] - domain[0]);
     }, [domain, step]);
+
     const [sliderValues, setSliderValues] = useState(
         values?.map((v) => mapToClosestStep(v, adjustedStep)) ||
             initialValue?.map((v) => mapToClosestStep(v, adjustedStep)) || [domain[0]]
     );
-
     const currSliderValues = useRef(sliderValues);
-    useLayoutEffect(() => {
-        currSliderValues.current = sliderValues;
-    }, [sliderValues]);
+    currSliderValues.current = sliderValues;
 
     const isFirstRender = useRef(true);
 
@@ -265,9 +263,7 @@ function BaseSlider<T extends string | number | React.ReactNode>({
         if (values !== undefined) {
             const mappedValues = values.map((v) => mapToClosestStep(v, adjustedStep));
 
-            // Only update if there's a significant difference and not just due to step mapping
-            // This prevents an infinite update loop
-            if (!isEqual(mappedValues, currSliderValues.current) && !isEqual(values, currSliderValues.current)) {
+            if (!isEqual(mappedValues, currSliderValues.current)) {
                 setSliderValues(mappedValues);
             }
         }
@@ -319,18 +315,9 @@ function BaseSlider<T extends string | number | React.ReactNode>({
                 isFirstRender.current = false;
                 return;
             }
-
             if (validateValues(sliderValues)) {
-                // Only call onChange if values actually changed from what was passed in
-                if (
-                    !isEqual(
-                        sliderValues,
-                        values.map((v) => mapToClosestStep(v, adjustedStep))
-                    )
-                ) {
-                    const formattedValues = sliderValues.map(getValueLabel);
-                    onChange?.(formattedValues);
-                }
+                const formattedValues = sliderValues.map(getValueLabel);
+                onChange?.(formattedValues);
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/ui-components/src/slider/slider.tsx
+++ b/packages/ui-components/src/slider/slider.tsx
@@ -16,7 +16,7 @@
  */
 import isEqual from 'lodash/isEqual';
 import round from 'lodash/round';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Handles, Slider as RCSlider, Rail, Ticks, Tracks } from 'react-compound-slider';
 
 import styled from '@darajs/styled-components';
@@ -249,13 +249,15 @@ function BaseSlider<T extends string | number | React.ReactNode>({
 
         return computeStep(domain[1] - domain[0]);
     }, [domain, step]);
-
     const [sliderValues, setSliderValues] = useState(
         values?.map((v) => mapToClosestStep(v, adjustedStep)) ||
             initialValue?.map((v) => mapToClosestStep(v, adjustedStep)) || [domain[0]]
     );
+
     const currSliderValues = useRef(sliderValues);
-    currSliderValues.current = sliderValues;
+    useLayoutEffect(() => {
+        currSliderValues.current = sliderValues;
+    }, [sliderValues]);
 
     const isFirstRender = useRef(true);
 
@@ -263,7 +265,9 @@ function BaseSlider<T extends string | number | React.ReactNode>({
         if (values !== undefined) {
             const mappedValues = values.map((v) => mapToClosestStep(v, adjustedStep));
 
-            if (!isEqual(mappedValues, currSliderValues.current)) {
+            // Only update if there's a significant difference and not just due to step mapping
+            // This prevents an infinite update loop
+            if (!isEqual(mappedValues, currSliderValues.current) && !isEqual(values, currSliderValues.current)) {
                 setSliderValues(mappedValues);
             }
         }
@@ -315,9 +319,18 @@ function BaseSlider<T extends string | number | React.ReactNode>({
                 isFirstRender.current = false;
                 return;
             }
+
             if (validateValues(sliderValues)) {
-                const formattedValues = sliderValues.map(getValueLabel);
-                onChange?.(formattedValues);
+                // Only call onChange if values actually changed from what was passed in
+                if (
+                    !isEqual(
+                        sliderValues,
+                        values.map((v) => mapToClosestStep(v, adjustedStep))
+                    )
+                ) {
+                    const formattedValues = sliderValues.map(getValueLabel);
+                    onChange?.(formattedValues);
+                }
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Issue reported when with a specific configuration the slider would 'move on its own', i.e. constantly readjust its tracks.
The reported configuration was `domain=[31635, 70876] values=[31635, 70876]`. 

The component has validation for step/domain compatibility (i.e. the range must be divisible by the step) but it was only verified when both were provided. The Slider can operate with an inferred step (i.e. only domain is provided) but then we wouldn't validate it.

This PR adds additional validation on the backend to run a similar step inference and cross-validate it with the domain and thus fail early.
Now the same reported scenario simply raises:

```
(...)
pydantic.error_wrappers.ValidationError: 1 validation error for Slider
step
  Step 1000 (inferred from domain range) is not compatible with domain [31635.0, 70876.0]. The domain range must be divisible by the step. (type=value_error)
```

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally
Amended unit tests to cover the reported scenario

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->