### PR TITLE
Fix: DO-7216 - SectionedList on-change bugfix and placeholder support

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -5,6 +5,8 @@ title: Changelog
 ## NEXT
 
 -  Fixed an issue where `Table` type inference would not handle the different datetime64 types correctly.
+-  Fixed an issue where `SectionedList` would not update the input value when clicking on an item.
+-  Updated the `SectionedList` component to support placeholder text.
 
 ## 1.19.1
 

--- a/packages/dara-components/js/common/select/select.tsx
+++ b/packages/dara-components/js/common/select/select.tsx
@@ -177,6 +177,7 @@ function Select(props: SelectProps): JSX.Element {
             <StyledSectionedList
                 $rawCss={css}
                 items={formattedItems}
+                placeholder={props.placeholder}
                 onSelect={onSelect}
                 selectedItem={selectedItem}
                 style={style}

--- a/packages/ui-components/changelog.md
+++ b/packages/ui-components/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fixed an issue where `SectionedList` would not update the input value when clicking on an item.
+- Updated the `SectionedList` component to support placeholder text.
+
 ## 1.19.1
 
 - Added a new `Dropdown` and `DropdownMenu` components which now match the rest of the UI kit

--- a/packages/ui-components/src/sectioned-list/sectioned-list.tsx
+++ b/packages/ui-components/src/sectioned-list/sectioned-list.tsx
@@ -185,7 +185,11 @@ function SectionedList(props: SectionedListProps): JSX.Element {
         itemToString: (item: Item) => (item ? item.label : ''),
         items,
         onInputValueChange: (change) => {
-            if (change.type === stateChangeTypes.ItemClick) {
+            const shouldUpdateInput = (
+                [stateChangeTypes.ItemClick, stateChangeTypes.InputChange] as UseComboboxStateChangeTypes[]
+            ).includes(change.type);
+
+            if (shouldUpdateInput) {
                 setInputValue(change.inputValue);
             }
 

--- a/packages/ui-components/src/sectioned-list/sectioned-list.tsx
+++ b/packages/ui-components/src/sectioned-list/sectioned-list.tsx
@@ -25,7 +25,7 @@ import Badge from '../badge/badge';
 import { Input, InputWrapper, Wrapper } from '../combo-box/combo-box';
 import ChevronButton from '../shared/chevron-button';
 import DropdownList from '../shared/dropdown-list';
-import ListItem, { StyledListItem } from '../shared/list-item';
+import { StyledListItem } from '../shared/list-item';
 import { type InteractiveComponentProps, type Item } from '../types';
 import { matchWidthToReference } from '../utils';
 import { syncKbdHighlightIdx } from '../utils/syncKbdHighlightIdx';
@@ -109,6 +109,8 @@ export interface SectionedListProps extends InteractiveComponentProps<Item> {
     onSelect?: (item: ListItem) => void | Promise<void>;
     /** Put the component in controlled mode and pass in the selectedItem */
     selectedItem?: ListItem | Item;
+    /** An optional placeholder for the input field to display when nothing is selected, defaults to '' */
+    placeholder?: string;
     /** Pass through of style property to the root element */
     style?: React.CSSProperties;
 }
@@ -162,7 +164,11 @@ function SectionedList(props: SectionedListProps): JSX.Element {
 
     const [pendingHighlight, setPendingHighlight] = useState(null);
     const [items, setItems] = useState(unpackedItems);
-    const [inputValue, setInputValue] = useState(props.selectedItem?.label ?? '');
+    const [inputValue, setInputValue] = useState(
+        props.selectedItem?.label && props.selectedItem.label !== 'null' ?
+            props.selectedItem.label
+        :   props.placeholder ?? ''
+    );
 
     const [kbdHighlightIdx, setKbdHighlightIdx] = React.useState<number | undefined>();
     const {
@@ -179,7 +185,9 @@ function SectionedList(props: SectionedListProps): JSX.Element {
         itemToString: (item: Item) => (item ? item.label : ''),
         items,
         onInputValueChange: (change) => {
-            setInputValue(change.inputValue);
+            if (change.type === stateChangeTypes.ItemClick) {
+                setInputValue(change.inputValue);
+            }
 
             if (!change.inputValue) {
                 setItems(unpackedItems);
@@ -300,7 +308,7 @@ function SectionedList(props: SectionedListProps): JSX.Element {
 
     useEffect(() => {
         if (props.selectedItem === null) {
-            setInputValue('');
+            setInputValue(props.placeholder ?? '');
         }
     }, [props.selectedItem]);
 

--- a/packages/ui-components/src/sectioned-list/sectioned-list.tsx
+++ b/packages/ui-components/src/sectioned-list/sectioned-list.tsx
@@ -314,7 +314,7 @@ function SectionedList(props: SectionedListProps): JSX.Element {
         if (props.selectedItem === null) {
             setInputValue(props.placeholder ?? '');
         }
-    }, [props.selectedItem]);
+    }, [props.selectedItem, props.placeholder]);
 
     const { refs, floatingStyles, context } = useFloating<HTMLElement>({
         open: isOpen,


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
The `onInputValueChange` in the sectioned-list component was getting triggered and updating the selected input even on state change event types like `__menu_mouse_leave__`, resulting in sometimes the `selectedItem` being overwritten.

The `Select` component supports the `placeholder` prop but this is not passed along to the `SectionedList` select component 

## Implementation Description
- Updated the `onInputValueChange` to only update the `InputValue` on `InputChange` and `ItemClick` state change events, allowing for selectedItem to only change when searching or actually clicking a new selected item.
- Passed the placeholder prop to the `SectionedList` component and updated logic accordingly to fallback to it.

## Any new dependencies Introduced
No

## How Has This Been Tested?
Manually

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

### BEFORE

https://github.com/user-attachments/assets/b53b6173-a60e-443d-9a9d-4f75ea689376

### AFTER

https://github.com/user-attachments/assets/f7d42c41-f74f-439f-acde-28cb417b6196


