### PR TITLE
Feat: DO-11008 add OIDC PKCE public client mode

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Added OIDC public client PKCE mode for identity providers that do not issue client secrets.
+
 ## 1.26.7
 
 - Fixed generic `DaraBaseModel` serialization so parametrized models such as `DerivedVariable[str]` preserve nested `BaseModel` fields when serialized.

--- a/packages/dara-core/dara/core/auth/oidc/config.py
+++ b/packages/dara-core/dara/core/auth/oidc/config.py
@@ -65,11 +65,12 @@ class OIDCAuthConfig(BaseAuthConfig):
     This config requires the following ENV variables to be set:
     - SSO_ISSUER_URL - URL of the identity provider issuer; should expose a `SSO_ISSUER_URL/.well-known/openid-configuration` endpoint for discovery
     - SSO_CLIENT_ID - client_id generated for the application by the identity provider
-    - SSO_CLIENT_SECRET - client_secret generated for the application by the identity provider
     - SSO_REDIRECT_URI - URL that identity provider should redirect back to, in most cases https://deployed-app-url/sso-callback
     - SSO_GROUPS - comma separated list of allowed SSO groups
 
     In addition, the following ENV variables can be set:
+    - SSO_CLIENT_AUTH_MODE - token endpoint client authentication mode, supports `client_secret_basic` and `pkce_public`, defaults to `client_secret_basic`
+    - SSO_CLIENT_SECRET - client_secret generated for the application by the identity provider; required when SSO_CLIENT_AUTH_MODE is `client_secret_basic`
     - SSO_ALLOWED_IDENTITY_ID - if set, only the user with matching identity_id will be allowed to access the app
     - SSO_VERIFY_AUDIENCE - if set, the ID token will be verified against the configured audience, by default `sso_client_id`
     - SSO_EXTRA_AUDIENCE - if set, extra audiences to verify against the ID token in addition to `sso_client_id`

--- a/packages/dara-core/dara/core/auth/oidc/config.py
+++ b/packages/dara-core/dara/core/auth/oidc/config.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import hashlib
 import secrets
 from typing import ClassVar
 from urllib.parse import urlencode, urlparse
@@ -204,7 +206,25 @@ class OIDCAuthConfig(BaseAuthConfig):
         """
         return secrets.token_urlsafe(32)
 
-    def get_authorization_params(self, state: str, nonce: str | None = None) -> dict[str, str]:
+    def generate_code_verifier(self) -> str:
+        """
+        Generate a PKCE code verifier for public client auth.
+        """
+        return secrets.token_urlsafe(64)
+
+    def get_code_challenge(self, code_verifier: str) -> str:
+        """
+        Generate the S256 PKCE code challenge for a verifier.
+        """
+        digest = hashlib.sha256(code_verifier.encode('ascii')).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b'=').decode('ascii')
+
+    def get_authorization_params(
+        self,
+        state: str,
+        nonce: str | None = None,
+        code_verifier: str | None = None,
+    ) -> dict[str, str]:
         """
         Build the query parameters for the authorization request per OpenID Connect Core 1.0 Section 3.1.2.1.
 
@@ -216,6 +236,7 @@ class OIDCAuthConfig(BaseAuthConfig):
 
         Recommended parameters:
         - state: Opaque value for CSRF protection bound to the browser session
+        - code_challenge/code_challenge_method: PKCE parameters when public client auth is enabled
 
         Override this method to add optional parameters like nonce, display, prompt, max_age, etc.
         """
@@ -226,14 +247,24 @@ class OIDCAuthConfig(BaseAuthConfig):
             'client_id': oidc_settings.client_id,
             'redirect_uri': oidc_settings.redirect_uri,
             **({'nonce': nonce} if nonce is not None else {}),
+            **(
+                {'code_challenge': self.get_code_challenge(code_verifier), 'code_challenge_method': 'S256'}
+                if code_verifier is not None
+                else {}
+            ),
             'state': state,
         }
 
-    def get_authorization_url(self, state: str, nonce: str | None = None) -> str:
+    def get_authorization_url(
+        self,
+        state: str,
+        nonce: str | None = None,
+        code_verifier: str | None = None,
+    ) -> str:
         """
         Build the full authorization URL using the discovery document's authorization_endpoint.
         """
-        params = self.get_authorization_params(state, nonce=nonce)
+        params = self.get_authorization_params(state, nonce=nonce, code_verifier=code_verifier)
         return f'{self.discovery.authorization_endpoint}?{urlencode(params)}'
 
     def validate_redirect_to(self, redirect_to: str | None) -> str | None:
@@ -261,14 +292,23 @@ class OIDCAuthConfig(BaseAuthConfig):
 
         :param body: Request body, may contain redirect_to for post-auth navigation
         """
