### PR TITLE
Fix: DO-11593 preserve login referrer encoding

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fixed auth login redirects so unauthenticated first loads and referrers containing encoded path/query characters are preserved correctly.
+
 ## 1.28.0
 
 - Internal: Upgraded FastAPI to the latest 0.136 release line and explicitly require Starlette 1.0.1+ for the BadHost CVE fix.

--- a/packages/dara-core/js/auth/auth.tsx
+++ b/packages/dara-core/js/auth/auth.tsx
@@ -125,7 +125,7 @@ export async function revokeSession(): Promise<RedirectResponse | SuccessRespons
 }
 
 /**
- * Resolve the referrer url to be passed back to login, adjusted for the base path.
+ * Resolve the encoded referrer url to be passed back to login, adjusted for the base path.
  */
 export function resolveReferrer(): string {
     if (!window.dara.base_url) {
@@ -144,6 +144,28 @@ export function resolveReferrer(): string {
     }
 
     return encodeURIComponent(strippedReferrer + window.location.search);
+}
+
+/**
+ * Parse the login referrer query param into the app path used internally for navigation.
+ */
+export function parseLoginReferrer(search: string, defaultPath: string): string {
+    const queryParams = new URLSearchParams(search);
+    return queryParams.get('referrer') ?? defaultPath;
+}
+
+/**
+ * Resolve the encoded login referrer while preserving an existing login referrer if present.
+ */
+export function resolveLoginReferrer(): string {
+    const queryParams = new URLSearchParams(window.location.search);
+    const existingReferrer = queryParams.get('referrer');
+
+    if (existingReferrer !== null) {
+        return encodeURIComponent(existingReferrer);
+    }
+
+    return resolveReferrer();
 }
 
 /**
@@ -167,8 +189,7 @@ export async function handleAuthErrors(res: Response, options: HandleAuthErrorsO
 
     if (authError && !shouldIgnoreError(authError, ignoreErrors)) {
         // use existing referrer if available in case we were already redirected because of e.g. missing token
-        const queryParams = new URLSearchParams(window.location.search);
-        const referrer = queryParams.get('referrer') ?? resolveReferrer();
+        const referrer = resolveLoginReferrer();
 
         const redirect = getAuthErrorRedirect(authError, authenticationFailureRedirect);
         const path = redirect === 'login' ? `/login?referrer=${referrer}` : `/error?code=${res.status}`;

--- a/packages/dara-core/js/auth/basic/basic-auth-login.tsx
+++ b/packages/dara-core/js/auth/basic/basic-auth-login.tsx
@@ -10,7 +10,7 @@ import DefaultFallback from '@/components/fallback/default';
 import { useRouterContext } from '@/router/context';
 import Center from '@/shared/center/center';
 
-import { requestSessionToken, verifySessionToken } from '../auth';
+import { parseLoginReferrer, requestSessionToken, verifySessionToken } from '../auth';
 
 const Wrapper = styled.div`
     display: flex;
@@ -137,9 +137,8 @@ function BasicAuthLogin(): JSX.Element {
     const location = useLocation();
     const navigate = useNavigate();
     const { defaultPath } = useRouterContext();
-    const queryParams = new URLSearchParams(location.search);
 
-    const previousLocation = queryParams.get('referrer') ?? defaultPath;
+    const previousLocation = parseLoginReferrer(location.search, defaultPath);
 
     const login = async (): Promise<void> => {
         setIsLoggingIn(true);
@@ -149,7 +148,7 @@ function BasicAuthLogin(): JSX.Element {
             const sessionCreated = await requestSessionToken({ password, username });
 
             if (sessionCreated) {
-                navigate(decodeURIComponent(previousLocation));
+                navigate(previousLocation);
             }
         } catch {
             setIsError(true);
@@ -162,7 +161,7 @@ function BasicAuthLogin(): JSX.Element {
         // If we landed on this page with a valid session already, redirect.
         verifySessionToken().then((verificationResult) => {
             if (verificationResult === 'verified') {
-                navigate(decodeURIComponent(previousLocation), { replace: true });
+                navigate(previousLocation, { replace: true });
             } else if (verificationResult === 'login_required') {
                 setIsVerifyingToken(false);
             }

--- a/packages/dara-core/js/auth/default/default-auth-login.tsx
+++ b/packages/dara-core/js/auth/default/default-auth-login.tsx
@@ -6,7 +6,7 @@ import DefaultFallback from '@/components/fallback/default';
 import { useRouterContext } from '@/router/context';
 import Center from '@/shared/center/center';
 
-import { requestSessionToken, verifySessionToken } from '../auth';
+import { parseLoginReferrer, requestSessionToken, verifySessionToken } from '../auth';
 
 /**
  * The Login component requests a new server-managed session cookie and then redirects.
@@ -15,15 +15,14 @@ function DefaultAuthLogin(): JSX.Element {
     const location = useLocation();
     const navigate = useNavigate();
     const { defaultPath } = useRouterContext();
-    const queryParams = new URLSearchParams(location.search);
 
-    const previousLocation = queryParams.get('referrer') ?? defaultPath;
+    const previousLocation = parseLoginReferrer(location.search, defaultPath);
 
     async function getNewToken(): Promise<void> {
         const sessionCreated = await requestSessionToken({});
         // in default auth this always succeeds
         if (sessionCreated) {
-            navigate(decodeURIComponent(previousLocation));
+            navigate(previousLocation);
         }
     }
 
@@ -32,7 +31,7 @@ function DefaultAuthLogin(): JSX.Element {
         // Otherwise, request a new session token.
         verifySessionToken().then((verificationResult) => {
             if (verificationResult === 'verified') {
-                navigate(decodeURIComponent(previousLocation), { replace: true });
+                navigate(previousLocation, { replace: true });
             } else if (verificationResult === 'login_required') {
                 getNewToken();
             }

--- a/packages/dara-core/js/auth/oidc/oidc-login.tsx
+++ b/packages/dara-core/js/auth/oidc/oidc-login.tsx
@@ -8,7 +8,7 @@ import DefaultFallback from '@/components/fallback/default';
 import { useRouterContext } from '@/router/context';
 import Center from '@/shared/center/center';
 
-import { handleAuthErrors, verifySessionToken } from '../auth';
+import { handleAuthErrors, parseLoginReferrer, verifySessionToken } from '../auth';
 
 /**
  * The Login component gets the username and password from the user and generates a session token.
@@ -19,8 +19,7 @@ function OIDCAuthLogin(): JSX.Element {
     const { defaultPath } = useRouterContext();
 
     const previousLocation = useMemo(() => {
-        const queryParams = new URLSearchParams(location.search);
-        return queryParams.get('referrer') ?? defaultPath;
+        return parseLoginReferrer(location.search, defaultPath);
     }, [location, defaultPath]);
 
     /**
@@ -53,7 +52,7 @@ function OIDCAuthLogin(): JSX.Element {
         // If we already have a valid session, redirect. Otherwise start OIDC login.
         verifySessionToken().then((verificationResult) => {
             if (verificationResult === 'verified') {
-                navigate(decodeURIComponent(previousLocation), { replace: true });
+                navigate(previousLocation, { replace: true });
             } else if (verificationResult === 'login_required') {
                 getNewToken();
             }

--- a/packages/dara-core/js/router/create-router.tsx
+++ b/packages/dara-core/js/router/create-router.tsx
@@ -156,6 +156,14 @@ export function findFirstPath(routes: RouteDefinition[]): string {
  */
 let verifiedToken = false;
 
+export function buildLoginRedirectUrl(baseUrl: string, referrer: string): string {
+    const redirectUrl = new URL(`${baseUrl}/login`, window.location.origin);
+    // resolveReferrer returns an encoded path. Assign the raw search string so
+    // URLSearchParams does not encode it a second time.
+    redirectUrl.search = `?referrer=${referrer}`;
+    return redirectUrl.toString();
+}
+
 interface RouterWithRoutes {
     router: ReturnType<typeof createBrowserRouter>;
     routeDefinitions: RouteDefinition[];
@@ -236,11 +244,9 @@ export function createRouter(config: DaraData, snapshot: () => Snapshot): Router
                                 // otherwise there is no valid session, redirect to login
                                 const referrer = resolveReferrer();
                                 const baseUrl: string = window.dara?.base_url ?? '';
-                                const redirectUrl = new URL(`${baseUrl}/login`, window.location.origin);
-                                redirectUrl.searchParams.set('referrer', referrer);
                                 // Intended RR API usage
                                 // eslint-disable-next-line @typescript-eslint/only-throw-error
-                                throw redirect(redirectUrl.toString());
+                                throw redirect(buildLoginRedirectUrl(baseUrl, referrer));
                             },
                         ],
                         // user-defined routes

