### PR TITLE
Fix: DO-6035 Fix for dev mode after the previous static url changes

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fix a bug in static_url handling when running the local dev server.
+
 ## 1.16.7
 
 -   Update how base_urls are handled so that Dara apps with custom JS can be run behind a proxy.

--- a/packages/dara-core/dara/core/js_tooling/js_utils.py
+++ b/packages/dara-core/dara/core/js_tooling/js_utils.py
@@ -293,7 +293,8 @@ class BuildCache(BaseModel):
             'private': True,
             'version': '0.0.1',
             'main': 'dist/index.js',
-            'scripts': {'dev': 'vite', 'build': 'vite build'},
+            # --base needs to be set here due to the changes in how static urls are resolved
+            'scripts': {'dev': 'vite --base=http://localhost:3000/static/', 'build': 'vite build'},
             'overrides': {'react': '^18.2.0', 'react-dom': '^18.2.0'},
         }
 


### PR DESCRIPTION
## Motivation and Context
Fix dev mode apps not loading correctly

## Implementation Description
The alteration to the base url in the vite config broke the development server. There doesn't appear to be a way to change the base url from the config so it needed to be applied in the dev command inserted into the package.json.

The alternate way that did not work was to leave the dev server serving on / and try to update the static path to "". Doing this seems to default back to /static/ though and setting it as / caused double // in a couple of places that broke other things.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Tested locally in studio

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.