+        oidc_settings = get_oidc_settings()
         redirect_to = self.validate_redirect_to(body.redirect_to)
+        code_verifier = self.generate_code_verifier() if oidc_settings.client_auth_mode == 'pkce_public' else None
         transaction = OIDCLoginTransaction(
             state=self.generate_state(),
             nonce=self.generate_nonce(),
+            code_verifier=code_verifier,
             redirect_to=redirect_to,
         )
         oidc_transaction_store.set(transaction)
-        return RedirectResponse(redirect_uri=self.get_authorization_url(transaction.state, nonce=transaction.nonce))
+        return RedirectResponse(
+            redirect_uri=self.get_authorization_url(
+                transaction.state,
+                nonce=transaction.nonce,
+                code_verifier=transaction.code_verifier,
+            )
+        )
 
     async def fetch_userinfo(self, access_token: str) -> dict | None:
         """

--- a/packages/dara-core/dara/core/auth/oidc/definitions.py
+++ b/packages/dara-core/dara/core/auth/oidc/definitions.py
@@ -294,6 +294,7 @@ class OIDCLoginTransaction(BaseModel):
     state: str = Field(..., description='Opaque state value sent to the authorization endpoint')
     login_session_id: str | None = Field(default=None, description='Pre-auth login session id bound to the browser')
     nonce: str = Field(..., description='Nonce value sent in the authorization request')
+    code_verifier: str | None = Field(default=None, description='PKCE code verifier for public client auth')
     redirect_to: str | None = Field(default=None, description='Optional redirect target after successful auth')
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(tz=timezone.utc),

--- a/packages/dara-core/dara/core/auth/oidc/routes.py
+++ b/packages/dara-core/dara/core/auth/oidc/routes.py
@@ -87,6 +87,7 @@ async def sso_callback(
                 'grant_type': 'authorization_code',
                 'code': body.auth_code,
                 'redirect_uri': oidc_settings.redirect_uri,
+                **({'code_verifier': transaction.code_verifier} if transaction.code_verifier is not None else {}),
             },
         )
 

--- a/packages/dara-core/dara/core/auth/oidc/settings.py
+++ b/packages/dara-core/dara/core/auth/oidc/settings.py
@@ -1,8 +1,11 @@
 import os
 from functools import lru_cache
+from typing import Literal
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+OIDCClientAuthMode = Literal['client_secret_basic', 'pkce_public']
 
 
 class OIDCSettings(BaseSettings):
@@ -12,11 +15,13 @@ class OIDCSettings(BaseSettings):
 
     # Required, using field with default=... to have pyright not complain about missing values
     client_id: str = Field(default=...)
-    client_secret: str = Field(default=...)
+    client_secret: str | None = None
     redirect_uri: str = Field(default=...)
     groups: str = Field(default=...)
 
     # Optional
+    client_auth_mode: OIDCClientAuthMode = 'client_secret_basic'
+    """Token endpoint client authentication mode."""
     issuer_url: str = 'https://login.causalens.com/api/authentication'
     jwks_lifespan: int = 86400  # 1 day
     jwt_algo: str = 'ES256'
@@ -56,6 +61,16 @@ class OIDCSettings(BaseSettings):
             self.client_id = audience_id
             self.client_secret = audience_secret
             self.verify_audience = True
+
+        return self
+
+    @model_validator(mode='after')
+    def validate_client_auth_mode(self):
+        """
+        Validate token endpoint authentication settings for the selected mode.
+        """
+        if self.client_auth_mode == 'client_secret_basic' and not self.client_secret:
+            raise ValueError('SSO_CLIENT_SECRET is required when SSO_CLIENT_AUTH_MODE=client_secret_basic')
 
         return self
 

--- a/packages/dara-core/dara/core/auth/oidc/utils.py
+++ b/packages/dara-core/dara/core/auth/oidc/utils.py
@@ -128,7 +128,9 @@ async def get_token_from_idp(
     Per RFC 6749 Section 4.1.3 (Authorization Code Grant) and Section 6 (Refreshing an Access Token),
     the token request is sent to the token_endpoint using POST with application/x-www-form-urlencoded.
 
-    Client authentication uses HTTP Basic auth with client_id:client_secret per RFC 6749 Section 2.3.1.
+    Client authentication uses the configured OIDC client auth mode. The default is HTTP Basic auth with
+    client_id:client_secret per RFC 6749 Section 2.3.1. Public clients send client_id in the form body
+    and rely on PKCE for the authorization code exchange.
 
     :param auth_config: Current OIDC auth config (used to get token_endpoint from discovery)
     :param body: Request body parameters (grant_type, code/refresh_token, redirect_uri, etc.)
@@ -140,20 +142,26 @@ async def get_token_from_idp(
     # Get token endpoint from discovery
     token_endpoint = auth_config.get_token_endpoint()
 
-    # Build Basic auth header: base64(client_id:client_secret)
-    credentials = f'{oidc_settings.client_id}:{oidc_settings.client_secret}'
-    encoded_credentials = b64encode(credentials.encode()).decode()
+    headers = {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+    }
+    data = body
+
+    if oidc_settings.client_auth_mode == 'client_secret_basic':
+        # Build Basic auth header: base64(client_id:client_secret)
+        credentials = f'{oidc_settings.client_id}:{oidc_settings.client_secret}'
+        encoded_credentials = b64encode(credentials.encode()).decode()
+        headers['Authorization'] = f'Basic {encoded_credentials}'
+    else:
+        data = {**body, 'client_id': oidc_settings.client_id}
 
     # Make the token request per RFC 6749
     # Note: Using application/x-www-form-urlencoded as required by spec
     response = await auth_config.client.post(
         url=token_endpoint,
-        headers={
-            'Accept': 'application/json',
-            'Authorization': f'Basic {encoded_credentials}',
-            'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        data=body,  # httpx will encode as form data
+        headers=headers,
+        data=data,  # httpx will encode as form data
         timeout=10,
     )
 

--- a/packages/dara-core/docs/advanced/authentication.mdx
+++ b/packages/dara-core/docs/advanced/authentication.mdx
@@ -97,22 +97,24 @@ The `OIDCAuthConfig` reads its configuration from environment variables. The fol
 | ------------------- | ------------------------------------------------------------------------------------------------------------- |
 | `SSO_ISSUER_URL`    | URL of the OIDC identity provider issuer                                                                      |
 | `SSO_CLIENT_ID`     | OAuth 2.0 client ID provided by your identity provider                                                        |
-| `SSO_CLIENT_ID`     | OAuth 2.0 client ID provided by your identity provider                                                        |
-| `SSO_CLIENT_SECRET` | OAuth 2.0 client secret provided by your identity provider                                                    |
 | `SSO_REDIRECT_URI`  | URL the identity provider should redirect to after authentication (e.g., `https://your-app.com/sso-callback`) |
 | `SSO_GROUPS`        | Comma-separated list of allowed groups for access control                                                     |
 
+`SSO_CLIENT_SECRET` is also required by default. It is not required when `SSO_CLIENT_AUTH_MODE=pkce_public`.
+
 The following environment variables are optional:
 
-| Variable                  | Default  | Description                                                                        |
-| ------------------------- | -------- | ---------------------------------------------------------------------------------- |
-| `SSO_JWKS_LIFESPAN`       | `86400`  | Lifespan of the JWKS cache in seconds (default 1 day)                              |
-| `SSO_JWT_ALGO`            | `ES256`  | Algorithm for verifying identity provider JWTs                                     |
-| `SSO_SCOPES`              | `openid` | Space-separated list of OAuth scopes to request                                    |
-| `SSO_VERIFY_AUDIENCE`     | `False`  | Whether to verify the `aud` claim in ID tokens                                     |
-| `SSO_EXTRA_AUDIENCE`      | `None`   | Additional audiences to verify against (defaults to `SSO_CLIENT_ID`)               |
-| `SSO_ALLOWED_IDENTITY_ID` | `None`   | If set, restricts access to a specific identity ID                                 |
-| `SSO_USE_USERINFO`        | `False`  | If `true`, fetch additional claims from the userinfo endpoint during login/refresh |
+| Variable                  | Default                 | Description                                                                                                  |
+| ------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `SSO_CLIENT_AUTH_MODE`    | `client_secret_basic`   | Token endpoint auth mode. Use `pkce_public` for public clients without a client secret.                      |
+| `SSO_CLIENT_SECRET`       | `None`                  | OAuth 2.0 client secret. Required when `SSO_CLIENT_AUTH_MODE=client_secret_basic`. Ignored for `pkce_public`. |
+| `SSO_JWKS_LIFESPAN`       | `86400`                 | Lifespan of the JWKS cache in seconds (default 1 day)                                                        |
+| `SSO_JWT_ALGO`            | `ES256`                 | Algorithm for verifying identity provider JWTs                                                               |
+| `SSO_SCOPES`              | `openid`                | Space-separated list of OAuth scopes to request                                                              |
+| `SSO_VERIFY_AUDIENCE`     | `False`                 | Whether to verify the `aud` claim in ID tokens                                                               |
+| `SSO_EXTRA_AUDIENCE`      | `None`                  | Additional audiences to verify against (defaults to `SSO_CLIENT_ID`)                                         |
+| `SSO_ALLOWED_IDENTITY_ID` | `None`                  | If set, restricts access to a specific identity ID                                                           |
+| `SSO_USE_USERINFO`        | `False`                 | If `true`, fetch additional claims from the userinfo endpoint during login/refresh                           |
 
 ### OIDC Authentication Flow
 

--- a/packages/dara-core/tests/python/test_oidc_auth.py
+++ b/packages/dara-core/tests/python/test_oidc_auth.py
@@ -324,6 +324,33 @@ async def test_session_no_state():
         assert transaction.redirect_to is None
 
 
+async def test_session_pkce_public_client_adds_code_challenge():
+    with mock.patch.dict(os.environ, {**os.environ, 'SSO_CLIENT_AUTH_MODE': 'pkce_public'}):
+        get_oidc_settings.cache_clear()
+        config = ConfigurationBuilder()
+
+        auth_config = make_config()
+        config.add_auth(auth_config)
+
+        app = _start_application(config._to_configuration())
+
+        async with AsyncClient(app) as client:
+            response = await client.post('/api/auth/session', json={})
+            assert response.status_code == 200
+
+            _, received_query = parse_url(response.json()['redirect_uri'])
+            received_state = received_query['state'][0]
+            transaction = oidc_transaction_store.take(received_state)
+
+            assert transaction is not None
+            assert transaction.code_verifier is not None
+            assert received_query['code_challenge'] == [auth_config.get_code_challenge(transaction.code_verifier)]
+            assert received_query['code_challenge_method'] == ['S256']
+            assert 'code_verifier' not in received_query
+
+        get_oidc_settings.cache_clear()
+
+
 async def test_session_with_state():
     """
     Check that /session returns redirect uri with state
