### PR TITLE
Improvement: DO-5860 Allow dara to run behind a path prefixed proxy

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,20 +2,25 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Add support for setting a root_path in `dara start` so it can run behind a path prefixed proxy. e.g. `dara start --root-path https://my.app.com/proxy/`
+
 ## 1.15.6
- - Changed the verification process of websockets to be the same as the http endpoints
+
+-   Changed the verification process of websockets to be the same as the http endpoints
 
 ## 1.15.2
 
--  Fix an issue where the internal `eng_logger` would be enabled even when `DARA_DEV_LOG_LEVEL` was set to `NONE` (which is the default).
+-   Fix an issue where the internal `eng_logger` would be enabled even when `DARA_DEV_LOG_LEVEL` was set to `NONE` (which is the default).
 
 ## 1.15.0
 
--  Fix a bug where when using `store=BackendStore(...)` kwarg with a `Variable`, the originating session would also be notified of the change causing rare desyncs and race conditions.
+-   Fix a bug where when using `store=BackendStore(...)` kwarg with a `Variable`, the originating session would also be notified of the change causing rare desyncs and race conditions.
 
 ## 1.14.9
 
--  Fix a bug in the websocket token refresh logic that caused it to get stuck in a repeating failure state.
+-   Fix a bug in the websocket token refresh logic that caused it to get stuck in a repeating failure state.
 
 ## 1.14.8
 

--- a/packages/dara-core/dara/core/cli.py
+++ b/packages/dara-core/dara/core/cli.py
@@ -60,6 +60,11 @@ def cli():
 @click.option('--log', default=lambda: os.environ.get('DARA_DEV_LOG_LEVEL', None), help='Dev logger level to use')
 @click.option('--reload-dir', multiple=True, help='Directories to watch for reload')
 @click.option('--skip-jsbuild', is_flag=True, help='Whether to skip building the JS assets')
+@click.option(
+    '--root-path',
+    default=lambda: os.getenv('DARA_ROOT_PATH'),
+    help='An optional root_path for running a Dara app behind a proxy',
+)
 def start(
     reload: bool,
     enable_hmr: bool,
@@ -76,6 +81,7 @@ def start(
     log: Optional[str],
     reload_dir: Optional[List[str]],
     skip_jsbuild: bool,
+    root_path: Optional[str],
 ):
     if config is None:
         folder_name = os.path.basename(os.getcwd()).replace('-', '_')
@@ -176,6 +182,7 @@ def start(
         log_config=logging_config,
         limit_max_requests=limit_max_requests,
         lifespan='on',
+        root_path=root_path,
     )
 
 


### PR DESCRIPTION
## Motivation and Context
For users wishing to run a dara app behind a path prefixed proxy then this setting had to be exposed.

## Implementation Description
* Allow the pass through of a root path to the uvicorn ASGI server via param or env var to the dara start cli

## Any new dependencies Introduced
No

## How Has This Been Tested?
Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.