--- a/packages/dara-core/tests/js/auth.spec.tsx
+++ b/packages/dara-core/tests/js/auth.spec.tsx
@@ -4,7 +4,9 @@ import { setupServer } from 'msw/node';
 import {
     getSessionIdentifier,
     handleAuthErrors,
+    parseLoginReferrer,
     resolveReferrer,
+    resolveLoginReferrer,
     setSessionIdentifier,
     verifySessionToken,
 } from '@/auth';
@@ -70,6 +72,40 @@ describe('resolve_referrer', () => {
         };
 
         expect(resolveReferrer()).toBe('%2Froute');
+    });
+});
+
+describe('parseLoginReferrer', () => {
+    it('parses the referrer query param once', () => {
+        const search = '?referrer=%2Ffiles%2Ffoo%252Fbar%3Fx%3Da%252Fb';
+
+        expect(parseLoginReferrer(search, '/default')).toBe('/files/foo%2Fbar?x=a%2Fb');
+    });
+
+    it('falls back to the default path when no referrer is present', () => {
+        expect(parseLoginReferrer('?other=value', '/default')).toBe('/default');
+    });
+});
+
+describe('resolveLoginReferrer', () => {
+    const originalWindowLocation = window.location;
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: originalWindowLocation,
+        });
+    });
+
+    it('preserves an existing referrer in encoded form', () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: new URL('https://test.com/login?referrer=%2Ffiles%2Ffoo%252Fbar%3Fx%3Da%252Fb'),
+        });
+
+        expect(resolveLoginReferrer()).toBe('%2Ffiles%2Ffoo%252Fbar%3Fx%3Da%252Fb');
     });
 });
 