@@ -391,12 +418,20 @@ async def test_sso_callback_creates_valid_session_token():
                 'refresh_token': refresh_token,
             }
 
-            respx.post(auth_config.discovery.token_endpoint).mock(
-                return_value=httpx.Response(status_code=200, json=mock_idp_response)
-            )
+            token_route = respx.post(auth_config.discovery.token_endpoint)
+            token_route.mock(return_value=httpx.Response(status_code=200, json=mock_idp_response))
 
             response = await client.post('/api/auth/sso-callback', json={'auth_code': 'TEST', 'state': state})
             assert response.status_code == 200
+
+            token_request = token_route.calls.last.request
+            assert token_request.headers['Authorization'].startswith('Basic ')
+            token_request_body = parse_qs(token_request.content.decode())
+            assert token_request_body['grant_type'] == ['authorization_code']
+            assert token_request_body['code'] == ['TEST']
+            assert token_request_body['redirect_uri'] == [get_oidc_settings().redirect_uri]
+            assert 'client_id' not in token_request_body
+            assert 'code_verifier' not in token_request_body
 
             # JWKS endpoint should have been called once to retrieve the key
             assert mock_urllib.call_count == 1
@@ -419,6 +454,45 @@ async def test_sso_callback_creates_valid_session_token():
             assert 'id_token' not in decoded_session_token
             assert decoded_session_token.get('exp') == MOCK_ID_TOKEN.get('exp')
             assert 'session_id' in decoded_session_token
