### PR TITLE
Fix: DO-6904 fix token refresh handling

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue with websockets being force closed on token refresh. This would cause certain elements of the application to hang until the page was refreshed.
+
 ## 1.17.3
 
 -  Fixed an issue where in some cases actions consuming DerivedVariables would cause extra calculations of the derived variable to be performed even if a cached value was available

--- a/packages/dara-core/js/shared/template-root/template-root.tsx
+++ b/packages/dara-core/js/shared/template-root/template-root.tsx
@@ -104,10 +104,6 @@ function TemplateRoot(props: TemplateRootProps): React.ReactNode {
 
         const newWsClient = setupWebsocket(token, config.live_reload);
         setWsClient(newWsClient);
-
-        return () => {
-            newWsClient.close();
-        };
     }, [token, config?.live_reload]);
 
     if (templateLoading || actionsLoading || componentsLoading || !wsClient) {


### PR DESCRIPTION
## Motivation and Context
The websocket in dara was being force closed and not recreated when the token refreshed. Removing the force closure resolves the issue. @krzysztof-causalens I'm not sure exactly what the reason for adding the closure was in the first place, so perhaps this breaks something else? 

## Implementation Description
* Removed the forced closure of the websocket on token change. The structure of the hook meant that the first time the token changed it would close the existing websocket but not recreate it. This permanently bricked the WS connection and the app would appear to hang anywhere that used actions or derived vars.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Tested Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.