@@ -203,6 +239,21 @@ describe('handleAuthErrors', () => {
         expect(handled).toBe(true);
         expect(window.location.pathname).toBe('/login');
         expect(window.location.search).toContain('referrer=%2Ftest%2Froute');
+        expect(getSessionIdentifier()).toBe(null);
+    });
+
+    it('preserves an existing encoded login referrer when redirecting back to login', async () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: new URL('https://test.com/login?referrer=%2Ffiles%2Ffoo%252Fbar%3Fx%3Da%252Fb'),
+        });
+
+        const handled = await handleAuthError('expired', 401);
+
+        expect(handled).toBe(true);
+        expect(window.location.pathname).toBe('/login');
+        expect(window.location.search).toBe('?referrer=%2Ffiles%2Ffoo%252Fbar%3Fx%3Da%252Fb');
         expect(getSessionIdentifier()).toBe(null);
     });
 

--- a/packages/dara-core/tests/js/router.spec.tsx
+++ b/packages/dara-core/tests/js/router.spec.tsx
@@ -1,5 +1,40 @@
 import { findFirstPath } from '@/router';
+import { buildLoginRedirectUrl } from '@/router/create-router';
 import type { RouteDefinition } from '@/types/core';
+
+describe('buildLoginRedirectUrl', () => {
+    const originalWindowLocation = window.location;
+
+    beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: new URL('http://localhost:8000/current'),
+        });
+    });
+
+    afterEach(() => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: originalWindowLocation,
+        });
+    });
+
+    it('preserves an encoded app path referrer without double encoding it', () => {
+        const redirectUrl = buildLoginRedirectUrl('', '%2Fapp%3Ffoo%3Dbar%26baz%3Dqux');
+
+        expect(redirectUrl).toBe('http://localhost:8000/login?referrer=%2Fapp%3Ffoo%3Dbar%26baz%3Dqux');
+        expect(new URL(redirectUrl).searchParams.get('referrer')).toBe('/app?foo=bar&baz=qux');
+    });
+
+    it('includes the app base url when redirecting to login', () => {
+        const redirectUrl = buildLoginRedirectUrl('/base', '%2F');
+
+        expect(redirectUrl).toBe('http://localhost:8000/base/login?referrer=%2F');
+        expect(new URL(redirectUrl).searchParams.get('referrer')).toBe('/');
+    });
+});
 
 describe('findFirstPath', () => {
     describe('simple scenarios', () => {


### PR DESCRIPTION
## Motivation and Context

Unauthenticated first loads in OIDC apps could hit `/error?code=400` before the identity provider flow started. The root auth redirect passed an already encoded referrer through `URLSearchParams`, double-encoding values such as `/` into `%252F`. `/login` decoded that once and sent `%2F` as `redirect_to`, which the backend correctly rejected as an invalid redirect target.

The first fix also surfaced a related client-side inconsistency: login components were manually calling `decodeURIComponent()` after `URLSearchParams.get('referrer')`, which already decodes once. That could turn an intended target such as `/files/foo%2Fbar?x=a%2Fb` into `/files/foo/bar?x=a/b` after login.

## Implementation Description

The root router login redirect now preserves the encoded referrer string when building `/login?referrer=...`, avoiding the extra `URLSearchParams` encoding pass.

Referrer handling is now split consistently by boundary:

- encoded referrer strings are used when constructing login URLs
- parsed referrer paths are used internally for navigation and OIDC `redirect_to` request bodies

Basic, default, and OIDC login flows now use the shared parsed referrer helper instead of decoding independently. Auth-error handling also re-encodes an existing login referrer before recycling it into a fresh `/login` redirect.

Updated the `dara-core` changelog with a high-level note for the fix.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `pnpm --filter @darajs/core exec vitest --run tests/js/auth.spec.tsx tests/js/router.spec.tsx tests/js/websocket-auth-recovery.spec.tsx tests/js/stream-variable.spec.tsx`
- `pnpm --filter @darajs/core exec tsc --noEmit`
- `git diff --check`

Tested locally - before I could reproduce that loading an OIDC-secured page without a cookie would always trigger 400 and redirect to `/error?code=400` instead of `/login`. After the fix user lands on `/login` as expected.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have added/updated the changelog for the relevant package.

## Screenshots (if appropriate):

N/A