### PR TITLE
Fix: DO-11207 Adjust the adaptive formatter for small numbers to show more decimal places

### DIFF
--- a/packages/dara-components/changelog.md
+++ b/packages/dara-components/changelog.md
@@ -5,6 +5,7 @@ title: Changelog
 ## NEXT
 
 - Internal: Hardened JavaScript dependency versions and removed unused build and test tooling dependencies.
+- Adjusted the adapative precision formatter handling of small numbers so more precise numbers are shown
 
 ## 1.26.10
 

--- a/packages/dara-components/js/common/table/cells/adaptive-precision-cell.tsx
+++ b/packages/dara-components/js/common/table/cells/adaptive-precision-cell.tsx
@@ -25,7 +25,7 @@ function AdaptivePrecisionCell(): (props: AdaptivePrecisionCellProps) => string 
         if (abs_value >= 100.0) {
             return String(round(value, 2).toFixed(2));
         }
-        if (abs_value < 0.01 && abs_value >= 0.001) {
+        if (abs_value < 0.1 && abs_value >= 0.001) {
             return String(round(value, 4).toFixed(4));
         }
         return String(round(value, 3).toFixed(3));


### PR DESCRIPTION
## Motivation and Context
Tweak to the adapative cell formatter for small numbers.

## Implementation Description
* Show 4dp when numbers are between 0.1 and 0.001 show 4 numbers rather than only 3. Workloads in this range can often need the extra precision and an extra 0 won't look odd given the range of the numbers

## Any new dependencies Introduced
No

## How Has This Been Tested?
Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.