### PR TITLE
Fix: DO-6971 UrlVariables being wiped

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where `UrlVariable` would be wiped in some cases. The variable now doesn't sync the default value to query params by default
+
 ## 1.18.2
 
 -  Internal: added `GENERATE_CODE_OVERRIDE` context variable to allow overriding the download code generation logic

--- a/packages/dara-core/js/shared/interactivity/url-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/url-variable.tsx
@@ -20,7 +20,11 @@ export function getOrRegisterUrlVariable<T>(variable: UrlVariable<T>): RecoilSta
             atom({
                 default: variable.default,
                 effects: [
-                    urlSyncEffect({ history: 'push', itemKey: variable.query, refine: mixed(), syncDefault: true }),
+                    urlSyncEffect({
+                        history: 'push',
+                        itemKey: variable.query,
+                        refine: mixed(),
+                    }),
                 ],
                 key: variable.uid,
             })

--- a/packages/dara-core/pyproject.toml
+++ b/packages/dara-core/pyproject.toml
@@ -9,7 +9,8 @@ lint = "poetry run pyright ./dara && poetry run ruff check ./dara"
 package = "poetry build -f wheel"
 publish = "poetry publish"
 security-scan = "poetry run bandit dara -r -ll -i"
-test = "mkdir -p ./dist && DARA_TEST_FLAG=true poetry run pytest ./tests -n auto -v"
+# Pool tests are ran after because they don't work well with parallelization
+test = "mkdir -p ./dist && DARA_TEST_FLAG=true poetry run pytest ./tests -n auto -v -m 'not pool' && poetry run pytest ./tests/python/test_pool.py -v"
 
 [tool.poetry]
 authors = ["Sam Smith <sam@causalens.com>", "Krzysztof Bielikowicz <krzysztof@causalens.com>"]
@@ -99,3 +100,6 @@ dara = "dara.core.cli:cli"
 
 [tool.pytest.ini_options]
 timeout = 300
+markers = [
+    "pool: worker pool tests, should not be used with xdist"
+]

--- a/packages/dara-core/tests/python/test_pool.py
+++ b/packages/dara-core/tests/python/test_pool.py
@@ -25,7 +25,7 @@ from dara.core.internal.pool.worker import WorkerProcess
 
 from tests.python.utils import sleep_for, wait_assert, wait_for
 
-pytestmark = [pytest.mark.anyio, pytest.mark.xdist_group(name='pool')]
+pytestmark = [pytest.mark.anyio, pytest.mark.pool]
 
 WORKER_PARAMS: WorkerParameters = {'task_module': 'tests.python.tasks'}
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

In some convoluted scenarios where URLVariables were being rendered within e.g. py_components, they would sync their default value instead of reading from URLs.
To circumvent that, I found that flipping `syncDefault` back to false fixes the issue.
This changes the behaviour slightly in that the default value doesn't immediately end up in the query params. This might be for the better though as it pollutes the user's url bar less. Passing a default value in the url bar still works, it's just not synced up.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in a reproducible scenario

https://github.com/user-attachments/assets/36e214ee-1b32-4644-b0f8-6905ef3f77b1



## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->