### PR TITLE
Improvement: DO-6672 Prevent BackendStore loopback on write, Remove ignore_current_channel, Fix first read

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ deps-project:
 
 # Preprocess resources required to test or build packages
 prepare:
-	lerna run build
+	pnpm lerna run build
 
 # Install any deps and prepare any docs that need to be built without requiring all modules to be installed
 prepare-docs:
@@ -16,13 +16,13 @@ prepare-docs:
 
 # Run lint / static testing
 lint:
-	poetry anthology run lint && lerna run lint
+	poetry anthology run lint && pnpm lerna run lint
 
 format:
-	poetry anthology run format && lerna run format
+	poetry anthology run format && pnpm lerna run format
 
 format-check:
-	poetry anthology run format-check && lerna run format:check
+	poetry anthology run format-check && pnpmlerna run format:check
 
 # Run security scan
 security-scan:
@@ -58,7 +58,7 @@ link:
 
 # Run tests
 test:
-	poetry anthology run test && lerna run test
+	poetry anthology run test && pnpm lerna run test
 
 # Version all the main packages in lockstep as a patch - run pnpm i and lock to update the lockfiles accordingly
 version-patch:
@@ -85,7 +85,7 @@ publish:
 
 	echo "//registry.npmjs.org/:_authToken=$${NPMJS_TOKEN}" >> .npmrc
 	git update-index --assume-unchanged .npmrc
-	lerna publish from-package --yes --no-git-reset --no-push --no-git-tag-version --force-publish
+	pnpm lerna publish from-package --yes --no-git-reset --no-push --no-git-tag-version --force-publish
 	sed -i '$$ d' .npmrc
 
 publish-docs:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ format:
 	poetry anthology run format && pnpm lerna run format
 
 format-check:
-	poetry anthology run format-check && pnpmlerna run format:check
+	poetry anthology run format-check && pnpm lerna run format:check
 
 # Run security scan
 security-scan:

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Replaced `ignore_current_channel` parameter with `ignore_channel` in `BackendStore.write`. Only sync writes now prevent loopback by default.
+-  Fixed an issue where sequence numbers would get out of sync on the first refresh due to sending a loopback write request.
+
 ## 1.16.20-alpha.1
 
 -  Reintroduced a `For` component that can be used to render a list of items. Note: this is an initial release of the component and we reserve the right to make (potentially breaking) changes to it in the next few releases as we roll it out internally.

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -501,7 +501,7 @@ def create_router(config: Configuration):
         async def _write(store_uid: str, value: Any):
             WS_CHANNEL.set(ws_channel)
             store_entry: BackendStoreEntry = await registry_mgr.get(backend_store_registry, store_uid)
-            result = store_entry.store.write(value)
+            result = store_entry.store.write(value, ignore_channel=ws_channel)
 
             # Backend implementation could return a coroutine
             if inspect.iscoroutine(result):

--- a/packages/dara-core/dara/core/persistence.py
+++ b/packages/dara-core/dara/core/persistence.py
@@ -18,6 +18,9 @@ from uuid import uuid4
 import aiorwlock
 import anyio
 import jsonpatch
