### PR TITLE
Improvement: DO-6963 don't resuspend components on DerivedVariable change in If and SwitchVariable

### DIFF
--- a/docs/advanced/loading-states.md
+++ b/docs/advanced/loading-states.md
@@ -109,3 +109,5 @@ Select(items=items, fallback=Fallback.Row(suspend_render=500))
 def my_component(items):
     return str(items)
 ```
+
+Note that there are exceptions to the default behavior of suspending the component. Notably, the `SwitchVariable` and the `If` component operate as if `suspend_render` was set to `False`, i.e. they don't suspend the component beyond initial load.

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 -  Fixed an issue where a race condition in the task pool could cause it to no longer be able to process tasks
+-  `If` components and `SwitchVariable`s now operate similar to the `suspend: False` setting - when used with `DerivedVariable`s, they will suspend the component initially until they have the initial value; for further changes, they will use the prior value rather than suspend again
 
 ## 1.19.0
 

--- a/packages/dara-core/js/shared/interactivity/condition-or-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/condition-or-variable.tsx
@@ -3,15 +3,15 @@ import { isCondition } from '@/types/utils';
 
 import { isConditionTrue } from './condition';
 // eslint-disable-next-line import/no-cycle
-import { useVariable } from './use-variable';
+import { type UseVariableOptions, useVariable } from './use-variable';
 
 /* eslint-disable react-hooks/rules-of-hooks */
-export function useConditionOrVariable<T>(arg: Variable<T> | Condition<T> | T): T {
+export function useConditionOrVariable<T>(arg: Variable<T> | Condition<T> | T, opts: UseVariableOptions = {}): T {
     // Note we assume arg never changes from a condition to a variable so we can use hooks conditionally
     if (isCondition(arg)) {
-        const value = useVariable(arg.variable)[0];
-        const other = useVariable(arg.other)[0];
+        const value = useVariable(arg.variable, opts)[0];
+        const other = useVariable(arg.other, opts)[0];
         return isConditionTrue(arg.operator, value, other) as T;
     }
-    return useVariable(arg)[0];
+    return useVariable(arg, opts)[0];
 }

--- a/packages/dara-core/js/shared/interactivity/switch-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/switch-variable.tsx
@@ -4,9 +4,10 @@ import type { SwitchVariable } from '@/types/core';
 import { useConditionOrVariable, useVariable } from './internal';
 
 export function useSwitchVariable<T>(variable: SwitchVariable<T>): any {
-    const value = useConditionOrVariable(variable.value);
-    const [valueMap] = useVariable(variable.value_map);
-    const [defaultValue] = useVariable(variable.default);
+    // don't suspend after initial render
+    const value = useConditionOrVariable(variable.value, { suspend: false });
+    const [valueMap] = useVariable(variable.value_map, { suspend: false });
+    const [defaultValue] = useVariable(variable.default, { suspend: false });
 
     // Always convert to string for consistent lookup since JS object keys are strings
     // This ensures consistent behavior between condition-based and value-based lookups

--- a/packages/dara-core/js/shared/interactivity/use-any-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-any-variable.tsx
@@ -11,7 +11,7 @@ import { useVariable } from './use-variable';
 
 /**
  * A helper hook to retrieve value of any variable.
- * For the rare occassions where a component can accept both a DataVariable and a non-DataVariable.
+ * For the rare occassions where a component can accept both a DataVariable and a non-DataVariable, in a non-suspinding fashion.
  */
 export function useAnyVariable(variable: AnyDataVariable): DataFrame | undefined;
 export function useAnyVariable<T = any>(variable: AnyVariable<T>): T;
@@ -39,5 +39,7 @@ export function useAnyVariable<T = any>(variable: AnyVariable<T>): DataFrame | T
         return data ?? undefined;
     }
 
-    return useVariable(variable)[0];
+    return useVariable(variable, {
+        suspend: false,
+    })[0];
 }

--- a/packages/dara-core/js/shared/interactivity/use-any-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-any-variable.tsx
@@ -11,7 +11,7 @@ import { useVariable } from './use-variable';
 
 /**
  * A helper hook to retrieve value of any variable.
- * For the rare occassions where a component can accept both a DataVariable and a non-DataVariable, in a non-suspinding fashion.
+ * For the rare occassions where a component can accept both a DataVariable and a non-DataVariable, in a non-suspending fashion.
  */
 export function useAnyVariable(variable: AnyDataVariable): DataFrame | undefined;
 export function useAnyVariable<T = any>(variable: AnyVariable<T>): T;

--- a/packages/dara-core/js/shared/interactivity/use-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable.tsx
@@ -32,6 +32,10 @@ function warnUpdateOnDerivedState(): void {
     console.warn('You tried to call update on variable with derived state, this is a noop and will be ignored.');
 }
 
+export interface UseVariableOptions {
+    suspend?: boolean | number;
+}
+
 /**
  * A helper hook that turns a Variable class into the actual value by accessing the appropriate recoil state from the
  * atomRegistry defined above. For convenience, it will also handle a non variable being passed and will return it
@@ -40,7 +44,10 @@ function warnUpdateOnDerivedState(): void {
  *
  * @param variable the possible variable to use
  */
-export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Dispatch<SetStateAction<T>>] {
+export function useVariable<T>(
+    variable: Variable<T> | T,
+    opts: UseVariableOptions = {}
+): [value: T, update: Dispatch<SetStateAction<T>>] {
     const extras = useRequestExtras();
 
     const { client: wsClient } = useContext(WebSocketCtx);
@@ -89,7 +96,7 @@ export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Di
             }
         }, [selectorLoadable]);
 
-        const deferred = useDeferLoadable(selectorLoadable);
+        const deferred = useDeferLoadable(selectorLoadable, opts.suspend);
 
         return [deferred.value, warnUpdateOnDerivedState];
     }
@@ -124,7 +131,7 @@ export function useVariable<T>(variable: Variable<T> | T): [value: T, update: Di
         }
     }, [loadable]);
 
-    const deferred = useDeferLoadable(loadable);
+    const deferred = useDeferLoadable(loadable, opts.suspend);
 
     return [deferred, setLoadable];
 }

--- a/packages/dara-core/js/shared/utils/use-defer-loadable.tsx
+++ b/packages/dara-core/js/shared/utils/use-defer-loadable.tsx
@@ -7,9 +7,12 @@ import { useFallbackCtx } from '../context/fallback-context';
  * A hook that allows you to defer the loading of a loadable depending on the suspend setting in FallbackCtx.
  *
  * @param loadable The loadable to defer
+ * @param suspendOverride Optional override for suspend setting in FallbackCtx
  */
-export default function useDeferLoadable<T>(loadable: Loadable<T>): T {
-    const { suspend } = useFallbackCtx();
+export default function useDeferLoadable<T>(loadable: Loadable<T>, suspendOverride?: boolean | number): T {
+    const { suspend: ctxSuspend } = useFallbackCtx();
+    const suspend = suspendOverride ?? ctxSuspend;
+
     // Suspend on first render with getValue()
     const [availableState, setAvailableState] = useState(() => loadable.getValue());
 


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

A quirk of the reactivity system of Dara was that components that are meant to be purely client-side and help users avoid backend roundtrips and thus excessive spinners, didn't quite achieve that:
The `If` component and `SwitchVariable`, when used together with a `DerivedVariable` as the Condition, would suspend the entire `If` component (in the former case) or the component consuming the switch (in the latter) on every computation change.

This PR changes those so that they behave as if `suspend=False` setting was set on them. This means that while they will suspend for the initial computation (unavoidable), further changes will choose to tear rather than suspend - use the prior state while a new one is computed.

Users can choose to use py_components instead if they want to opt into granular fallback control and explicitly suspend, If/SwitchVariable are designed as the 'good default' while avoiding those.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

Passed extra `suspend` option into useVariable, explicitly set to override the fallback setting in `If` and `SwitchVariable`

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally


https://github.com/user-attachments/assets/5c0ac375-2c9f-48d9-bffd-8ce3a25ca5b0

Demo

```python
var_input = Variable(default=1)


async def compute(inp: int):
    await asyncio.sleep(2)
    return int(inp) * 2


output = DerivedVariable(compute, variables=[var_input], cache=None)

def page():
    return Stack(
        Input(value=var_input, type='number'),
        Text(
            'OUTPUT:',
            raw_css=SwitchVariable.when(output > 5, {'color': 'red'}, {'color': 'green'}),
            fallback=Fallback.Row(),
        ),
        Text(text=output, fallback=Fallback.Row()),
        If(output > 5, Text('Greater than 5'), Text('Less than 5')),
    )

```

The colored OUTPUT text (using SwitchVariable) and the `If` 'greater/less' text does not suspend, only the direct text does.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->