### PR TITLE
Improvement: DO-7968 tweak inconsistent handling of navigations between link and navigate action, deprecate Anchor

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Marked `dara.components.common.Anchor` as deprecated, `dara.core.Link` should be used instead
+
 ## 1.21.9
 
 - Fixed an issue where `Select` component would show `null` instead of placeholder when `value` was `None`

--- a/packages/dara-components/dara/components/common/anchor.py
+++ b/packages/dara-components/dara/components/common/anchor.py
@@ -17,6 +17,8 @@ limitations under the License.
 
 from typing import List, Optional, Union
 
+from typing_extensions import deprecated
+
 from dara.components.common.base_component import (
     ContentComponent,
     LayoutError,
@@ -27,6 +29,7 @@ from dara.core.definitions import discover
 from dara.core.interactivity import AnyVariable, DerivedVariable, Variable
 
 
+@deprecated('Use `dara.core.Link` instead')
 @discover
 class Anchor(ModifierComponent):
     """

--- a/packages/dara-core/dara/core/base_definitions.py
+++ b/packages/dara-core/dara/core/base_definitions.py
@@ -31,6 +31,7 @@ from typing import (
     ClassVar,
     Dict,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -436,6 +437,59 @@ class PendingTask(BaseTask):
         if self.error:
             raise self.error
         return self.result
+
+
+class RouterPath(BaseModel):
+    path: Optional[str] = None
+    """
+    A URL pathname, beginning with '/'.
+    """
+
+    search: Optional[str] = None
+    """
+    A URL search string, beginning with '?'.
+    """
+
+    hash: Optional[str] = None
+    """
+    A URL hash string, beginning with '#'.
+    """
+
+
+class NavigateOptions(BaseModel):
+    """
+    Options for the navigate action
+    """
+    replace: bool = False
+    """
+    Replaces the current entry in the history stack instead of pushing a new one.
+
+    ```
+    # with a history stack like this
+    A -> B
+
+    # normal link click pushes a new entry
+    A -> B -> C
+
+    # but with `replace`, B is replaced by C
+    A -> C
+    ```
+    """
+
+    relative: Literal['route', 'path'] = 'route'
+    """
+    Defines the relative path behavior for the link.
+
+    ```python
+    NavigateOptions(to='..') # default, relative='route'
+    NavigateOptions(to='..', relative='path')
+    ```
+
+    Consider a route hierarchy where a parent route pattern is "blog" and a child route pattern is "blog/:slug/edit".
+    - route — default, resolves the link relative to the route pattern. In the example above, a relative link of "..." will remove both :slug/edit segments back to "/blog".
+    - path — relative to the path so "..." will only remove one URL segment up to "/blog/:slug"
+    Note that index routes and layout routes do not have paths so they are not included in the relative path calculation.
+    """
 
 
 class AnnotatedAction(BaseModel):

--- a/packages/dara-core/dara/core/interactivity/actions.py
+++ b/packages/dara-core/dara/core/interactivity/actions.py
@@ -51,6 +51,8 @@ from dara.core.base_definitions import (
     ActionImpl,
     ActionResolverDef,
     AnnotatedAction,
+    NavigateOptions,
+    RouterPath,
     TaskProgressUpdate,
 )
 from dara.core.base_definitions import DaraBaseModel as BaseModel
@@ -372,8 +374,14 @@ class NavigateToImpl(ActionImpl):
 
     py_name = 'NavigateTo'
 
-    url: Optional[str] = None
+    url: Union[str, RouterPath]
+
     new_tab: bool = False
+
+    options: Optional[NavigateOptions] = None
+    """
+    Options for relative navigations
+    """
 
 
 @deprecated('Use @action or `NavigateToImpl` for simple cases')
@@ -947,7 +955,9 @@ class ActionCtx:
         """
         return await TriggerVariable(variable=variable, force=force).execute(self)
 
-    async def navigate(self, url: str, new_tab: bool = False):
+    async def navigate(
+        self, url: Union[str, RouterPath], new_tab: bool = False, options: Optional[NavigateOptions] = None
+    ):
         """
         Navigate to a given url
 
@@ -991,8 +1001,9 @@ class ActionCtx:
 
         :param url: the url to navigate to
         :param new_tab: whether to open the url in a new tab, defaults to False
+        :param options: options for relative navigations, defaults to None
         """
-        return await NavigateToImpl(url=url, new_tab=new_tab).execute(self)
+        return await NavigateToImpl(url=url, new_tab=new_tab, options=options).execute(self)
 
     async def logout(self):
         """

--- a/packages/dara-core/js/actions/navigate-to.tsx
+++ b/packages/dara-core/js/actions/navigate-to.tsx
@@ -1,16 +1,14 @@
+import { getBasename } from '@/router/utils';
 import { type ActionHandler, type NavigateToImpl } from '@/types/core';
 
+const ABSOLUTE_URL_REGEX = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
 /**
- * Check whether the passed url is a valid url
+ * Check whether the passed absolute url is a valid url
  *
  * @param url the url to check
  */
 function isValidHttpUrl(url: string): boolean {
-    // Check if the url starts with a slash, which is a valid relative url
-    if (url.startsWith('/')) {
-        return true;
-    }
-
     let newUrl;
 
     try {
@@ -23,25 +21,73 @@ function isValidHttpUrl(url: string): boolean {
 }
 
 /**
+ * Strips the basename from the pathname
+ *
+ * From https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/router/utils.ts#L1511
+ */
+export function stripBasename(pathname: string, basename: string): string | null {
+    if (basename === '/') {
+        return pathname;
+    }
+
+    if (!pathname.toLowerCase().startsWith(basename.toLowerCase())) {
+        return null;
+    }
+
+    // We want to leave trailing slash behavior in the user's control, so if they
+    // specify a basename with a trailing slash, we should support it
+    const startIndex = basename.endsWith('/') ? basename.length - 1 : basename.length;
+    const nextChar = pathname.charAt(startIndex);
+    if (nextChar && nextChar !== '/') {
+        // pathname does not start with basename/
+        return null;
+    }
+
+    return pathname.slice(startIndex) || '/';
+}
+
+/**
  * Front-end handler for NavigateTo action.
  * Navigates to a specified URL.
+ *
+ * Absolute/relative and external/internal differentiation follows logic from react-router's Link component:
+ * https://github.com/remix-run/react-router/blob/32d759958978b9fbae676806dd6c84ade9866746/packages/react-router/lib/dom/lib.tsx#L623-L658
  */
 const NavigateTo: ActionHandler<NavigateToImpl> = (ctx, actionImpl): void => {
-    const isValidUrl = isValidHttpUrl(actionImpl.url);
+    const basename = getBasename();
+    let isExternal = false;
+    let to = actionImpl.url;
 
-    if (!isValidUrl) {
-        throw new Error(`Invalid URL: ${actionImpl.url}`);
+    // detect external URLs for absolute URLs
+    if (typeof actionImpl.url === 'string' && ABSOLUTE_URL_REGEX.test(actionImpl.url)) {
+        try {
+            const currentUrl = new URL(window.location.href);
+            const targetUrl = new URL(actionImpl.url);
+            const path = stripBasename(targetUrl.pathname, basename);
+
+            // same-origin absolute URLs are treated as relative
+            if (targetUrl.origin === currentUrl.origin && path != null) {
+                // Strip the protocol/origin/basename for same-origin absolute URLs
+                to = path + targetUrl.search + targetUrl.hash;
+            } else {
+                isExternal = true;
+            }
+        } catch {
+            throw new Error(`Invalid URL: ${actionImpl.url}`);
+        }
     }
 
-    if (actionImpl.new_tab) {
-        window.open(actionImpl.url, actionImpl.new_tab ? '_blank' : undefined);
+    if (isExternal && typeof to === 'string') {
+        if (actionImpl.new_tab) {
+            window.open(to, '_blank');
+        } else {
+            window.location.href = to;
+        }
+        return;
     }
+
     // use router navigate if the url is relative
-    else if (actionImpl.url.startsWith('/')) {
-        ctx.navigate(actionImpl.url);
-    } else {
-        window.location.href = actionImpl.url;
-    }
+    ctx.navigate(to, actionImpl.options);
 };
 
 export default NavigateTo;

--- a/packages/dara-core/js/components/link.tsx
+++ b/packages/dara-core/js/components/link.tsx
@@ -11,20 +11,18 @@ import type { ComponentInstance, StyledComponentProps, Variable } from '@/types'
 
 type MaybeVariable<T> = T | Variable<T>;
 
-export interface LinkProps extends StyledComponentProps {
+export interface LinkProps extends StyledComponentProps, Omit<NavLinkProps, 'style' | 'children' | 'prefetch' | 'to'> {
     className?: string;
     case_sensitive: boolean;
     children: Array<ComponentInstance>;
     prefetch?: boolean;
-    relative: NavLinkProps['relative'];
-    replace: NavLinkProps['replace'];
     to: MaybeVariable<NavLinkProps['to']>;
     // Used via useComponentStyles
     // eslint-disable-next-line react/no-unused-prop-types
     active_css?: StyledComponentProps['raw_css'];
     // eslint-disable-next-line react/no-unused-prop-types
     inactive_css?: StyledComponentProps['raw_css'];
-    end: NavLinkProps['end'];
+    referrer_policy?: NavLinkProps['referrerPolicy'];
 }
 
 const NavLinkWrapper = React.forwardRef(
@@ -148,6 +146,11 @@ function Link(props: LinkProps): React.ReactNode {
                 onMouseMove={props.prefetch ? handleMouseMove : undefined}
                 onFocus={props.prefetch ? handleFocus : undefined}
                 onTouchStart={props.prefetch ? handleTouchStart : undefined}
+                // core AnchorElementAttributes
+                download={props.download}
+                referrerPolicy={props.referrer_policy}
+                target={props.target}
+                rel={props.rel}
             >
                 {props.children.map((child, idx) => (
                     <DynamicComponent component={child} key={idx} />

--- a/packages/dara-core/js/router/index.tsx
+++ b/packages/dara-core/js/router/index.tsx
@@ -4,3 +4,4 @@ export { createRouter, findFirstPath } from './create-router';
 export { fetchRouteData, getFromPreloadCache, usePreloadRoute, type LoaderData } from './fetching';
 export { default as RouteContentDisplay, createRouteLoader, type LoaderResult } from './route-content';
 export { default as RouterRoot } from './router-root';
+export * from './utils';

--- a/packages/dara-core/js/router/utils.ts
+++ b/packages/dara-core/js/router/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Get the basename of the app, uses window.dara.base_url if set, otherwise '/'
+ */
+export function getBasename(): string {
+    if (window.dara.base_url !== '') {
+        return new URL(window.dara.base_url, window.origin).pathname;
+    }
+    return '/';
+}

--- a/packages/dara-core/js/types/core.tsx
+++ b/packages/dara-core/js/types/core.tsx
@@ -1,4 +1,4 @@
-import type { Location, NavigateFunction } from 'react-router';
+import type { Location, NavigateFunction, NavigateOptions, To } from 'react-router';
 import { type CallbackInterface } from 'recoil';
 import * as z from 'zod/v4';
 
@@ -492,8 +492,9 @@ export interface TriggerVariableImpl extends ActionImpl {
 }
 
 export interface NavigateToImpl extends ActionImpl {
-    url: string;
+    url: To;
     new_tab: boolean;
+    options?: NavigateOptions;
 }
 
 export interface ResetVariablesImpl extends ActionImpl {


### PR DESCRIPTION
<!--- The title format is expected to follow the pattern:-->
<!--- CHANGE TYPE: Ticket Name -->
<!--- Docs: DO-100 Update PR Template -->
<!--- Where CHANGE TYPEs are: Docs, Breaking, Improvement, Fix, Refactor, Feat, Security -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it has a spec, please link to the spec here. -->

This PR is a quick pass through the Link/navigate inconsistencies I spotted when using new routing features in an internal app.

Improvements:
- added missing baseline anchor features to `Link` (`download`, `rel`, `referrerPolicy`, target`)
- deprecated Anchor in exchange (since now Link supports everything required)
- fixed `navigate` action not handling relative links properly (bare `path`, relative `./path` or `../path` etc); internal absolute links are now also client-navigated rather than full page navigations
- allowed passing a path object to navigate action in addition to a string
- added support for passing extra navigation options to navigate action (includes `relative` setting and `replace` flag)

## Implementation Description
<!--- Why did you follow this implementation approach- -->
<!--- Is there any background knowledge necessary to understand the approach taken- -->
<!--- Describe the limitations, pitfalls and tradeoffs of the approach- -->

## Any new dependencies Introduced
<!--- Where there any dependencies added? Why?- -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally in a test app
Tests WIP

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [ ] I have added comments to all the bits that are hard to follow.
- [ ] I have added/updated Documentation.
- [ ] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):
<!--- For UI changes make sure to add an image or GIF showcasing the change-->