### PR TITLE
Fix: DO-7486 handle loader data being a promise

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+-  Fixed an issue where syncing variables with path params would sometimes fail if the route has a longer running action attached
+
 ## 1.21.6
 
 -  Fixed an issue where instantiating actions would fail during route preloading

--- a/packages/dara-core/js/pages/route-error-boundary.tsx
+++ b/packages/dara-core/js/pages/route-error-boundary.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { isRouteErrorResponse, useRouteError } from 'react-router';
 
-import styled from '@darajs/styled-components';
+import styled, { ThemeProvider, theme } from '@darajs/styled-components';
 import { Button } from '@darajs/ui-components';
 
 import { useConfig } from '@/shared';
@@ -147,4 +147,12 @@ function RouteErrorBoundary(): React.ReactNode {
     );
 }
 
-export default RouteErrorBoundary;
+function RouteErrorBoundaryPage(): React.ReactNode {
+    return (
+        <ThemeProvider theme={theme}>
+            <RouteErrorBoundary />
+        </ThemeProvider>
+    );
+}
+
+export default RouteErrorBoundaryPage;


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

Two issues found:
- the top-level route error boundary would fail to render because it's outside the main theme provider - added an extra default theme provider for it to handle
- the above uncovered a race condition where if loader data was a promise (can be for PageRoutes) we wouldn't properly await it - fixed the typing and awaited it there properly


## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in an app where this reproduces

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->