### PR TITLE
Improvement: DO-5864 improve `Variable.default` serialization, add serializers for `VisualEdgeEncoder.nodec` and the `cai_causal_graph` `Node` type

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where `cai_causal_graph`'s `Node` wasn't serialized in `VisualEdgeEncoder` component.
+
 ## 1.16.1
 
 -  Fixed an issue where `AccordionItem` wouldn't serialize its children properly

--- a/packages/dara-components/tests/python/graphs/test_edge_encoder.py
+++ b/packages/dara-components/tests/python/graphs/test_edge_encoder.py
@@ -1,0 +1,58 @@
+from cai_causal_graph import CausalGraph
+from cai_causal_graph.graph_components import Node
+from fastapi.encoders import jsonable_encoder
+
+from dara.components.graphs import VisualEdgeEncoder
+from dara.core import Variable
+
+
+def test_serialize():
+    # as strings
+    encoder = VisualEdgeEncoder(nodes=['Age', 'Unemployment', 'Education', 'Income'])
+    encoded = jsonable_encoder(encoder)
+
+    assert encoded['props']['nodes'] == ['Age', 'Unemployment', 'Education', 'Income']
+
+    # as dict of [str, Node]
+    encoder = VisualEdgeEncoder(
+        nodes={
+            'Age': Node('Age'),
+            'Unemployment': Node('Unemployment'),
+            'Education': Node('Education'),
+            'Income': Node('Income'),
+        }
+    )
+    encoded = jsonable_encoder(encoder)
+
+    assert encoded['props']['nodes'] == {
+        'Age': encoder.nodes['Age'].to_dict(),
+        'Unemployment': encoder.nodes['Unemployment'].to_dict(),
+        'Education': encoder.nodes['Education'].to_dict(),
+        'Income': encoder.nodes['Income'].to_dict(),
+    }
+
+    # as variable with list of strings
+    encoder = VisualEdgeEncoder(nodes=Variable(default=['Age', 'Unemployment', 'Education', 'Income']))
+    encoded = jsonable_encoder(encoder)
+
+    assert encoded['props']['nodes']['default'] == ['Age', 'Unemployment', 'Education', 'Income']
+
+    # as variable with dict of [str, Node]
+    encoder = VisualEdgeEncoder(
+        nodes=Variable(
+            default={
+                'Age': Node('Age'),
+                'Unemployment': Node('Unemployment'),
+                'Education': Node('Education'),
+                'Income': Node('Income'),
+            }
+        )
+    )
+    encoded = jsonable_encoder(encoder)
+
+    assert encoded['props']['nodes']['default'] == {
+        'Age': encoder.nodes.default['Age'].to_dict(),
+        'Unemployment': encoder.nodes.default['Unemployment'].to_dict(),
+        'Education': encoder.nodes.default['Education'].to_dict(),
+        'Income': encoder.nodes.default['Income'].to_dict(),
+    }

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -6,6 +6,7 @@ title: Changelog
 
 -   Fix an issue where `Fallback` components would fail to serialize correctly
 -   Allow extra fields in the `Settings` model.
+-   Improve serialization of `Variable.default` to handle more common scenarios
 
 ## 1.16.0
 

--- a/packages/dara-core/dara/core/internal/encoder_registry.py
+++ b/packages/dara-core/dara/core/internal/encoder_registry.py
@@ -19,6 +19,7 @@ from inspect import Parameter, isclass
 from typing import (
     Any,
     Callable,
+    Dict,
     MutableMapping,
     Optional,
     Type,
@@ -196,6 +197,7 @@ encoder_registry: MutableMapping[Type[Any], Encoder] = {
 try:
     # technically you can use dara core without this package
     from cai_causal_graph import CausalGraph, Skeleton
+    from cai_causal_graph.graph_components import Node
 except ImportError:
     # If the import fails, we don't need to register the encoders for these types
     pass
@@ -204,8 +206,16 @@ else:
         {
             CausalGraph: Encoder(serialize=lambda x: x.to_dict(), deserialize=lambda x: CausalGraph.from_dict(x)),
             Skeleton: Encoder(serialize=lambda x: x.to_dict(), deserialize=lambda x: Skeleton.from_dict(x)),
+            Node: Encoder(serialize=lambda x: x.to_dict(), deserialize=lambda x: Node.from_dict(x)),
         }
     )
+
+
+def get_jsonable_encoder() -> Dict[Type[Any], Callable[..., Any]]:
+    """
+    Get the encoder registry as a dict of {type: serialize} pairs
+    """
+    return {k: v['serialize'] for k, v in encoder_registry.items()}
 
 
 def deserialize(value: Any, typ: Optional[Type]):


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Issues reported around serializing visual edge encoder. The `nodes` type can include `cai_causal_graph.graph_components.Node` type (or a `dict[str, Node]` to be precise) which is not serializable by default.

To improve it I applied the following:
- `Variable.default` now uses `jsonable_encoder` with custom encoders using our registry, which now also handles cases where the serializable type is within a dict/list/one of the known serializable containers
- added a `field_serializer` to `VisualEdgeEncoder.nodes` to handle serializing the type explicitly
- added a serializer for `Node` to encoder registry

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally using different combinations of CausalGraph.Node with edge encoder:

```python
        VisualEdgeEncoder(
            nodes=['Age', 'Unemployment', 'Education', 'Income'],
            ...
        ),
        VisualEdgeEncoder(
            nodes={
                'Age': Node('Age'),
                'Unemployment': Node('Unemployment'),
                'Education': Node('Education'),
                'Income': Node('Income'),
            },
            ...
        ),
        VisualEdgeEncoder(
            nodes=Variable(
                default={
                    'Age': Node('Age'),
                    'Unemployment': Node('Unemployment'),
                    'Education': Node('Education'),
                    'Income': Node('Income'),
                }
            ),
            ...
        ),
        VisualEdgeEncoder(
            nodes=DerivedVariable(
                lambda: {
                    'Age': Node('Age'),
                    'Unemployment': Node('Unemployment'),
                    'Education': Node('Education'),
                    'Income': Node('Income'),
                },
                variables=[]
            ),
            ...
        ),

```

Tests added to cover those

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->