+from dara.core.auth.definitions import USER
+from dara.core.internal.utils import run_user_handler
+from dara.core.logging import dev_logger
 from pydantic import (
     BaseModel,
     Field,
@@ -26,10 +29,6 @@ from pydantic import (
     field_validator,
     model_serializer,
 )
-
-from dara.core.auth.definitions import USER
-from dara.core.internal.utils import run_user_handler
-from dara.core.logging import dev_logger
 
 if TYPE_CHECKING:
     from dara.core.interactivity.plain_variable import Variable
@@ -112,20 +111,20 @@ class FileBackend(PersistenceBackend):
     path: str
     _lock: aiorwlock.RWLock = PrivateAttr(default_factory=aiorwlock.RWLock)
 
-    @field_validator('path', check_fields=True)
+    @field_validator("path", check_fields=True)
     @classmethod
     def validate_path(cls, value):
-        if not os.path.splitext(value)[1] == '.json':
-            raise ValueError('FileBackend path must be a .json file')
+        if not os.path.splitext(value)[1] == ".json":
+            raise ValueError("FileBackend path must be a .json file")
         return value
 
     async def _read_data(self):
-        async with await anyio.open_file(self.path, 'r') as f:
+        async with await anyio.open_file(self.path, "r") as f:
             content = await f.read()
             return json.loads(content) if content else {}
 
     async def _write_data(self, data: Dict[str, Any]):
-        async with await anyio.open_file(self.path, 'w') as f:
+        async with await anyio.open_file(self.path, "w") as f:
             await f.write(json.dumps(data))
 
     async def has(self, key: str) -> bool:
@@ -170,15 +169,15 @@ class PersistenceStore(BaseModel, abc.ABC):
     # TODO: if need be this can also hold a reference to js impl
 
     @abc.abstractmethod
-    async def init(self, variable: 'Variable'):
+    async def init(self, variable: "Variable"):
         """
         Initialize the store when connecting to a variable
         """
 
-    @model_serializer(mode='wrap')
+    @model_serializer(mode="wrap")
     def ser_model(self, nxt: SerializerFunctionWrapHandler) -> dict:
         parent_dict = nxt(self)
-        parent_dict['__typename'] = self.__class__.__name__
+        parent_dict["__typename"] = self.__class__.__name__
         return parent_dict
 
 
@@ -195,7 +194,7 @@ class BackendStore(PersistenceStore):
 
     uid: str = Field(default_factory=lambda: str(uuid4()))
     backend: PersistenceBackend = Field(default_factory=InMemoryBackend, exclude=True)
-    scope: Literal['global', 'user'] = 'global'
+    scope: Literal["global", "user"] = "global"
     readonly: bool = False
 
     default_value: Any = Field(default=None, exclude=True)
@@ -222,16 +221,16 @@ class BackendStore(PersistenceStore):
         """
         kwargs: Dict[str, Any] = {}
         if backend:
-            kwargs['backend'] = backend
+            kwargs["backend"] = backend
 
         if uid:
-            kwargs['uid'] = uid
+            kwargs["uid"] = uid
 
         if scope:
-            kwargs['scope'] = scope
+            kwargs["scope"] = scope
 
         if readonly:
-            kwargs['readonly'] = readonly
+            kwargs["readonly"] = readonly
 
         super().__init__(**kwargs)
 
@@ -239,14 +238,16 @@ class BackendStore(PersistenceStore):
         """
         Get the key for this store
         """
-        if self.scope == 'global':
-            key = 'global'
+        if self.scope == "global":
+            key = "global"
 
             # Make sure the store is initialized
-            if 'global' not in self.initialized_scopes:
-                self.initialized_scopes.add('global')
+            if "global" not in self.initialized_scopes:
+                self.initialized_scopes.add("global")
                 if not await run_user_handler(self.backend.has, args=(key,)):
-                    await run_user_handler(self.backend.write, (key, self.default_value))
+                    await run_user_handler(
+                        self.backend.write, (key, self.default_value)
+                    )
                     # Initialize sequence number for this key
                     self.sequence_number[key] = 0
 
@@ -261,20 +262,24 @@ class BackendStore(PersistenceStore):
             if user_key not in self.initialized_scopes:
                 self.initialized_scopes.add(user_key)
                 if not await run_user_handler(self.backend.has, args=(user_key,)):
-                    await run_user_handler(self.backend.write, (user_key, self.default_value))
+                    await run_user_handler(
+                        self.backend.write, (user_key, self.default_value)
+                    )
                     # Initialize sequence number for this key
                     self.sequence_number[user_key] = 0
 
             return user_key
 
-        raise ValueError('User not found when trying to compute the key for a user-scoped store')
+        raise ValueError(
+            "User not found when trying to compute the key for a user-scoped store"
+        )
 
     def _get_user(self, key: str) -> Optional[str]:
         """
         Get the user for a given key. Returns None if the key is global.
         Reverts the `_get_key` method to get the user for a given key.
         """
-        if key == 'global':
+        if key == "global":
             return None
 
         # otherwise key is a user identity_id or identity_name
@@ -299,14 +304,16 @@ class BackendStore(PersistenceStore):
             )
             return True
         except ValueError:
-            dev_logger.info(f'BackendStore with uid "{self.uid}" already exists, reusing the same instance')
+            dev_logger.info(
+                f'BackendStore with uid "{self.uid}" already exists, reusing the same instance'
+            )
             return False
 
     @property
-    def ws_mgr(self) -> 'WebsocketManager':
+    def ws_mgr(self) -> "WebsocketManager":
         from dara.core.internal.registries import utils_registry
 
-        return utils_registry.get('WebsocketManager')
+        return utils_registry.get("WebsocketManager")
 
     def _create_msg(self, scope_key: str, **payload) -> Dict[str, Any]:
         """
@@ -317,7 +324,11 @@ class BackendStore(PersistenceStore):
         if not payload or len(payload) != 1:
             raise ValueError("Exactly one of 'value' or 'patches' must be provided")
 
-        return {'store_uid': self.uid, 'sequence_number': self.sequence_number.get(scope_key, 0), **payload}
+        return {
+            "store_uid": self.uid,
+            "sequence_number": self.sequence_number.get(scope_key, 0),
+            **payload,
+        }
 
     def _get_next_sequence_number(self, key: str) -> int:
         """
@@ -329,7 +340,9 @@ class BackendStore(PersistenceStore):
         self.sequence_number[key] = current + 1
         return self.sequence_number[key]
 
-    async def _notify_user(self, user_identifier: str, ignore_channel: Optional[str] = None, **payload):
+    async def _notify_user(
+        self, user_identifier: str, ignore_channel: Optional[str] = None, **payload
+    ):
         """
         Notify a given user about updates to this store.
         :param user_identifier: user to notify
@@ -349,7 +362,7 @@ class BackendStore(PersistenceStore):
         :param payload: either value=... or patches=...
         """
         return await self.ws_mgr.broadcast(
-            self._create_msg('global', **payload),
+            self._create_msg("global", **payload),
             ignore_channel=ignore_channel,
         )
 
@@ -359,9 +372,9 @@ class BackendStore(PersistenceStore):
         Broadcasts to all users if scope is global or sends to the current user if scope is user.
 
         :param value: value to notify about
-        :param ignore_channel: if True, ignore the specified channel
+        :param ignore_channel: if passed, ignore the specified channel when broadcasting
         """
-        if self.scope == 'global':
+        if self.scope == "global":
             return await self._notify_global(value=value, ignore_channel=ignore_channel)
 
         # For user scope, we need to find channels for the user and notify them
@@ -371,7 +384,9 @@ class BackendStore(PersistenceStore):
             return
 
         user_identifier = user.identity_id or user.identity_name
-        return await self._notify_user(user_identifier, value=value, ignore_channel=ignore_channel)
+        return await self._notify_user(
+            user_identifier, value=value, ignore_channel=ignore_channel
+        )
 
     async def _notify_patches(self, patches: List[Dict[str, Any]]):
         """
@@ -380,7 +395,7 @@ class BackendStore(PersistenceStore):
 
         :param patches: list of JSON patch operations
         """
-        if self.scope == 'global':
+        if self.scope == "global":
             return await self._notify_global(patches=patches)
 
         # For user scope, we need to find channels for the user and notify them
@@ -392,7 +407,7 @@ class BackendStore(PersistenceStore):
         user_identifier = user.identity_id or user.identity_name
         return await self._notify_user(user_identifier, patches=patches)
 
-    async def init(self, variable: 'Variable'):
+    async def init(self, variable: "Variable"):
         """
         Write the default value to the store if it's not set
 
@@ -411,7 +426,9 @@ class BackendStore(PersistenceStore):
 
             await self.backend.subscribe(_on_value)
 
-    async def write_partial(self, data: Union[List[Dict[str, Any]], Any], notify: bool = True):
+    async def write_partial(
+        self, data: Union[List[Dict[str, Any]], Any], notify: bool = True
+    ):
         """
         Apply partial updates to the store using JSON Patch operations or automatic diffing.
 
@@ -422,7 +439,7 @@ class BackendStore(PersistenceStore):
         :param notify: whether to broadcast the patches to clients
         """
         if self.readonly:
-            raise ValueError('Cannot write to a read-only store')
+            raise ValueError("Cannot write to a read-only store")
 
         key = await self._get_key()
 
@@ -434,22 +451,24 @@ class BackendStore(PersistenceStore):
             current_value = {}
 
         # Determine if data is patches or a full object
-        if isinstance(data, list) and all(isinstance(item, dict) and 'op' in item for item in data):
+        if isinstance(data, list) and all(
+            isinstance(item, dict) and "op" in item for item in data
+        ):
             # Data is a list of patch operations
             patches = data
 
             if not isinstance(current_value, (dict, list)):
                 # JSON patches can only be applied to structured data (objects/arrays)
                 raise ValueError(
-                    f'Cannot apply JSON patches to non-structured data. '
-                    f'Current value is of type {type(current_value).__name__}, but patches require dict or list.'
+                    f"Cannot apply JSON patches to non-structured data. "
+                    f"Current value is of type {type(current_value).__name__}, but patches require dict or list."
                 )
 
             # Apply patches to current value
             try:
                 updated_value = jsonpatch.apply_patch(current_value, patches)
             except (jsonpatch.InvalidJsonPatch, jsonpatch.JsonPatchException) as e:
-                raise ValueError(f'Invalid JSON patch operation: {e}') from e
+                raise ValueError(f"Invalid JSON patch operation: {e}") from e
         else:
             # Data is a full object - generate patches by diffing
             patches = jsonpatch.make_patch(current_value, data).patch
@@ -466,7 +485,9 @@ class BackendStore(PersistenceStore):
 
         return updated_value
 
-    async def write(self, value: Any, notify=True, ignore_channel: Optional[str] = None):
+    async def write(
+        self, value: Any, notify=True, ignore_channel: Optional[str] = None
+    ):
         """
         Persist a value to the store.
 
@@ -475,10 +496,10 @@ class BackendStore(PersistenceStore):
 
         :param value: value to write
         :param notify: whether to broadcast the new value to clients
-        :param ignore_channel: if True, ignore the specified websocket channel
+        :param ignore_channel: if passed, ignore the specified websocket channel when broadcasting
         """
         if self.readonly:
-            raise ValueError('Cannot write to a read-only store')
+            raise ValueError("Cannot write to a read-only store")
 
         key = await self._get_key()
 
@@ -514,7 +535,7 @@ class BackendStore(PersistenceStore):
         :param notify: whether to broadcast that the value was deleted to clients
         """
         if self.readonly:
-            raise ValueError('Cannot delete from a read-only store')
+            raise ValueError("Cannot delete from a read-only store")
 
         key = await self._get_key()
         if notify:

--- a/packages/dara-core/dara/core/persistence.py
+++ b/packages/dara-core/dara/core/persistence.py
@@ -29,7 +29,6 @@ from pydantic import (
 
 from dara.core.auth.definitions import USER
 from dara.core.internal.utils import run_user_handler
-from dara.core.internal.websocket import WS_CHANNEL
 from dara.core.logging import dev_logger
 
 if TYPE_CHECKING:
@@ -330,39 +329,40 @@ class BackendStore(PersistenceStore):
         self.sequence_number[key] = current + 1
         return self.sequence_number[key]
 
-    async def _notify_user(self, user_identifier: str, ignore_current_channel: bool = True, **payload):
+    async def _notify_user(self, user_identifier: str, ignore_channel: Optional[str] = None, **payload):
         """
         Notify a given user about updates to this store.
         :param user_identifier: user to notify
-        :param ignore_current_channel: if True, ignore the current websocket channel
+        :param ignore_channel: if specified, ignore the specified channel
         :param payload: either value=... or patches=...
         """
         return await self.ws_mgr.send_message_to_user(
             user_identifier,
             self._create_msg(user_identifier, **payload),
-            ignore_channel=WS_CHANNEL.get() if ignore_current_channel else None,
+            ignore_channel=ignore_channel,
         )
 
-    async def _notify_global(self, ignore_current_channel: bool = True, **payload):
+    async def _notify_global(self, ignore_channel: Optional[str] = None, **payload):
         """
         Notify all users about updates to this store.
-        :param ignore_current_channel: if True, ignore the current websocket channel
+        :param ignore_channel: if specified, ignore the specified channel
         :param payload: either value=... or patches=...
         """
         return await self.ws_mgr.broadcast(
             self._create_msg('global', **payload),
-            ignore_channel=WS_CHANNEL.get() if ignore_current_channel else None,
+            ignore_channel=ignore_channel,
         )
 
-    async def _notify_value(self, value: Any):
+    async def _notify_value(self, value: Any, ignore_channel: Optional[str] = None):
         """
         Notify all clients about the new value for this store.
         Broadcasts to all users if scope is global or sends to the current user if scope is user.
 
         :param value: value to notify about
+        :param ignore_channel: if True, ignore the specified channel
         """
         if self.scope == 'global':
-            return await self._notify_global(value=value)
+            return await self._notify_global(value=value, ignore_channel=ignore_channel)
 
         # For user scope, we need to find channels for the user and notify them
         user = USER.get()
@@ -371,7 +371,7 @@ class BackendStore(PersistenceStore):
             return
 
         user_identifier = user.identity_id or user.identity_name
-        return await self._notify_user(user_identifier, value=value)
+        return await self._notify_user(user_identifier, value=value, ignore_channel=ignore_channel)
 
     async def _notify_patches(self, patches: List[Dict[str, Any]]):
         """
@@ -406,8 +406,8 @@ class BackendStore(PersistenceStore):
             async def _on_value(key: str, value: Any):
                 # here we explicitly DON'T ignore the current channel, in case we created this variable inside e.g. a py_component we want to notify its creator as well
                 if user := self._get_user(key):
-                    return await self._notify_user(user, ignore_current_channel=False, value=value)
-                return await self._notify_global(ignore_current_channel=False, value=value)
+                    return await self._notify_user(user, value=value)
+                return await self._notify_global(value=value)
 
             await self.backend.subscribe(_on_value)
 
@@ -466,7 +466,7 @@ class BackendStore(PersistenceStore):
 
         return updated_value
 
-    async def write(self, value: Any, notify=True):
+    async def write(self, value: Any, notify=True, ignore_channel: Optional[str] = None):
         """
         Persist a value to the store.
 
@@ -475,6 +475,7 @@ class BackendStore(PersistenceStore):
 
         :param value: value to write
         :param notify: whether to broadcast the new value to clients
+        :param ignore_channel: if True, ignore the specified websocket channel
         """
         if self.readonly:
             raise ValueError('Cannot write to a read-only store')
@@ -486,7 +487,7 @@ class BackendStore(PersistenceStore):
         self._get_next_sequence_number(key)
 
         if notify:
-            await self._notify_value(value)
+            await self._notify_value(value, ignore_channel=ignore_channel)
 
         return res
 

--- a/packages/dara-core/js/shared/interactivity/persistence.tsx
+++ b/packages/dara-core/js/shared/interactivity/persistence.tsx
@@ -55,6 +55,7 @@ function BackendStoreSync({ children }: { children: React.ReactNode }): JSX.Elem
         await validateResponse(response, `Failed to fetch the store value for key: ${itemKey}`);
         const { value, sequence_number } = await response.json();
 
+        STORE_LATEST_VALUE_MAP.set(itemKey, value);
         STORE_SEQUENCE_MAP.set(itemKey, sequence_number);
 
         return value;

--- a/packages/dara-core/package.json
+++ b/packages/dara-core/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "rimraf dist && rimraf dara/core/umd && vite build && tsc && cp -R js/assets dist/ && cp js/index.css dist/ && tsc-alias && cp -R dist/umd/ dara/core/umd/",
-    "build-dev": "tsc && (concurrently \"tsc -w\" \"tsc-alias -w\")",
+    "build-dev": "mkdir -p dist && cp js/index.css dist/ && cp -R js/assets dist/ && tsc && (concurrently \"tsc -w\" \"tsc-alias -w\")",
     "clean": "rimraf api assets components shared types *.js.map *.d.ts '!(*.config).js' *.css",
     "cypress:open": "cypress open",
     "lint": "tsc --noemit && eslint js tests cypress --ext .tsx,.ts --max-warnings 0 && stylelint './js/**/*.tsx'",

--- a/packages/dara-core/tests/python/test_persistence.py
+++ b/packages/dara-core/tests/python/test_persistence.py
@@ -8,7 +8,6 @@ import pytest
 from anyio import sleep
 from dara.core.auth.definitions import USER, UserData
 from dara.core.interactivity.plain_variable import Variable
-from dara.core.internal.websocket import WS_CHANNEL
 from dara.core.persistence import (
     BackendStore,
     FileBackend,
@@ -200,8 +199,7 @@ async def test_user_scope_notifications(user_backend_store, mock_ws_mgr):
         any_order=True,
     )
 
-    # test that if we're under a WS_CHANNEL scope, we don't notify the same originating channel
-    WS_CHANNEL.set('channel3')
+    # test that when an ignore_channel is provided, we don't notify it
     await user_backend_store.write('test_value_3', notify=True, ignore_channel='channel3')
     assert mock_ws_mgr.send_message_to_user.call_count == 3
     mock_ws_mgr.send_message_to_user.assert_has_calls(

--- a/packages/dara-core/tests/python/test_persistence.py
+++ b/packages/dara-core/tests/python/test_persistence.py
@@ -6,9 +6,6 @@ from unittest.mock import AsyncMock, call
 
 import pytest
 from anyio import sleep
-from fastapi.encoders import jsonable_encoder
-from pydantic import Field, ValidationError
-
 from dara.core.auth.definitions import USER, UserData
 from dara.core.interactivity.plain_variable import Variable
 from dara.core.internal.websocket import WS_CHANNEL
@@ -18,6 +15,8 @@ from dara.core.persistence import (
     InMemoryBackend,
     PersistenceBackend,
 )
+from fastapi.encoders import jsonable_encoder
+from pydantic import Field, ValidationError
 
 from tests.python.utils import wait_for
 
@@ -203,7 +202,7 @@ async def test_user_scope_notifications(user_backend_store, mock_ws_mgr):
 
     # test that if we're under a WS_CHANNEL scope, we don't notify the same originating channel
     WS_CHANNEL.set('channel3')
-    await user_backend_store.write('test_value_3', notify=True)
+    await user_backend_store.write('test_value_3', notify=True, ignore_channel='channel3')
     assert mock_ws_mgr.send_message_to_user.call_count == 3
     mock_ws_mgr.send_message_to_user.assert_has_calls(
         [
@@ -843,25 +842,6 @@ async def test_write_partial_copy_and_move_operations(backend_store):
     assert await backend_store.read() == expected
 
 
-async def test_write_partial_with_ws_channel(backend_store, mock_ws_mgr):
-    """
-    Test that write_partial respects WS_CHANNEL context for ignoring originating channel
-    """
-    await backend_store.write({'name': 'John'}, notify=False)
-    
-    # Set WS channel context
-    WS_CHANNEL.set('test_channel')
-    
-    patches = [{'op': 'replace', 'path': '/name', 'value': 'Jane'}]
-    await backend_store.write_partial(patches)
-    
-    # Should ignore the originating channel
-    mock_ws_mgr.broadcast.assert_called_once_with(
-        {'store_uid': backend_store.uid, 'patches': patches, 'sequence_number': 2},
-        ignore_channel='test_channel'
-    )
-    
-    WS_CHANNEL.set(None)
 
 
 async def test_write_partial_non_structured_data(backend_store):


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->
Previously we had ignore_current_channel for all notifications to prevent loopbacks.

This now causes an issue with partial updates, where the user needs to specifically set `WS_CHANNEL.set(None)` before a `write_partial` to repaint the UI.

Now that we're also checking for `STORE_LATEST_VALUE_MAP` on the client, we can ignore only the `write` part in `sync_backend_store`, removing `ignore_current_channel` and the need to reset WS_CHANNEL.

Also fixes an issue where the first read after a browser refresh was sending another write on the client, un-syncing the sequence numbers.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Demo app, fixed tests

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->