### PR TITLE
Improvement: DO-5991: Improve serialization of `ActionImpl` to automatically serialize nested fields

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,7 +4,6 @@ title: Changelog
 
 ## NEXT
 
--   Fix `fastapi_vite_dara` environment variables to enable HMR mode
 -   Improve serialization of `ActionImpl` to automatically serialize nested fields
 
 ## 1.16.2

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fix `fastapi_vite_dara` environment variables to enable HMR mode
+-   Improve serialization of `ActionImpl` to automatically serialize nested fields
+
 ## 1.16.2
 
 -   Fix an issue where `Fallback` components would fail to serialize correctly

--- a/packages/dara-core/dara/core/base_definitions.py
+++ b/packages/dara-core/dara/core/base_definitions.py
@@ -41,12 +41,14 @@ from typing import (
 
 import anyio
 from anyio.streams.memory import MemoryObjectSendStream
+from fastapi.encoders import jsonable_encoder
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
     SerializeAsAny,
     SerializerFunctionWrapHandler,
+    field_serializer,
     model_serializer,
 )
 from pydantic._internal._model_construction import ModelMetaclass
@@ -536,6 +538,9 @@ class ActionImpl(DaraBaseModel):
         dict_form['__typename'] = 'ActionImpl'
         return dict_form
 
+    @field_serializer('*')
+    def serialize_field(self, value: Any):
+        return jsonable_encoder(value)
 
 ActionInstance = Union[ActionImpl, AnnotatedAction]
 """

--- a/packages/dara-core/dara/core/base_definitions.py
+++ b/packages/dara-core/dara/core/base_definitions.py
@@ -542,6 +542,7 @@ class ActionImpl(DaraBaseModel):
     def serialize_field(self, value: Any):
         return jsonable_encoder(value)
 
+
 ActionInstance = Union[ActionImpl, AnnotatedAction]
 """
 @deprecated alias for backwards compatibility


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Issue came up in pydantic v2 migration: Derived fields in `ActionImpl` require explicit serialization in user-land.

This PR marks every derived field in `ActionImpl` to be automatically serialized by `jsonable_encoder`.


## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->