### PR TITLE
Fix: DO-6306 Patch dara referrer handling when a base_url is set

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-   Fix an issue with base_url handling during redirection in the authentication flow
+
 ## 1.16.10
 
 -   Unlock the `python-multipart` dependency, is now `>=0.0.7`

--- a/packages/dara-core/js/auth/auth.tsx
+++ b/packages/dara-core/js/auth/auth.tsx
@@ -121,6 +121,28 @@ export async function revokeSession(): Promise<RedirectResponse | SuccessRespons
 }
 
 /**
+ * Resolve the referrer url to be passed back to login, adjusted for the base path.
+ */
+export function resolve_referrer(): string {
+    if (!window.dara.base_url) {
+        return encodeURIComponent(window.location.pathname + window.location.search);
+    }
+
+    const base_url_path = new URL(window.dara.base_url).pathname;
+    const referrer = window.location.pathname;
+
+    // Remove the matching part of the base_url from the referrer.
+    let strippedReferrer = referrer.replace(base_url_path, '');
+
+    // If this has stripped the leading / then replace it
+    if (!strippedReferrer.startsWith('/')) {
+        strippedReferrer = `/${strippedReferrer}`;
+    }
+
+    return encodeURIComponent(strippedReferrer + window.location.search);
+}
+
+/**
  * Helper function to handle auth errors in a response
  *
  * @param res the response object to check
@@ -139,8 +161,7 @@ export async function handleAuthErrors(
 
         // use existing referrer if available in case we were already redirected because of e.g. missing token
         const queryParams = new URLSearchParams(window.location.search);
-        const referrer =
-            queryParams.get('referrer') ?? encodeURIComponent(window.location.pathname + window.location.search);
+        const referrer = queryParams.get('referrer') ?? resolve_referrer();
 
         const path =
             toLogin || shouldRedirectToLogin(content.detail) ?

--- a/packages/dara-core/js/auth/auth.tsx
+++ b/packages/dara-core/js/auth/auth.tsx
@@ -123,7 +123,7 @@ export async function revokeSession(): Promise<RedirectResponse | SuccessRespons
 /**
  * Resolve the referrer url to be passed back to login, adjusted for the base path.
  */
-export function resolve_referrer(): string {
+export function resolveReferrer(): string {
     if (!window.dara.base_url) {
         return encodeURIComponent(window.location.pathname + window.location.search);
     }
@@ -161,7 +161,7 @@ export async function handleAuthErrors(
 
         // use existing referrer if available in case we were already redirected because of e.g. missing token
         const queryParams = new URLSearchParams(window.location.search);
-        const referrer = queryParams.get('referrer') ?? resolve_referrer();
+        const referrer = queryParams.get('referrer') ?? resolveReferrer();
 
         const path =
             toLogin || shouldRedirectToLogin(content.detail) ?

--- a/packages/dara-core/js/shared/private-route/private-route.tsx
+++ b/packages/dara-core/js/shared/private-route/private-route.tsx
@@ -2,7 +2,7 @@
 import { ReactNode, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 
-import { resolve_referrer } from '@/auth/auth';
+import { resolveReferrer } from '@/auth/auth';
 import { useSessionToken } from '@/auth/use-session-token';
 import DefaultFallback from '@/components/fallback/default';
 import useAction, { useActionIsLoading } from '@/shared/utils/use-action';
@@ -37,7 +37,7 @@ function PrivateRoute({ children, on_load, name }: PrivateRouteProps): ReactNode
     }, []);
 
     if (!token) {
-        const referrer = resolve_referrer();
+        const referrer = resolveReferrer();
         return (
             <Redirect
                 to={{

--- a/packages/dara-core/js/shared/private-route/private-route.tsx
+++ b/packages/dara-core/js/shared/private-route/private-route.tsx
@@ -2,6 +2,7 @@
 import { ReactNode, useEffect } from 'react';
 import { Redirect } from 'react-router-dom';
 
+import { resolve_referrer } from '@/auth/auth';
 import { useSessionToken } from '@/auth/use-session-token';
 import DefaultFallback from '@/components/fallback/default';
 import useAction, { useActionIsLoading } from '@/shared/utils/use-action';
@@ -36,7 +37,7 @@ function PrivateRoute({ children, on_load, name }: PrivateRouteProps): ReactNode
     }, []);
 
     if (!token) {
-        const referrer = encodeURIComponent(window.location.pathname + window.location.search);
+        const referrer = resolve_referrer();
         return (
             <Redirect
                 to={{

--- a/packages/dara-core/tests/js/auth.spec.tsx
+++ b/packages/dara-core/tests/js/auth.spec.tsx
@@ -1,4 +1,4 @@
-import { resolve_referrer } from '@/auth/auth';
+import { resolveReferrer } from '@/auth/auth';
 
 describe('resolve_referrer', () => {
     let originalWindowLocation = window.location;
@@ -24,7 +24,7 @@ describe('resolve_referrer', () => {
             base_url: 'https://test.com/',
         };
 
-        expect(resolve_referrer()).toBe('%2Ftest%2Froute');
+        expect(resolveReferrer()).toBe('%2Ftest%2Froute');
     });
 
     it("should remove the path part of the base_url when it's set", () => {
@@ -32,6 +32,6 @@ describe('resolve_referrer', () => {
             base_url: 'https://test.com/test',
         };
 
-        expect(resolve_referrer()).toBe('%2Froute');
+        expect(resolveReferrer()).toBe('%2Froute');
     });
 });

--- a/packages/dara-core/tests/js/auth.spec.tsx
+++ b/packages/dara-core/tests/js/auth.spec.tsx
@@ -1,0 +1,37 @@
+import { resolve_referrer } from '@/auth/auth';
+
+describe('resolve_referrer', () => {
+    let originalWindowLocation = window.location;
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: new URL('https://test.com/test/route'),
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: originalWindowLocation,
+        });
+    });
+
+    it('should resolve the full path when no base_url is set', () => {
+        window.dara = {
+            base_url: 'https://test.com/',
+        };
+
+        expect(resolve_referrer()).toBe('%2Ftest%2Froute');
+    });
+
+    it("should remove the path part of the base_url when it's set", () => {
+        window.dara = {
+            base_url: 'https://test.com/test',
+        };
+
+        expect(resolve_referrer()).toBe('%2Froute');
+    });
+});

--- a/packages/dara-core/tests/js/auth.spec.tsx
+++ b/packages/dara-core/tests/js/auth.spec.tsx
@@ -1,7 +1,7 @@
 import { resolveReferrer } from '@/auth/auth';
 
 describe('resolve_referrer', () => {
-    let originalWindowLocation = window.location;
+    const originalWindowLocation = window.location;
 
     beforeEach(() => {
         Object.defineProperty(window, 'location', {


### PR DESCRIPTION
## Motivation and Context
* The base_url wasn't being handled correctly when setting the referrer into state for redirection. This caused the path part of the base_url to be duplicated on redirect.

## Implementation Description
* Added a resolver function that adjusts the referrer based on the base_url.
* Adds a test to check it's working correctly.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Unit test added

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.