### PR TITLE
Fix: DO-6431 import discovery edge case when importing component instances

### DIFF
--- a/docs/advanced/import-discovery.md
+++ b/docs/advanced/import-discovery.md
@@ -86,3 +86,37 @@ config.add_component(LocalComponent, local=True)
 ```
 
 The local flag marks the component as a local one, meaning it does not need to define the `js_module` field - this is normally required to defined the `npm` JavaScript package containing the component implementation. This is because the local module is defined via the `dara.config.json` file. This is described in detail in the [custom JS page](./custom-js.mdx).
+
+3. Importing component *instances*
+
+In some cases, you may want to import a component instance from another module, e.g.
+
+```python
+# file: my_project/my_component.py
+from dara.components import UploadDropzone
+
+dropzone = UploadDropzone()
+
+# file: my_project/main.py
+from dara.core import ConfigurationBuilder
+from .my_component import dropzone
+
+config = ConfigurationBuilder()
+config.add_page(name='Upload Dropzone', content=dropzone)
+```
+
+This is supported, and import discovery will pick up that `dropzone` is an instance of `UploadDropzone` and register it in the app.
+It will not, however, recurse into the `my_component.py` module to discover any other components. In general it is recommended to instead define components or parts of the page as functions and import those:
+
+```python
+# file: my_project/my_component.py
+def dropzone() -> UploadDropzone:
+    return UploadDropzone()
+
+# file: my_project/main.py
+from dara.core import ConfigurationBuilder
+from .my_component import dropzone
+
+config = ConfigurationBuilder()
+config.add_page(name='Upload Dropzone', content=dropzone())
+```

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where import discovery would not register a component if it was imported as a component *instance* defined in another file
+
 ## 1.16.15
 
 -  Bump minimum version of `pyjwt` to `2.3.0`

--- a/packages/dara-core/dara/core/internal/import_discovery.py
+++ b/packages/dara-core/dara/core/internal/import_discovery.py
@@ -36,7 +36,7 @@ def _is_component_subclass(obj: Any) -> bool:
 def _is_component_instance(obj: Any) -> TypeGuard[ComponentInstance]:
     try:
         return isinstance(obj, ComponentInstance)
-    except:
+    except Exception:
         return False
 
 

--- a/packages/dara-core/dara/core/internal/import_discovery.py
+++ b/packages/dara-core/dara/core/internal/import_discovery.py
@@ -20,6 +20,8 @@ import sys
 from types import ModuleType
 from typing import Any, List, Optional, Set, Tuple, Type, Union
 
+from typing_extensions import TypeGuard
+
 from dara.core.base_definitions import ActionDef, ActionImpl
 from dara.core.definitions import ComponentInstance, JsComponentDef, discover
 from dara.core.interactivity.any_variable import AnyVariable
@@ -29,6 +31,13 @@ from dara.core.visual.dynamic_component import py_component
 
 def _is_component_subclass(obj: Any) -> bool:
     return inspect.isclass(obj) and issubclass(obj, ComponentInstance) and obj != ComponentInstance
+
+
+def _is_component_instance(obj: Any) -> TypeGuard[ComponentInstance]:
+    try:
+        return isinstance(obj, ComponentInstance)
+    except:
+        return False
 
 
 def _is_action_subclass(obj: Any) -> bool:
@@ -101,6 +110,8 @@ def run_discovery(
         # Look for subclasses of ComponentInstance or ActionImpl
         if _is_component_subclass(v):
             components.add(v)
+        elif _is_component_instance(v):
+            components.add(v.__class__)
         elif _is_action_subclass(v):
             actions.add(v)
         elif inspect.isfunction(v):


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Issue reported where defining an instance in another file and importing it directly would not auto discover the component:

```py
# file: my_project/my_component.py
from dara.components import UploadDropzone

dropzone = UploadDropzone()

# file: my_project/main.py
from dara.core import ConfigurationBuilder
from .my_component import dropzone

config = ConfigurationBuilder()
config.add_page(name='Upload Dropzone', content=dropzone)
```

This is because the algorithm only looked for component *classes*. It is now extended to also consider component instances and register their types. We collect them in a set so there is no risk of duplicates, the only downside of this change is a very minor performance penalty as it's another check to run.


## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in a repro app

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->