+
+
+async def test_sso_callback_pkce_public_client_exchanges_code_without_client_secret():
+    with mock.patch.dict(os.environ, {**os.environ, 'SSO_CLIENT_AUTH_MODE': 'pkce_public'}):
+        get_oidc_settings.cache_clear()
+        config = ConfigurationBuilder()
+
+        auth_config = make_config()
+        config.add_auth(auth_config)
+
+        with mocked_urllib(MOCK_JWKS_DATA):
+            app = _start_application(config._to_configuration())
+            async with AsyncClient(app) as client:
+                state = await start_oidc_login(client)
+                transaction = oidc_transaction_store.get(state)
+                assert transaction is not None
+                assert transaction.code_verifier is not None
+
+                mock_idp_response = {
+                    'id_token': make_mock_id_token(state),
+                }
+                token_route = respx.post(auth_config.discovery.token_endpoint)
+                token_route.mock(return_value=httpx.Response(status_code=200, json=mock_idp_response))
+
+                response = await client.post('/api/auth/sso-callback', json={'auth_code': 'TEST', 'state': state})
+                assert response.status_code == 200
+
+                token_request = token_route.calls.last.request
+                assert 'Authorization' not in token_request.headers
+
+                token_request_body = parse_qs(token_request.content.decode())
+                assert token_request_body['grant_type'] == ['authorization_code']
+                assert token_request_body['code'] == ['TEST']
+                assert token_request_body['redirect_uri'] == [get_oidc_settings().redirect_uri]
+                assert token_request_body['client_id'] == [get_oidc_settings().client_id]
+                assert token_request_body['code_verifier'] == [transaction.code_verifier]
+                assert 'client_secret' not in token_request_body
+
+        get_oidc_settings.cache_clear()
 
 
 async def test_sso_callback_requires_state():

