### PR TITLE
Fix: DO-6799 raw_css set to a Variable with dict styles wouldn't update

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -  Fixed an issue where `ComponentInstance` would fail validation if `raw_css` was explicitly set to `None`
+-  Fixed an issue where setting `raw_css` to a `Variable` with an object value would not update the component's styles
 
 ## 1.17.0
 

--- a/packages/dara-core/js/shared/utils/use-component-styles.tsx
+++ b/packages/dara-core/js/shared/utils/use-component-styles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import { useContext, useMemo } from 'react';
 import * as React from 'react';
 
@@ -118,7 +117,8 @@ export default function useComponentStyles(
 
         // Filter out null/undefined values so they don't end up accidentally overriding other style properties
         return Object.fromEntries(Object.entries(stylesObj).filter(([, v]) => v !== null && v !== undefined));
-    }, [useDeepCompare(props)]);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [useDeepCompare(props), rawStyles, flexProps]);
 
     return [styles, rawCss];
 }


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Issue with `raw_css` set to a Variable that resolves to a dict. Caused by missing memo dependency.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by modifying the JS in a local app where the issue was found

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->