### PR TITLE
Fix: DO-11363 missing auth cookies redirect to login, only refresh token on 401 not 403 status

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fixed missing auth session cookies being reported as bad requests instead of unauthorized session failures, so expired browser cookies redirect users back to login, and limited refresh-token retries to authentication failures.
+
 ## 1.26.12
 
 - Internal: Hardened JavaScript dependency versions and removed unused build and test tooling dependencies.

--- a/packages/dara-core/dara/core/auth/routes.py
+++ b/packages/dara-core/dara/core/auth/routes.py
@@ -170,7 +170,7 @@ def _get_auth_token(
     if session_cookie_token is not None:
         return session_cookie_token
 
-    raise HTTPException(status_code=400, detail=BAD_REQUEST_ERROR(missing_message))
+    raise HTTPException(status_code=401, detail=EXPIRED_TOKEN_ERROR)
 
 
 def _set_session_token_cookie(response: Response, token: str):

--- a/packages/dara-core/js/api/http.tsx
+++ b/packages/dara-core/js/api/http.tsx
@@ -97,8 +97,8 @@ export async function request(url: string | URL, ...options: RequestInit[]): Pro
         ...other,
     });
 
-    // in case of an auth error, attempt to refresh the token and retry the request
-    if (response.status === 401 || response.status === 403) {
+    // in case of an authentication error, attempt to refresh the token and retry the request
+    if (response.status === 401) {
         try {
             // Ensure only one tab refreshes at a time; others wait and reuse the refreshed token.
             await runSessionRefresh(async () => {

--- a/packages/dara-core/tests/js/http.spec.tsx
+++ b/packages/dara-core/tests/js/http.spec.tsx
@@ -83,14 +83,18 @@ describe('HTTP Utils', () => {
 
     afterAll(() => server.close());
 
-    it('attempts to refresh the token if 402 or 403 occurs, failing if no refresh token is present', async () => {
+    it('attempts to refresh the token on 401, failing if no refresh token is present', async () => {
         const res = await request('/error-401', { method: 'GET' });
         expect(res.status).toBe(401);
         expect(refreshAttempted).toHaveBeenCalledTimes(1);
+    });
 
-        const res2 = await request('/error-403', { method: 'GET' });
-        expect(res2.status).toBe(403);
-        expect(refreshAttempted).toHaveBeenCalledTimes(2);
+    it('does not attempt to refresh the token on 403', async () => {
+        document.cookie = `${REFRESH_TOKEN_NAME}=${REFRESH_TOKEN}; `;
+
+        const res = await request('/error-403', { method: 'GET' });
+        expect(res.status).toBe(403);
+        expect(refreshAttempted).not.toHaveBeenCalled();
     });
 
     it('refreshes the token and retries the request', async () => {
@@ -249,7 +253,7 @@ describe('HTTP Utils', () => {
         expect(requested401).toHaveBeenCalledTimes(1);
 
         // make another request while the refresh is still in progress
-        const res2Promise = request('/error-403');
+        const res2Promise = request('/error-401');
 
         resolve();
         delay = null;
@@ -265,9 +269,7 @@ describe('HTTP Utils', () => {
         expect(await res2.json()).toEqual({ success: true });
 
         expect(refreshAttempted).toHaveBeenCalledTimes(1);
-        // first request was made twice
-        expect(requested401).toHaveBeenCalledTimes(2);
-        // the second request should not have made a request until it got the new token
-        expect(requested403).toHaveBeenCalledTimes(1);
+        // first request was made twice; the second request waited and only sent after refresh completed
+        expect(requested401).toHaveBeenCalledTimes(3);
     });
 });

--- a/packages/dara-core/tests/python/test_auth.py
+++ b/packages/dara-core/tests/python/test_auth.py
@@ -8,7 +8,14 @@ from async_asgi_testclient import TestClient as AsyncClient
 from fastapi import Request
 
 from dara.core.auth.basic import BasicAuthConfig, MultiBasicAuthConfig
-from dara.core.auth.definitions import ID_TOKEN, JWT_ALGO, SESSION_ID, SESSION_TOKEN_COOKIE_NAME, TokenData
+from dara.core.auth.definitions import (
+    EXPIRED_TOKEN_ERROR,
+    ID_TOKEN,
+    JWT_ALGO,
+    SESSION_ID,
+    SESSION_TOKEN_COOKIE_NAME,
+    TokenData,
+)
 from dara.core.auth.utils import token_refresh_cache
 from dara.core.configuration import ConfigurationBuilder
 from dara.core.http import get
@@ -87,7 +94,8 @@ async def test_verify_session():
 
         # Test no auth
         response = await client.get('/api/test-ext/test')
-        assert response.status_code == 400
+        assert response.status_code == 401
+        assert response.json()['detail'] == EXPIRED_TOKEN_ERROR
 
         # Test wrong scheme
         response = await client.get('/api/test-ext/test', headers={'Authorization': 'Basic user:pw'})
@@ -148,6 +156,21 @@ async def test_verify_session_invalid_cookie_clears_auth_cookies_without_refresh
         cleared_cookies = response.headers.getall('set-cookie')
         assert any(cookie.startswith('dara_refresh_token="";') for cookie in cleared_cookies)
         assert any(cookie.startswith(f'{SESSION_TOKEN_COOKIE_NAME}="";') for cookie in cleared_cookies)
+
+
+async def test_verify_session_missing_auth_returns_unauthorized():
+    """Check that missing auth credentials are treated as an auth failure, not a bad request."""
+
+    config = ConfigurationBuilder()
+    config.add_auth(BasicAuthConfig('test', 'test'))
+
+    app = _start_application(config._to_configuration())
+
+    async with AsyncClient(app) as client:
+        response = await client.post('/api/auth/verify-session')
+
+        assert response.status_code == 401
+        assert response.json()['detail'] == EXPIRED_TOKEN_ERROR
 
 
 async def test_authorization_header_injected_from_session_cookie():
@@ -355,8 +378,8 @@ async def test_stale_session_cookie_recovers_after_refresh_attempt():
 
         # Cookie jar should no longer contain stale auth cookies after refresh response.
         followup_verify_response = await client.post('/api/auth/verify-session')
-        assert followup_verify_response.status_code == 400
-        assert followup_verify_response.json()['detail']['message'] == 'No auth credentials passed'
+        assert followup_verify_response.status_code == 401
+        assert followup_verify_response.json()['detail'] == EXPIRED_TOKEN_ERROR
 
 
 async def test_refresh_token_unsupported():


### PR DESCRIPTION
## Motivation and Context

When a browser session cookie expires and is no longer sent, Dara can receive authenticated API requests with no bearer token and no session cookie. The backend classified that as a `400 bad_request`, which the frontend routes to `/error?code=400` rather than back to login.

The client also attempted refresh-token recovery for `403` responses. A `403` means the user is authenticated but not authorized, so refreshing the session is not expected to resolve it and can mask the authorization failure.

## Implementation Description

Missing auth credentials now return the existing expired-session auth payload with HTTP `401`, so the frontend treats the response as an authentication failure and redirects users to login with the correct session-expired reason. Malformed `Authorization` headers still return `400`, preserving the bad-request behavior for invalid auth syntax.

The HTTP client now attempts `/api/auth/refresh-token` only for `401` responses. `403` responses are returned to callers for normal auth-error handling without using the refresh token.

Backend auth tests cover the missing-credentials path on `/verify-session`, update the general protected-endpoint expectation, and keep stale-cookie cleanup behavior aligned with the new status. JS HTTP tests now cover refresh-on-401 and no-refresh-on-403.

## Any new dependencies Introduced

No new dependencies.

## How Has This Been Tested?

- `cd packages/dara-core && DARA_TEST_FLAG=True poetry run pytest tests/python/test_auth.py -q`
- `cd packages/dara-core && pnpm exec vitest run tests/js/http.spec.tsx --reporter=verbose`
- `poetry anthology run lint`
- `poetry anthology run format-check`
- `pnpm lerna run lint`
- `pnpm lerna run format:check`
- `git diff --check`

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow. N/A: no non-obvious code added.
- [x] I have added/updated Documentation. N/A: behavior fix covered by changelog.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

N/A