### PR TITLE
Fix: DO-6282 re-export CodeMirror dependencies

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Internal: re-export `@codemirror` packages to solve duplication of CM dependencies across UMD bundles
+
 ## 1.16.6
 
 -  Added a new improved `UiCodeEditor` implementation into this package directly, superseding the old `@darajs/ui-code-editor` package.

--- a/packages/dara-components/js/smart/ui-code-editor/index.tsx
+++ b/packages/dara-components/js/smart/ui-code-editor/index.tsx
@@ -28,3 +28,14 @@ export * from './code-editor';
 export * from './codemirror-context';
 export * from './types';
 export * from './utils';
+
+// Re-export CodeMirror modules to prevent duplication in other packages
+export * as CMState from '@codemirror/state';
+export * as CMView from '@codemirror/view';
+export * as CMAutoComplete from '@codemirror/autocomplete';
+export * as CMLanguage from '@codemirror/language';
+export * as CMSearch from '@codemirror/search';
+export * as CMCommands from '@codemirror/commands';
+export * as CMLint from '@codemirror/lint';
+export * as CMLangMarkdown from '@codemirror/lang-markdown';
+export * as CMLangJson from '@codemirror/lang-json';


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

When using UMD bundles, downstream packages using CodeMirror complain about duplicated `@codemirror/state` package. As a fix, we now re-export the dependencies from `@darajs/components` for the downstream packages to use. 

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by copying the built UMD locally 

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->