--- a/packages/dara-core/tests/python/test_oidc_settings.py
+++ b/packages/dara-core/tests/python/test_oidc_settings.py
@@ -31,6 +31,29 @@ def test_audience_override(monkeypatch: pytest.MonkeyPatch):
         assert s.verify_audience is True
 
 
+def test_client_secret_required_for_default_auth_mode():
+    with pytest.raises(ValidationError):
+        OIDCSettings(
+            _env_file=None,  # type: ignore
+            client_id='client-id',
+            redirect_uri='http://localhost:8000/sso-callback',
+            groups='dev',
+        )
+
+
+def test_client_secret_not_required_for_pkce_public_auth_mode():
+    s = OIDCSettings(
+        _env_file=None,  # type: ignore
+        client_id='client-id',
+        client_auth_mode='pkce_public',
+        redirect_uri='http://localhost:8000/sso-callback',
+        groups='dev',
+    )
+
+    assert s.client_secret is None
+    assert s.client_auth_mode == 'pkce_public'
+
+
 def test_error_on_missing_env():
     """
     Check that the settings error out on missing env vars


### PR DESCRIPTION
## Motivation and Context

Some OIDC identity providers only support public clients with PKCE and do not issue or accept client secrets. Dara's built-in OIDC config previously assumed confidential-client token exchange with `client_secret_basic`, which prevented those providers from using the main OIDC auth flow.

## Implementation Description

Added `SSO_CLIENT_AUTH_MODE` with two explicit modes:

- `client_secret_basic`, the existing default confidential-client behavior.
- `pkce_public`, which generates a per-login PKCE verifier, sends an S256 `code_challenge` in the authorization request, and exchanges the authorization code without a client secret.

The PKCE verifier is kept server-side in the existing OIDC login transaction store. The token exchange path now builds either a Basic-auth request or a public-client form request based on the selected mode.

The OIDC authentication docs now describe the new mode and the conditional `SSO_CLIENT_SECRET` requirement, and the dara-core changelog includes the PKCE support entry.

One limitation observed during smoke testing is that the internal Causalens login service currently accepts the public-client PKCE authorization-code exchange, but public-client refresh-token exchange returns an IDP error. Dara clears auth cookies on refresh failure and falls back to relogin behavior; full public-client refresh support depends on IDP behavior.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `cd packages/dara-core && DARA_TEST_FLAG=True poetry run pytest tests/python/test_oidc_settings.py tests/python/test_oidc_auth.py -q`
- `poetry anthology run format-check`
- `poetry anthology run lint`
- Manually smoke tested login against `dev.login.causalens.com` with both `SSO_CLIENT_AUTH_MODE=pkce_public` and the default `client_secret_basic` mode.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

N/A