### PR TITLE
Fix: DO-11489 address tmp Dependabot advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   form-data: '>=4.0.4 <5'
+  tmp: '>=0.2.6 <0.3'
   lodash: '>=4.18.1 <5'
   minimatch@>=10: '>=10.2.5 <11'
   qs: '>=6.15.2 <7'
@@ -9594,8 +9595,8 @@ packages:
     resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -15627,7 +15628,7 @@ snapshots:
       request-progress: 3.0.0
       semver: 7.7.2
       supports-color: 8.1.1
-      tmp: 0.2.5
+      tmp: 0.2.6
       untildify: 4.0.0
       yauzl: 2.10.0
 
@@ -16637,7 +16638,7 @@ snapshots:
       jszip: 3.10.1
       readable-stream: 3.6.2
       saxes: 5.0.1
-      tmp: 0.2.5
+      tmp: 0.2.6
       unzipper: 0.10.14
       uuid: 8.3.2
 
@@ -19301,7 +19302,7 @@ snapshots:
       semver: 7.7.2
       string-width: 4.2.3
       tar-stream: 2.2.0
-      tmp: 0.2.5
+      tmp: 0.2.6
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
@@ -21088,7 +21089,7 @@ snapshots:
 
   tinyspy@4.0.3: {}
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   tmpl@1.0.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,7 @@ patchedDependencies:
   tinykeys: patches/tinykeys.patch
 overrides:
   form-data: '>=4.0.4 <5'
+  tmp: '>=0.2.6 <0.3'
   lodash: '>=4.18.1 <5'
   minimatch@>=10: '>=10.2.5 <11'
   qs: '>=6.15.2 <7'


### PR DESCRIPTION
## Motivation and Context

New dependabot alert that popped up while previous #635 PR was in flight

Dependabot alert [333](https://github.com/causalens/dara/security/dependabot/333) reports vulnerable transitive `tmp@0.2.5` usage in `pnpm-lock.yaml`. The patched version is `tmp@0.2.6`.

## Implementation Description

Added a narrow pnpm override for `tmp` to require `>=0.2.6 <0.3` and regenerated the pnpm lockfile. This keeps the existing parent packages in place while resolving the transitive package to the patched release for the current Cypress, ExcelJS, and Nx/Lerna dependency paths.

## Any new dependencies Introduced

No new dependencies. This updates an existing transitive dependency from `tmp@0.2.5` to `tmp@0.2.6`.

## How Has This Been Tested?

- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm why tmp --recursive --depth 10`
- `git diff --check`

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression). N/A: lockfile-only dependency override; frozen install and dependency graph were validated.
- [x] I have added comments to all the bits that are hard to follow. N/A: no code comments needed for dependency metadata.
- [x] I have added/updated Documentation. N/A: internal dependency metadata only.
- [x] I have updated the appropriate changelog with a line for my changes. N/A: internal dependency metadata only.

## Screenshots (if appropriate):

N/A