### PR TITLE
Improvement: DO-6942 add generate_code_override context variable

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Internal: added `GENERATE_CODE_OVERRIDE` context variable to allow overriding the download code generation logic
+
 ## 1.18.1
 
 -  Fixed missing `cachetools` dependency

--- a/packages/dara-core/dara/core/internal/download.py
+++ b/packages/dara-core/dara/core/internal/download.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Awaitable
+from contextvars import ContextVar
 from typing import Callable, Optional, Tuple
 from uuid import uuid4
 
@@ -73,6 +74,13 @@ async def download(data_entry: DownloadDataEntry) -> Tuple[anyio.AsyncFile, Call
     return (async_file, cleanup)
 
 
+GENERATE_CODE_OVERRIDE = ContextVar[Optional[Callable[[str], str]]]('GENERATE_CODE_OVERRIDE', default=None)
+"""
+Optional context variable which can be used to override the default behaviour of code generation.
+Invoked with the file path to generate a download code for.
+"""
+
+
 async def generate_download_code(file_path: str, cleanup_file: bool) -> str:
     """
     Generate a one-time download code for a given dataset.
@@ -88,7 +96,10 @@ async def generate_download_code(file_path: str, cleanup_file: bool) -> str:
     user = USER.get()
 
     # Unique download id
-    uid = str(uuid4())
+    if override := GENERATE_CODE_OVERRIDE.get():
+        uid = override(file_path)
+    else:
+        uid = str(uuid4())
 
     # Put it in the store under the registry entry with TTL configured
     await store.set(

--- a/packages/dara-core/tests/python/test_download.py
+++ b/packages/dara-core/tests/python/test_download.py
@@ -17,7 +17,13 @@ from dara.core.definitions import ComponentInstance
 from dara.core.interactivity.actions import DownloadContent
 from dara.core.interactivity.plain_variable import Variable
 from dara.core.internal.cache_store import CacheStore
-from dara.core.internal.download import DownloadDataEntry, DownloadRegistryEntry, download, generate_download_code
+from dara.core.internal.download import (
+    GENERATE_CODE_OVERRIDE,
+    DownloadDataEntry,
+    DownloadRegistryEntry,
+    download,
+    generate_download_code,
+)
 from dara.core.internal.registries import utils_registry
 from dara.core.internal.registry import RegistryType
 from dara.core.main import _start_application
@@ -359,3 +365,10 @@ async def test_download_override():
             assert response.content == b'test'
             assert custom_download_called
             assert code_override_called
+
+
+async def test_download_code_override():
+    GENERATE_CODE_OVERRIDE.set(lambda x: f'{x}_override')
+
+    code = await generate_download_code('test_download.txt', cleanup_file=True)
+    assert code == 'test_download.txt_override'


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Turns out overriding download behaviour in #458 isn't enough when we don't know how a code was generated. This PR adds an extra context var to override how the code itself is generated. This lets us encode additional information in the generated codes to e.g. route the download implementation to different sources.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in a project which needs it

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->