### PR TITLE
Fix: DO-6799 component instance fails validation when raw_css=None

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where `ComponentInstance` would fail validation if `raw_css` was explicitly set to `None`
+
 ## 1.17.0
 
 -  Added `SwitchVariable` for frontend-only conditional logic. Use `SwitchVariable.when()` for boolean conditions and `SwitchVariable.match()` for value mappings. Provides better performance than `DerivedVariable` for simple conditional logic by avoiding backend roundtrips.

--- a/packages/dara-core/dara/core/definitions.py
+++ b/packages/dara-core/dara/core/definitions.py
@@ -212,7 +212,7 @@ class ComponentInstance(BaseModel):
         if isinstance(css, (NonDataVariable, CSSProperties, str)):
             return css
 
-        raise ValueError(f'raw_css must be a CSSProperties, dict, str, or NonDataVariable, got {type(css)}')
+        raise ValueError(f'raw_css must be a CSSProperties, dict, str, None or NonDataVariable, got {type(css)}')
 
     @classmethod
     def isinstance(cls, obj: Any) -> bool:

--- a/packages/dara-core/dara/core/definitions.py
+++ b/packages/dara-core/dara/core/definitions.py
@@ -93,16 +93,14 @@ class ErrorHandlingConfig(BaseModel):
     def validate_raw_css(cls, value):
         from dara.core.interactivity.non_data_variable import NonDataVariable
 
-        if isinstance(value, str):
-            return str
+        if value is None:
+            return None
+        if isinstance(value, (str, NonDataVariable, CSSProperties)):
+            return value
         if isinstance(value, dict):
             return {_kebab_to_camel(k): v for k, v in value.items()}
-        if isinstance(value, NonDataVariable):
-            return value
-        if isinstance(value, CSSProperties):
-            return value
 
-        raise ValueError(f'raw_css must be a CSSProperties, dict, str, or NonDataVariable, got {type(value)}')
+        raise ValueError(f'raw_css must be a CSSProperties, dict, str, None or NonDataVariable, got {type(value)}')
 
     def model_dump(self, *args, **kwargs):
         result = super().model_dump(*args, **kwargs)
@@ -204,17 +202,14 @@ class ComponentInstance(BaseModel):
     def parse_css(cls, css: Optional[Any]):
         from dara.core.interactivity.non_data_variable import NonDataVariable
 
+        if css is None:
+            return None
+
         # If it's a plain dict, change kebab case to camel case
         if isinstance(css, dict):
             return {_kebab_to_camel(k): v for k, v in css.items()}
 
-        if isinstance(css, NonDataVariable):
-            return css
-
-        if isinstance(css, CSSProperties):
-            return css
-
-        if isinstance(css, str):
+        if isinstance(css, (NonDataVariable, CSSProperties, str)):
             return css
 
         raise ValueError(f'raw_css must be a CSSProperties, dict, str, or NonDataVariable, got {type(css)}')

--- a/packages/dara-core/tests/python/test_components.py
+++ b/packages/dara-core/tests/python/test_components.py
@@ -40,6 +40,20 @@ def test_css_variable():
     }
 
 
+def test_none_raw_css():
+    """Test that ComponentInstance can accept None for raw_css"""
+
+    class TestInstance(ComponentInstance):
+        pass
+
+    instance = TestInstance(raw_css=None)
+    assert instance.dict() == {
+        'name': 'TestInstance',
+        'props': {},
+        'uid': instance.uid,
+    }
+
+
 def test_children():
     class TestComponent(StyledComponentInstance):
         foo: str


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Regression caused by prior release, passing raw_css as explicitly None would fail validation.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Adjusted validation

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added regression test, failed before but passes now

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->