### PR TITLE
Improvement: DO-7496 - propagate the `id_` field to the DOM

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -7,6 +7,7 @@ title: Changelog
 - The `pixi.js` dependency is now lazy-loaded from CDN upon first use, decreasing the required bundle size from ~8.3MB to ~6.9MB
 - Fixed an issue where images included in the `Markdown` component would not work correctly when running the app behind a proxy, i.e. with a custom base url
 - Fixed an issue where buttons allowed propagation of clicks to the parent which meant they could not be nested
+- Set the `id_` property as the default id to all components in the library to allow for more precise identification of components
 
 ## 1.20.1
  - Add flag `suppress_click_events_for_selection` and `onselect_row` event to the table which makes sure that selection can work along with onClickRow even if they do something different, i.e.

--- a/packages/dara-components/js/common/accordion/accordion.tsx
+++ b/packages/dara-components/js/common/accordion/accordion.tsx
@@ -78,6 +78,7 @@ function Accordion(props: AccordionProps): JSX.Element {
             onChange={handleChange as any}
             style={style}
             value={value}
+            id={props.id_}
         />
     );
 }

--- a/packages/dara-components/js/common/anchor/anchor.tsx
+++ b/packages/dara-components/js/common/anchor/anchor.tsx
@@ -68,7 +68,7 @@ function Anchor(props: AnchorProps): JSX.Element {
             as={AsComponent}
             className={props.clean ? 'report-clean-anchor' : props.className}
             href={props.href}
-            id={props.name}
+            id={props.id_ ?? props.name}
             rel="noreferrer"
             style={style}
             target={props.new_tab ? '_blank' : '_self'}

--- a/packages/dara-components/js/common/bullet-list/bullet_list.tsx
+++ b/packages/dara-components/js/common/bullet-list/bullet_list.tsx
@@ -20,7 +20,7 @@ function BulletList(props: BulletListProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const tag = (props.numbered ? 'ol' : 'ul') as keyof JSX.IntrinsicElements;
     return (
-        <StyledTag $rawCss={css} as={tag} style={style}>
+        <StyledTag $rawCss={css} as={tag} style={style} id={props.id_}>
             {items.map((item: string, index: number) => (
                 <li key={`li-${index}`} style={{ textAlign: 'left' }}>
                     {item}

--- a/packages/dara-components/js/common/button/button.tsx
+++ b/packages/dara-components/js/common/button/button.tsx
@@ -74,6 +74,7 @@ function Button(
 
     return (
         <StyledButton
+            id={props.id_}
             $rawCss={css}
             className={className}
             disabled={disabledValue}

--- a/packages/dara-components/js/common/card/card.tsx
+++ b/packages/dara-components/js/common/card/card.tsx
@@ -100,7 +100,7 @@ function Card(props: CardProps): JSX.Element {
     const [subtitle] = useVariable(props.subtitle);
     const [style, css] = useComponentStyles(props);
     return (
-        <CardDiv $rawCss={css} accent={props.accent} style={style}>
+        <CardDiv $rawCss={css} accent={props.accent} style={style} id={props.id_}>
             {title && <Title>{title}</Title>}
             {subtitle && <Subtitle hasTitle={props.title !== null}>{subtitle}</Subtitle>}
             <ChildrenWrapper

--- a/packages/dara-components/js/common/carousel/carousel.tsx
+++ b/packages/dara-components/js/common/carousel/carousel.tsx
@@ -76,6 +76,7 @@ function Carousel(props: CarouselProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     return (
         <StyledCarousel
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             items={remappedItems}

--- a/packages/dara-components/js/common/code/code.tsx
+++ b/packages/dara-components/js/common/code/code.tsx
@@ -18,6 +18,7 @@ function Code(props: CodeProps): JSX.Element {
 
     return (
         <StyledCodeViewer
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             value={code}

--- a/packages/dara-components/js/common/component-select-list/component-select-list.tsx
+++ b/packages/dara-components/js/common/component-select-list/component-select-list.tsx
@@ -57,6 +57,7 @@ function ComponentSelectList(props: ComponentSelectListProps): JSX.Element {
 
     return (
         <StyledComponentSelectList
+            id={props.id_}
             $rawCss={css}
             items={remappedItems}
             itemsPerRow={props.items_per_row}

--- a/packages/dara-components/js/common/dropdown-menu/dropdown-menu.tsx
+++ b/packages/dara-components/js/common/dropdown-menu/dropdown-menu.tsx
@@ -63,6 +63,7 @@ function DropdownMenu(props: DropdownMenuProps): JSX.Element {
 
     return (
         <UIDropdownMenu
+            id={props.id_}
             onClick={onClick}
             menuItems={menuItems}
             button={<Button {...props.button.props} />}

--- a/packages/dara-components/js/common/dropzone/dropzone.tsx
+++ b/packages/dara-components/js/common/dropzone/dropzone.tsx
@@ -165,6 +165,7 @@ function UploadDropzone(props: DropzoneProps): JSX.Element {
     }
     return (
         <StyledDropzone
+            id={props.id_}
             $rawCss={css}
             accept={props.accept}
             enablePaste={props.enable_paste}

--- a/packages/dara-components/js/common/form-page/form-page.tsx
+++ b/packages/dara-components/js/common/form-page/form-page.tsx
@@ -32,7 +32,7 @@ function FormPage(props: FormPageProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
 
     return (
-        <StyledWrapper $rawCss={css} className={props.className} style={style}>
+        <StyledWrapper $rawCss={css} className={props.className} id={props.id_} style={style}>
             {props.title && <PageTitle>{props.title}</PageTitle>}
             {props.children.map((child, idx) => (
                 <DynamicComponent component={child} key={`form-page-${idx}-${child.uid}`} />

--- a/packages/dara-components/js/common/form/form.tsx
+++ b/packages/dara-components/js/common/form/form.tsx
@@ -81,7 +81,7 @@ function Form(props: FormProps): JSX.Element {
 
     return (
         <FormCtx.Provider value={{ formValues: formState, resolveInitialValue, updateForm: updateForm as any }}>
-            <StyledForm $rawCss={css} className={props.className} style={style}>
+            <StyledForm $rawCss={css} className={props.className} style={style} id={props.id_}>
                 {pages.length === 0 && (
                     <FormWrapper style={{ alignItems: props.align, justifyContent: props.justify }}>
                         {props.children.map((child, idx) => (

--- a/packages/dara-components/js/common/grid/column.tsx
+++ b/packages/dara-components/js/common/grid/column.tsx
@@ -41,6 +41,7 @@ function Column(props: ColumnProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     return (
         <StyledColumn
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             direction={props.direction}

--- a/packages/dara-components/js/common/grid/grid.tsx
+++ b/packages/dara-components/js/common/grid/grid.tsx
@@ -55,6 +55,7 @@ function Grid(props: GridProps): JSX.Element {
 
     return (
         <StyledGrid
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             style={{

--- a/packages/dara-components/js/common/grid/row.tsx
+++ b/packages/dara-components/js/common/grid/row.tsx
@@ -312,6 +312,7 @@ function Row(props: RowProps): JSX.Element {
 
     return (
         <StyledRow
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             style={{

--- a/packages/dara-components/js/common/heading/heading.tsx
+++ b/packages/dara-components/js/common/heading/heading.tsx
@@ -21,7 +21,7 @@ function Heading(props: HeadingProps): JSX.Element {
             $rawCss={css}
             as={tag}
             className={props.className}
-            id={anchorName(heading)}
+            id={props.id_ ?? anchorName(heading)}
             style={{ color: theme.colors.text, textAlign: props.align as any, ...style }}
         >
             {heading}

--- a/packages/dara-components/js/common/html-raw/html-raw.tsx
+++ b/packages/dara-components/js/common/html-raw/html-raw.tsx
@@ -24,6 +24,7 @@ function HtmlRaw(props: HtmlRawProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     return (
         <Wrapper
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             // bearer:disable javascript_react_dangerously_set_inner_html

--- a/packages/dara-components/js/common/icon/icon.tsx
+++ b/packages/dara-components/js/common/icon/icon.tsx
@@ -14,6 +14,7 @@ function Icon(props: IconProps): JSX.Element {
 
     return (
         <IconComponent
+            id={props.id_}
             $rawCss={css}
             style={{ alignItems: 'center', display: 'flex', ...validStyle, color: props.color }}
         />

--- a/packages/dara-components/js/common/image/image.tsx
+++ b/packages/dara-components/js/common/image/image.tsx
@@ -25,7 +25,7 @@ function Image(props: ImageProps): JSX.Element {
     const source = prependBaseUrl(props.src);
 
     return (
-        <StyledImg $rawCss={css} style={style}>
+        <StyledImg $rawCss={css} style={style} id={props.id_}>
             <img alt={`Could not load ${source}`} loading="lazy" src={source} />
         </StyledImg>
     );

--- a/packages/dara-components/js/common/label/label.tsx
+++ b/packages/dara-components/js/common/label/label.tsx
@@ -39,6 +39,7 @@ function Label(props: LabelProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     return (
         <StyledLabel
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             style={{

--- a/packages/dara-components/js/common/markdown/markdown.tsx
+++ b/packages/dara-components/js/common/markdown/markdown.tsx
@@ -81,6 +81,7 @@ function Markdown(props: MarkdownProps): JSX.Element {
 
     return (
         <CustomMarkdown
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             style={style}

--- a/packages/dara-components/js/common/modal/modal.tsx
+++ b/packages/dara-components/js/common/modal/modal.tsx
@@ -33,6 +33,7 @@ function Modal(props: ModalProps): JSX.Element {
 
     return (
         <StyledModal
+            id={props.id_}
             $rawCss={css}
             onAttemptClose={onAttemptClose}
             render={show}

--- a/packages/dara-components/js/common/overlay/overlay.tsx
+++ b/packages/dara-components/js/common/overlay/overlay.tsx
@@ -57,6 +57,7 @@ function Overlay(props: OverlayProps): JSX.Element {
     const [show] = useVariable(props.show || true);
     return (
         <OverlayWrapper
+            id={props.id_}
             $rawCss={css}
             margin={props.margin}
             padding={props.padding}

--- a/packages/dara-components/js/common/paragraph/paragraph.tsx
+++ b/packages/dara-components/js/common/paragraph/paragraph.tsx
@@ -20,7 +20,7 @@ const StyledP = injectCss('p');
 function Paragraph(props: ParagraphProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     return (
-        <StyledP $rawCss={css} className={props.className} style={{ textAlign: props.align, ...style }}>
+        <StyledP $rawCss={css} className={props.className} style={{ textAlign: props.align, ...style }} id={props.id_}>
             <DisplayCtx.Provider value={{ component: ComponentType.PARAGRAPH, direction: 'horizontal' }}>
                 {props.children.map((child, idx) => (
                     <DynamicComponent component={child} key={`stack-${idx}-${child.name}`} />

--- a/packages/dara-components/js/common/progress-bar/progress-bar.tsx
+++ b/packages/dara-components/js/common/progress-bar/progress-bar.tsx
@@ -28,7 +28,7 @@ function ProgressBar(props: ProgressBarProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     const [progress] = useVariable(props.progress);
     return (
-        <StyledProgressBar $rawCss={css} style={style}>
+        <StyledProgressBar $rawCss={css} style={style} id={props.id_}>
             <UiProgressBar color={props.color} progress={progress} small={props.small} />
         </StyledProgressBar>
     );

--- a/packages/dara-components/js/common/spacer/spacer.tsx
+++ b/packages/dara-components/js/common/spacer/spacer.tsx
@@ -1,5 +1,5 @@
-import { useContext } from 'react';
 import * as React from 'react';
+import { useContext } from 'react';
 
 import { DisplayCtx, type StyledComponentProps, injectCss, useComponentStyles } from '@darajs/core';
 import styled from '@darajs/styled-components';
@@ -47,7 +47,14 @@ function Spacer(props: SpacerProps): JSX.Element {
     const displayCtx = useContext(DisplayCtx);
     const isHStack = displayCtx.direction === 'horizontal';
     return (
-        <StyledSpacer $rawCss={css} className={props.className} isHStack={isHStack} size={props.size} style={style}>
+        <StyledSpacer
+            $rawCss={css}
+            className={props.className}
+            isHStack={isHStack}
+            size={props.size}
+            style={style}
+            id={props.id_}
+        >
             {props.line && <StyledLine inset={props.inset} isHStack={isHStack} />}
         </StyledSpacer>
     );

--- a/packages/dara-components/js/common/stack/stack.tsx
+++ b/packages/dara-components/js/common/stack/stack.tsx
@@ -57,6 +57,7 @@ function Stack(props: StackProps, ref: ForwardedRef<HTMLDivElement>): JSX.Elemen
 
     return (
         <StyledStack
+            id={props.id_}
             $rawCss={css}
             className={props.className}
             data-type="children-wrapper"

--- a/packages/dara-components/js/common/tabbed-card/tabbed-card.tsx
+++ b/packages/dara-components/js/common/tabbed-card/tabbed-card.tsx
@@ -98,7 +98,7 @@ function TabbedCard(props: TabbedCardProps): JSX.Element {
     };
 
     return (
-        <TabbedCardWrapper $rawCss={css} style={style}>
+        <TabbedCardWrapper $rawCss={css} style={style} id={props.id_}>
             <Tabs<Tab> onSelectTab={onSelectTab as any} selectedTab={selectedTab} tabs={tabs} />
             <Card data-active-tab={selectedTab.title} data-type="children-wrapper">
                 <DisplayCtx.Provider value={{ component: 'tabbedcard', direction: 'vertical' }}>

--- a/packages/dara-components/js/common/table/table.tsx
+++ b/packages/dara-components/js/common/table/table.tsx
@@ -733,6 +733,7 @@ function Table(props: TableProps): JSX.Element {
 
     return (
         <TableWrapper
+            id={props.id_}
             $rawCss={css}
             style={{
                 display: 'flex',

--- a/packages/dara-components/js/common/text/text.tsx
+++ b/packages/dara-components/js/common/text/text.tsx
@@ -40,6 +40,7 @@ function Text(props: TextProps): JSX.Element {
     if (['anchor', 'paragraph'].includes(display_ctx.component ?? '')) {
         return (
             <StyledSpan
+                id={props.id_}
                 $rawCss={css}
                 className={props.className}
                 style={{
@@ -61,6 +62,7 @@ function Text(props: TextProps): JSX.Element {
     const tag = props.formatted ? 'pre' : 'div';
     return (
         <StyledTag
+            id={props.id_}
             $rawCss={css}
             as={tag}
             className={props.className}

--- a/packages/dara-components/js/common/tooltip/tooltip.tsx
+++ b/packages/dara-components/js/common/tooltip/tooltip.tsx
@@ -34,6 +34,7 @@ function Tooltip(props: TooltipProps): JSX.Element {
 
     return (
         <StyledTooltip
+            id={props.id_}
             $rawCss={css}
             content={
                 typeof content === 'string' ? content : (

--- a/packages/dara-components/js/graphs/causal-graph-viewer.tsx
+++ b/packages/dara-components/js/graphs/causal-graph-viewer.tsx
@@ -109,6 +109,7 @@ function CausalGraphViewer(props: CausalGraphViewerProps): React.ReactNode {
 
     return (
         <StyledGraphViewer
+            id={props.id_}
             $rawCss={css}
             additionalLegends={formattedAdditionalLegends}
             allowSelectionWhenNotEditable={props.allow_selection_when_not_editable}

--- a/packages/dara-components/js/graphs/node-hierarchy-builder.tsx
+++ b/packages/dara-components/js/graphs/node-hierarchy-builder.tsx
@@ -73,6 +73,7 @@ function NodeHierarchyBuilder(props: NodeHierarchyBuilderProps): JSX.Element {
 
     return (
         <StyledHierarchyBuilder
+            id={props.id_}
             $rawCss={css}
             nodeFontSize={props.node_font_size}
             nodeSize={props.node_size}

--- a/packages/dara-components/js/graphs/visual-edge-encoder.tsx
+++ b/packages/dara-components/js/graphs/visual-edge-encoder.tsx
@@ -164,6 +164,7 @@ function VisualEdgeEncoder(props: VisualEdgeEncoderProps): JSX.Element {
 
     return (
         <StyledGraphEditor
+            id={props.id_}
             $rawCss={css}
             additionalLegends={formattedAdditionalLegends}
             allowSelectionWhenNotEditable={props.allow_selection_when_not_editable}

--- a/packages/dara-components/js/plotting/bokeh/bokeh.tsx
+++ b/packages/dara-components/js/plotting/bokeh/bokeh.tsx
@@ -61,7 +61,8 @@ function Bokeh(props: BokehProps): JSX.Element {
 
     const docJson = useMemo<DocJson>(() => JSON.parse(props.document), [props.document]);
     const rootId = useMemo(() => docJson.roots[0]!.id, [docJson]);
-    const id = props.id_ ?? useId();
+    const uid = useId();
+    const id = props.id_ ?? uid;
 
     const events: [string, (...args: any) => any][] = [];
 

--- a/packages/dara-components/js/plotting/bokeh/bokeh.tsx
+++ b/packages/dara-components/js/plotting/bokeh/bokeh.tsx
@@ -61,7 +61,7 @@ function Bokeh(props: BokehProps): JSX.Element {
 
     const docJson = useMemo<DocJson>(() => JSON.parse(props.document), [props.document]);
     const rootId = useMemo(() => docJson.roots[0]!.id, [docJson]);
-    const id = useId();
+    const id = props.id_ ?? useId();
 
     const events: [string, (...args: any) => any][] = [];
 

--- a/packages/dara-components/js/plotting/matplotlib/matplotlib.tsx
+++ b/packages/dara-components/js/plotting/matplotlib/matplotlib.tsx
@@ -15,6 +15,7 @@ function Matplotlib(props: MatplotlibProps): JSX.Element {
     const [style, css] = useComponentStyles(props);
     return (
         <StyledImg
+            id={props.id_}
             $rawCss={css}
             alt="Matplotlib graph"
             src={`data:image/svg+xml;base64,${props.figure}`}

--- a/packages/dara-components/js/plotting/plotly/plotly-factory.jsx
+++ b/packages/dara-components/js/plotting/plotly/plotly-factory.jsx
@@ -247,7 +247,7 @@ export default function plotComponentFactory(Plotly) {
         render() {
             return (
                 <div
-                    id={this.props.divId}
+                    id={this.props.id_ ?? this.props.divId}
                     style={this.props.style}
                     ref={this.getRef}
                     className={this.props.className}

--- a/packages/dara-components/js/plotting/plotly/plotly.tsx
+++ b/packages/dara-components/js/plotting/plotly/plotly.tsx
@@ -391,6 +391,7 @@ function Plotly(props: PlotlyProps): JSX.Element {
 
     return (
         <StyledPlotly
+            id={props.id_}
             $rawCss={css}
             style={{
                 flex: '1 1 auto',

--- a/packages/dara-components/js/smart/chat/chat.tsx
+++ b/packages/dara-components/js/smart/chat/chat.tsx
@@ -203,6 +203,7 @@ function Chat(props: ChatProps): JSX.Element {
             {showChat && (
                 // we set the z-index so that the latest chat thread opened is always on top, and if there is a chat thread open, we set the background color so that the transparency does not show the thread behind
                 <ThreadWrapper
+                    id={props.id_}
                     className="chat-thread"
                     style={{
                         zIndex,

--- a/packages/dara-components/js/smart/code-editor.tsx
+++ b/packages/dara-components/js/smart/code-editor.tsx
@@ -34,6 +34,7 @@ function CodeEditor(props: CodeEditorProps): JSX.Element {
 
     return (
         <StyledCodeEditor
+            id={props.id_}
             $rawCss={css}
             initialValue={script}
             onChange={onChange}

--- a/packages/dara-components/js/smart/hierarchy-selector/hierarchy-selector.tsx
+++ b/packages/dara-components/js/smart/hierarchy-selector/hierarchy-selector.tsx
@@ -27,6 +27,7 @@ function HierarchySelector(props: HierarchySelectorProps): JSX.Element {
     const [selected, setValue] = useVariable(props.value);
     return (
         <StyledHierarchySelector
+            id={props.id_}
             $rawCss={css}
             allowSelectCategory={props.allow_category_select}
             allowSelectLeaf={props.allow_leaf_select}

--- a/packages/dara-components/js/smart/hierarchy-viewer/hierarchy-viewer.tsx
+++ b/packages/dara-components/js/smart/hierarchy-viewer/hierarchy-viewer.tsx
@@ -29,6 +29,7 @@ function HierarchyViewer(props: HierarchyViewerProps): JSX.Element {
 
     return (
         <StyledHierarchyViewer
+            id={props.id_}
             $rawCss={css}
             allowLeafClick={props.allow_leaf_click}
             allowParentClick={props.allow_parent_click}

--- a/packages/dara-core/dara/core/definitions.py
+++ b/packages/dara-core/dara/core/definitions.py
@@ -187,7 +187,7 @@ class ComponentInstance(BaseModel):
     """
     An optional unique identifier for the component, defaults to None
 
-    This id intended to help identify components with human-readable names in the serialized trees, and id is also set as the `id` attribute of the DOM element
+    This is intended to help identify components with human-readable names in the serialized trees, and is also set as the `id` attribute of the DOM element
     """
 
     for_: Optional[str] = None

--- a/packages/dara-core/dara/core/definitions.py
+++ b/packages/dara-core/dara/core/definitions.py
@@ -187,7 +187,7 @@ class ComponentInstance(BaseModel):
     """
     An optional unique identifier for the component, defaults to None
 
-    This has no runtime effect and are intended to help identify components with human-readable names in the serialized trees, not in the DOM
+    This id intended to help identify components with human-readable names in the serialized trees, and id is also set as the `id` attribute of the DOM element
     """
 
     for_: Optional[str] = None

--- a/packages/dara-core/js/components/link.tsx
+++ b/packages/dara-core/js/components/link.tsx
@@ -72,6 +72,7 @@ function Link(props: LinkProps): React.ReactNode {
     return (
         <DisplayCtx.Provider value={{ component: 'anchor', direction: displayCtx.direction }}>
             <StyledNavLink
+                id={props.id_}
                 className={props.className}
                 to={props.to}
                 end={props.end}

--- a/packages/dara-core/js/types/core.tsx
+++ b/packages/dara-core/js/types/core.tsx
@@ -284,6 +284,7 @@ export interface BaseComponentProps {
     raw_css?: React.CSSProperties | string;
     style?: React.CSSProperties;
     track_progress?: boolean;
+    id_?: string;
 }
 
 /**

--- a/packages/ui-causal-graph-editor/changelog.md
+++ b/packages/ui-causal-graph-editor/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Set the `id_` property as the default id to all components in the library to allow for more precise identification of components
+
 ## 1.13.1
 
 -   Fixed an issue where nodes and edges would sometimes not show in `CausalGraphEditor`

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -739,7 +739,13 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
             }}
         >
             <PointerContext.Provider value={{ disablePointerEvents: isDragging, onPanelEnter, onPanelExit }}>
-                <GraphPane $hasFocus={hasFocus} onClick={() => onPaneFocus(true)} ref={paneRef} style={props.style} id={props.id}>
+                <GraphPane
+                    $hasFocus={hasFocus}
+                    onClick={() => onPaneFocus(true)}
+                    ref={paneRef}
+                    style={props.style}
+                    id={props.id}
+                >
                     <Graph onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                         <Overlay
                             bottomLeft={

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -16,8 +16,8 @@
  */
 import debounce from 'lodash/debounce';
 import noop from 'lodash/noop';
-import { useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import styled, { useTheme } from '@darajs/styled-components';
 import { Dots, Spinner, Tooltip } from '@darajs/ui-components';
@@ -175,6 +175,8 @@ export interface CausalGraphEditorProps extends Settings {
     tooltipSize?: number;
     /** Optional parameter to specify when parts of the graph should be hidden. */
     zoomThresholds?: ZoomThresholds;
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -716,7 +718,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     // if the graph is not editable and there are no nodes, there's nothing to display so show a message
     if (!props.editable && Object.keys(props.graphData?.nodes).length === 0) {
         return (
-            <Wrapper style={props.style}>
+            <Wrapper style={props.style} id={props.id}>
                 <Center style={{ height: 300 }}>The CausalGraph structure is empty.</Center>
             </Wrapper>
         );
@@ -737,7 +739,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
             }}
         >
             <PointerContext.Provider value={{ disablePointerEvents: isDragging, onPanelEnter, onPanelExit }}>
-                <GraphPane $hasFocus={hasFocus} onClick={() => onPaneFocus(true)} ref={paneRef} style={props.style}>
+                <GraphPane $hasFocus={hasFocus} onClick={() => onPaneFocus(true)} ref={paneRef} style={props.style} id={props.id}>
                     <Graph onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave}>
                         <Overlay
                             bottomLeft={

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node-hierarchy-builder.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node-hierarchy-builder.tsx
@@ -93,6 +93,8 @@ export interface NodeHierarchyBuilderProps<T> {
     viewOnly?: boolean;
     /** Optional whether to wrap text within nodes */
     wrapNodeText?: boolean;
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -252,7 +254,7 @@ function NodeHierarchyBuilder<T extends string | Node>(props: NodeHierarchyBuild
                             value={searchInput}
                         />
                     </SearchWrapper>
-                    <NodesWrapper ref={layersWrapperRef}>
+                    <NodesWrapper ref={layersWrapperRef} id={props.id}>
                         {hierarchyData.map((layer, idx) => (
                             <Fragment key={layer.id}>
                                 <Layer

--- a/packages/ui-components/changelog.md
+++ b/packages/ui-components/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Set the `id_` property as the default id to all components in the library to allow for more precise identification of components
+
+
 ## 1.20.0
 
 - Fixed an issue where `SectionedList` would not update the input value when clicking on an item.

--- a/packages/ui-components/src/accordion/accordion.tsx
+++ b/packages/ui-components/src/accordion/accordion.tsx
@@ -52,6 +52,8 @@ export interface AccordionProps {
     style?: React.CSSProperties;
     /** Optional prop to put the component in controlled mode */
     value?: Array<number> | number;
+    /** Optional id property */
+    id?: string;
 }
 
 function getInitialOpen(
@@ -91,6 +93,7 @@ function Accordion({
     multi = true,
     onChange,
     value,
+    id,
 }: AccordionProps): JSX.Element {
     const [openItems, setOpenItems] = useState<boolean[]>(getInitialOpen(initialOpenItems, value, items));
 
@@ -129,7 +132,7 @@ function Accordion({
     }, [value]);
 
     return (
-        <AccordionWrapper className={className} style={style}>
+        <AccordionWrapper className={className} id={id} style={style}>
             {items.map((item, index) => (
                 <AccordionItem
                     backgroundColor={backgroundColor}

--- a/packages/ui-components/src/carousel/carousel.tsx
+++ b/packages/ui-components/src/carousel/carousel.tsx
@@ -194,6 +194,8 @@ export interface CarouselProps {
     style?: React.CSSProperties;
     /** The value of the carousel */
     value?: number;
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -228,7 +230,7 @@ function Carousel(props: CarouselProps): JSX.Element {
     }, [props.value]);
 
     return (
-        <CarouselComponent className={props.className} style={props.style}>
+        <CarouselComponent className={props.className} id={props.id} style={props.style}>
             <Button
                 data-testid="carousel-left-button"
                 onClick={() => {

--- a/packages/ui-components/src/code-viewer/code-viewer.tsx
+++ b/packages/ui-components/src/code-viewer/code-viewer.tsx
@@ -65,6 +65,8 @@ export interface CodeViewerProps extends InteractiveComponentProps<string> {
     language: Language;
     /** The code theme to display */
     codeTheme?: CodeComponentThemes;
+    /** Optional id property */
+    id?: string;
 }
 
 const StyledPre = styled.pre<{ $isLightTheme?: boolean }>`
@@ -120,6 +122,7 @@ function CodeViewer(props: CodeViewerProps): JSX.Element {
                 ...props.style,
             }}
             className={props.className}
+            id={props.id}
         >
             <TopBar $isLightTheme={props.codeTheme !== 'dark'}>
                 <span>{props.language}</span>

--- a/packages/ui-components/src/component-select-list/component-select-list.tsx
+++ b/packages/ui-components/src/component-select-list/component-select-list.tsx
@@ -144,6 +144,8 @@ export interface ComponentSelectListProps {
     selectedItems?: Array<string>;
     /** Pass through of style property to the root element */
     style?: React.CSSProperties;
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -174,6 +176,7 @@ function ComponentSelectList(props: ComponentSelectListProps): JSX.Element {
     return (
         <Wrapper
             className={props.className}
+            id={props.id}
             itemsPerRow={props.itemsPerRow && props.itemsPerRow > 0 ? props.itemsPerRow : 3}
             style={props.style}
         >

--- a/packages/ui-components/src/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui-components/src/dropdown-menu/dropdown-menu.tsx
@@ -145,6 +145,8 @@ export type DropdownMenuProps = {
      * This is useful for displaying additional information in the dropdown.
      */
     footer?: React.ReactNode;
+    /** Optional id property */
+    id?: string;
 };
 
 interface DropdownProps {
@@ -167,7 +169,7 @@ export const Dropdown = (props: DropdownProps): JSX.Element => {
     const { menuItems, onClick } = props;
 
     return (
-        <DropdownMenu>
+        <DropdownMenu id={props.id}>
             {menuItems.map((section: MenuItem[], index) => (
                 <React.Fragment key={`dropdown-section-${index}`}>
                     {section.map((item: MenuItem, itemIndex) => (

--- a/packages/ui-components/src/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui-components/src/dropdown-menu/dropdown-menu.tsx
@@ -163,6 +163,8 @@ interface DropdownProps {
      * This is useful for displaying additional information in the dropdown.
      */
     footer?: React.ReactNode;
+    /** Optional id property */
+    id?: string;
 }
 
 export const Dropdown = (props: DropdownProps): JSX.Element => {

--- a/packages/ui-components/src/dropzone/dropzone.tsx
+++ b/packages/ui-components/src/dropzone/dropzone.tsx
@@ -72,7 +72,7 @@ export interface UploadDropzoneProps {
         event: DragEvent | Event
     ) => void | Promise<void>;
     /** Styling property */
-    style?: React.CSSProperties
+    style?: React.CSSProperties;
     /** Optional id property */
     id?: string;
 }
@@ -105,7 +105,13 @@ function UploadDropzone(props: UploadDropzoneProps): JSX.Element {
     });
 
     return (
-        <Dropzone {...getRootProps()} className={props.className} id={props.id} isDragActive={isDragActive} style={props.style}>
+        <Dropzone
+            {...getRootProps()}
+            className={props.className}
+            id={props.id}
+            isDragActive={isDragActive}
+            style={props.style}
+        >
             <input {...getInputProps()} />
             <DropzoneMessage>
                 Drop your file, <br />

--- a/packages/ui-components/src/dropzone/dropzone.tsx
+++ b/packages/ui-components/src/dropzone/dropzone.tsx
@@ -72,7 +72,9 @@ export interface UploadDropzoneProps {
         event: DragEvent | Event
     ) => void | Promise<void>;
     /** Styling property */
-    style?: React.CSSProperties;
+    style?: React.CSSProperties
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -103,7 +105,7 @@ function UploadDropzone(props: UploadDropzoneProps): JSX.Element {
     });
 
     return (
-        <Dropzone {...getRootProps()} className={props.className} isDragActive={isDragActive} style={props.style}>
+        <Dropzone {...getRootProps()} className={props.className} id={props.id} isDragActive={isDragActive} style={props.style}>
             <input {...getInputProps()} />
             <DropzoneMessage>
                 Drop your file, <br />

--- a/packages/ui-components/src/hierarchy-selector/hierarchy-selector.tsx
+++ b/packages/ui-components/src/hierarchy-selector/hierarchy-selector.tsx
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 
 import styled, { useTheme } from '@darajs/styled-components';
 
@@ -48,6 +48,8 @@ interface HierarchySelectorProps {
     selected?: string;
     /** Pass through of the style to the root container */
     style?: React.CSSProperties;
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -79,7 +81,7 @@ function HierarchySelector(props: HierarchySelectorProps): JSX.Element {
 
     const { label, id, children } = props.rootNode;
     return (
-        <Wrapper className={props.className} style={props.style}>
+        <Wrapper className={props.className} style={props.style} id={props.id}>
             <Root>
                 <CircleIcon selected={id === selectedNodeId} />
                 <Cell

--- a/packages/ui-components/src/markdown/markdown.tsx
+++ b/packages/ui-components/src/markdown/markdown.tsx
@@ -16,6 +16,8 @@ interface MarkdownProps extends Options {
     className?: string;
     /** Native react style property, can be used to fine tune the element appearance */
     style?: React.CSSProperties;
+    /** Optional id property */
+    id?: string;
 }
 
 const CustomMarkdownWrapper = styled.div`
@@ -379,7 +381,7 @@ function Markdown(props: MarkdownProps): JSX.Element {
     const { markdown, className, style, ...reactMarkdownProps } = props;
 
     return (
-        <CustomMarkdownWrapper className={className} style={style}>
+        <CustomMarkdownWrapper className={className} style={style} id={props.id}>
             <ReactMarkdown
                 {...reactMarkdownProps}
                 components={{

--- a/packages/ui-components/src/markdown/markdown.tsx
+++ b/packages/ui-components/src/markdown/markdown.tsx
@@ -153,7 +153,7 @@ const CustomMarkdownWrapper = styled.div`
 
     /* don't apply default styles if the pre block has the pretty code display */
     /* stylelint-disable-next-line */
-    pre:not(.prism-code):not(:has(.prism-code)) {
+    pre:not(.prism-code, :has(.prism-code)) {
         overflow-x: auto;
 
         margin-top: 1.7rem;

--- a/packages/ui-components/src/modal/modal.tsx
+++ b/packages/ui-components/src/modal/modal.tsx
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useState } from 'react';
 import * as React from 'react';
+import { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
 import styled from '@darajs/styled-components';

--- a/packages/ui-components/src/tooltip/tooltip.tsx
+++ b/packages/ui-components/src/tooltip/tooltip.tsx
@@ -108,6 +108,8 @@ export interface TooltipProps {
     styling?: 'default' | 'error';
     /** Optional parameter that sets tooltip visibility to be in controlled mode */
     visible?: boolean;
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -254,6 +256,7 @@ function Tooltip({
                 {...getFloatingProps()}
             >
                 <TooltipWrapper
+                    id={id}
                     $hidden={false}
                     className={className}
                     style={style}

--- a/packages/ui-components/src/tooltip/tooltip.tsx
+++ b/packages/ui-components/src/tooltip/tooltip.tsx
@@ -133,6 +133,7 @@ function Tooltip({
     hidden = false,
     style,
     delay = 0,
+    id,
     onClickOutside = () => false,
 }: TooltipProps): JSX.Element {
     const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/ui-hierarchy-viewer/changelog.md
+++ b/packages/ui-hierarchy-viewer/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Set the `id_` property as the default id to all components in the library to allow for more precise identification of components
+
 ## 1.0.0
 
 -   Initial release

--- a/packages/ui-hierarchy-viewer/src/hierarchy-viewer/hierarchy-viewer.tsx
+++ b/packages/ui-hierarchy-viewer/src/hierarchy-viewer/hierarchy-viewer.tsx
@@ -41,6 +41,8 @@ interface HierarchyViewerProps {
     onClick?: (node: Node) => void | Promise<void>;
     /** Optional style that can be passed to the wrapper */
     style?: React.CSSProperties;
+    /** Optional id property */
+    id?: string;
 }
 
 /**
@@ -53,7 +55,7 @@ interface HierarchyViewerProps {
 function HierarchyViewer(props: HierarchyViewerProps): JSX.Element {
     const [ref, dimensions] = useDimensions<HTMLDivElement>();
     return (
-        <Wrapper className={props.className} id="hierarchy-viewer-root" ref={ref} style={props.style}>
+        <Wrapper className={props.className} id={props.id || 'hierarchy-viewer-root'} ref={ref} style={props.style}>
             <Treemap
                 allowLeafClick={props.allowLeafClick}
                 allowParentClick={props.allowParentClick}


### PR DESCRIPTION


<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
When using the pythonic dara components, we can set the `id_` property, but this is not propagated to the frontend. This change propagates the property to the DOM.

## Implementation Description
- Introduced `id` prop to multiple components including Accordion, Button, Card, and more.
- Updated existing components to utilize `props.id_` for setting the `id` attribute in the rendered output.

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->