### PR TITLE
Improvement: DO-7407 add in_place flag to write_partial

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -6,6 +6,7 @@ title: Changelog
 
 -  Added a new `prefetch` property to `Link` that allows for prefetching the navigation data when the user intends to navigate to the link. The data is kept in a short-lived cache to speed up the perceived performance of the navigation.
 -  Implemented router optimizations by preloading top-level derived values (DerivedVariables and py_components) on a page when navigating to it. This saves us having to make multiple requests to the backend when navigating to a page with a lot of derived values; especially when combined with link prefetching, this can make a big difference in UX.
+-  Added a new `in_place` parameter to `write_partial` on `Variable` and `BackendStore` to allow for more performant in-place application of patches. This is opt-in as to preserve old behaviour but is recommended for performance critical updates of large structures.
 
 ## 1.21.0
 

--- a/packages/dara-core/dara/core/interactivity/plain_variable.py
+++ b/packages/dara-core/dara/core/interactivity/plain_variable.py
@@ -284,7 +284,7 @@ class Variable(ClientVariable, Generic[VariableType]):
         assert isinstance(self.store, BackendStore), 'This method can only be used with a BackendStore'
         return await self.store.write(value, notify=notify, ignore_channel=ignore_channel)
 
-    async def write_partial(self, data: Union[List[Dict[str, Any]], Any], notify: bool = True):
+    async def write_partial(self, data: Union[List[Dict[str, Any]], Any], notify: bool = True, in_place: bool = False):
         """
         Apply partial updates to the variable's BackendStore using JSON Patch operations or automatic diffing.
         Raises an error if the variable does not have a BackendStore attached.
@@ -294,9 +294,13 @@ class Variable(ClientVariable, Generic[VariableType]):
 
         :param data: Either a list of JSON patch operations (RFC 6902) or a full object to diff against current value
         :param notify: whether to broadcast the patches to clients
+        :param in_place: whether to apply the patches in-place or return a new value.
+        When set to True, the value will be mutated when applying the patches rather than deep-cloned.
+        This is recommended when the updated value is large and deep-cloning it can be expensive; however, users should exercise
+        caution when using the option as previous results retrieved from `variable.read()` will potentially be mutated, depending on the backend used.
         """
         assert isinstance(self.store, BackendStore), 'This method can only be used with a BackendStore'
-        return await self.store.write_partial(data, notify=notify)
+        return await self.store.write_partial(data, notify=notify, in_place=in_place)
 
     async def read(self):
         """


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

When performance profiling an internal Dara app, I noticed a lot of time is spent in the write_partial operation due to its built-in clone by default. This is undesirable and unnecessary in some cases. 
Exposed the flag directly so users can opt into it when e.g. using the FileBackend (which makes it a strict upgrade in perf). Keeping the flag disabled by default as otherwise it can produce unexpected behaviour, e.g. previous returned values by `read()` will be changed in place when using `MemoryBackend`.


The same issue exists on the client-side but unfortunately React and Recoil require strict  immutability of the data they hold or otherwise all the guarantees go out of the window.

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in an internal app, took time to apply patches down from 400-1100ms to <1ms.

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->