### PR TITLE
Fix: DO-11607 align OIDC ID token signing algorithm policy

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## NEXT
 
-- Changed OIDC ID token signing algorithm handling to support `SSO_ID_TOKEN_SIGNED_RESPONSE_ALG`, use JWKS-verifiable non-`none` discovery algorithms when no explicit algorithm is configured, and fall back to RS256.
+- Fixed OIDC ID token signing algorithm handling to match the spec better while maintaining escape hatches for non-compliant IDPs. The `SSO_ID_TOKEN_SIGNED_RESPONSE_ALG` env var remains as an override; JWKS-verifiable non-`none` discovery algorithms are preferred when no explicit algorithm is configured, with a fallback to RS256.
 - Fixed auth login redirects so unauthenticated first loads and referrers containing encoded path/query characters are preserved correctly.
 
 ## 1.28.0

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,6 +4,7 @@ title: Changelog
 
 ## NEXT
 
+- Changed OIDC ID token signing algorithm handling to support `SSO_ID_TOKEN_SIGNED_RESPONSE_ALG`, use JWKS-verifiable non-`none` discovery algorithms when no explicit algorithm is configured, and fall back to RS256.
 - Fixed auth login redirects so unauthenticated first loads and referrers containing encoded path/query characters are preserved correctly.
 
 ## 1.28.0

--- a/packages/dara-core/dara/core/auth/oidc/config.py
+++ b/packages/dara-core/dara/core/auth/oidc/config.py
@@ -37,13 +37,14 @@ from ..definitions import (
 )
 from ..utils import decode_token, sign_jwt
 from .definitions import (
+    ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY,
     JWK_CLIENT_REGISTRY_KEY,
     IdTokenClaims,
     OIDCDiscoveryMetadata,
     OIDCLoginTransaction,
 )
 from .routes import sso_callback
-from .settings import OIDCSettings, get_oidc_settings
+from .settings import DEFAULT_ID_TOKEN_SIGNING_ALG, OIDCSettings, get_oidc_settings
 from .transaction_store import oidc_transaction_store
 from .utils import decode_id_token, get_token_from_idp
 
@@ -54,10 +55,23 @@ OIDCAuthLogout = AuthComponent(js_module='@darajs/core', py_module='dara.core', 
 OIDCAuthSSOCallback = AuthComponent(js_module='@darajs/core', py_module='dara.core', js_name='OIDCAuthSSOCallback')
 
 USERINFO_ERROR = OTHER_AUTH_ERROR('Identity provider userinfo failed')
+UNSUPPORTED_JWKS_SIGNING_ALG_PREFIXES = ('HS',)
 
 
 class _RetryableDiscoveryError(Exception):
     """Transient failure while fetching the OIDC discovery document."""
+
+
+def _is_supported_jwks_id_token_signing_alg(alg: str) -> bool:
+    """
+    Whether Dara can verify this ID token JWS alg with the issuer JWKS.
+
+    OpenID Connect Core 1.0 Section 10.1 treats MAC-based signatures as
+    client-secret based. This implementation validates ID tokens with the
+    OP's jwks_uri keys, so HMAC algorithms are out of scope.
+    """
+    alg_upper = alg.upper()
+    return alg.lower() != 'none' and not alg_upper.startswith(UNSUPPORTED_JWKS_SIGNING_ALG_PREFIXES)
 
 
 class OIDCAuthConfig(BaseAuthConfig):
@@ -78,7 +92,8 @@ class OIDCAuthConfig(BaseAuthConfig):
     - SSO_EXTRA_AUDIENCE - if set, extra audiences to verify against the ID token in addition to `sso_client_id`
     - SSO_SCOPES - space-separated list of scopes to request from the identity provider, defaults to `openid`
     - SSO_GROUP_CLAIM_NAME - name of the claim containing user groups, defaults to `groups`
-    - SSO_JWT_ALGO - algorithm to use for verifying IDP-provided JWTs, defaults to `ES256`
+    - SSO_ID_TOKEN_SIGNED_RESPONSE_ALG - ID token signing alg registered for this client; if unset, Dara uses signed algs from discovery or `RS256`
+    - SSO_JWT_ALGO - deprecated alias for `SSO_ID_TOKEN_SIGNED_RESPONSE_ALG`
     - SSO_USE_USERINFO - if set to `true`, require the userinfo endpoint during login and refresh
     """
 
@@ -119,6 +134,73 @@ class OIDCAuthConfig(BaseAuthConfig):
     def get_discovery_url(self) -> str:
         issuer_url = get_oidc_settings().issuer_url
         return f'{issuer_url}/.well-known/openid-configuration'
+
+    def resolve_id_token_signing_algs(
+        self,
+        discovery: OIDCDiscoveryMetadata,
+        oidc_settings: OIDCSettings,
+    ) -> list[str]:
+        """
+        Resolve the relying party's allowed ID token signing algorithms against provider discovery.
+        """
+        configured_alg = oidc_settings.configured_id_token_signed_response_alg
+
+        if configured_alg is not None:
+            # Explicit env config is Dara's local verifier policy and is more
+            # specific than provider capability metadata. Keep accepting it even
+            # when a non-compliant OP omits the alg from discovery.
+            if configured_alg not in discovery.id_token_signing_alg_values_supported:
+                dev_logger.warning(
+                    'OIDC ID token signing algorithm is not advertised by discovery',
+                    {'expected': configured_alg, 'supported': discovery.id_token_signing_alg_values_supported},
+                )
+            return [configured_alg]
+
+        supported_signed_algs = [
+            alg
+            for alg in discovery.id_token_signing_alg_values_supported
+            if _is_supported_jwks_id_token_signing_alg(alg)
+        ]
+        unsupported_signed_algs = [
+            alg for alg in discovery.id_token_signing_alg_values_supported if alg not in supported_signed_algs
+        ]
+        if unsupported_signed_algs:
+            dev_logger.info(
+                'OIDC discovery metadata advertises unsupported ID token signing algorithms',
+                {'unsupported': unsupported_signed_algs, 'supported': discovery.id_token_signing_alg_values_supported},
+            )
+
+        # OpenID Connect Discovery 1.0 Section 3 defines
+        # id_token_signing_alg_values_supported as the OP support set and says
+        # RS256 MUST be included. CONCESSION: an internal IDP currently
+        # advertises only ES256. When no client metadata/env override exists,
+        # accept the OP's discovered JWKS-verifiable signing algorithms rather
+        # than aborting solely because RS256 is absent.
+        if supported_signed_algs:
+            if DEFAULT_ID_TOKEN_SIGNING_ALG not in supported_signed_algs:
+                dev_logger.warning(
+                    'OIDC discovery metadata does not advertise the default ID token signing algorithm',
+                    {
+                        'expected': DEFAULT_ID_TOKEN_SIGNING_ALG,
+                        'supported': discovery.id_token_signing_alg_values_supported,
+                    },
+                )
+            return supported_signed_algs
+
+        # OpenID Connect Discovery 1.0 Section 3 says RS256 MUST be included in
+        # id_token_signing_alg_values_supported. If the OP publishes no usable
+        # JWKS-verifiable signed algorithms, keep RS256 as the last resort
+        # policy. RFC 8725 Section 3.1 still requires selecting allowed algs
+        # independently of the JWT header.
+        if discovery.id_token_signing_alg_values_supported:
+            dev_logger.warning(
+                'OIDC discovery metadata does not advertise any JWKS-verifiable ID token signing algorithms',
+                {
+                    'fallback': DEFAULT_ID_TOKEN_SIGNING_ALG,
+                    'supported': discovery.id_token_signing_alg_values_supported,
+                },
+            )
+        return [DEFAULT_ID_TOKEN_SIGNING_ALG]
 
     async def fetch_discovery_document(self, discovery_url: str, oidc_settings: OIDCSettings) -> httpx.Response:
         """
@@ -181,14 +263,16 @@ class OIDCAuthConfig(BaseAuthConfig):
             raise RuntimeError(
                 f'OIDC discovery issuer mismatch: expected {oidc_settings.issuer_url}, got {self._discovery.issuer}'
             )
+        id_token_signing_algs = self.resolve_id_token_signing_algs(self._discovery, oidc_settings)
 
         dev_logger.info(f'Successfully fetched OIDC discovery document from {discovery_url}')
 
-        # 3. Register a PyJWKClient instance bound to the jwks_uri from discovery
+        # 3. Store runtime OIDC verifier configuration from discovery
         from dara.core.internal.registries import utils_registry
 
         py_jwk_client = PyJWKClient(self.discovery.jwks_uri, lifespan=oidc_settings.jwks_lifespan)
-        utils_registry.register(JWK_CLIENT_REGISTRY_KEY, py_jwk_client)
+        utils_registry.set(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY, id_token_signing_algs)
+        utils_registry.set(JWK_CLIENT_REGISTRY_KEY, py_jwk_client)
 
         # Return cleanup to close the HTTP client
         async def _cleanup():

--- a/packages/dara-core/dara/core/auth/oidc/definitions.py
+++ b/packages/dara-core/dara/core/auth/oidc/definitions.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 
 from pydantic import BaseModel, ConfigDict, Field
 
+ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY = 'OIDCIdTokenSigningAlgs'
 JWK_CLIENT_REGISTRY_KEY = 'PyJWKClient'
 OIDC_LOGIN_SESSION_COOKIE_NAME = 'dara_oidc_login_session'
 
@@ -86,8 +87,14 @@ class OIDCDiscoveryMetadata(BaseModel):
     )
 
     id_token_signing_alg_values_supported: list[str] = Field(
-        ...,
-        description='REQUIRED. JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for the ID Token to encode the Claims in a JWT. The algorithm RS256 MUST be included. The value none MAY be supported but MUST NOT be used unless the Response Type used returns no ID Token from the Authorization Endpoint.',
+        default_factory=list,
+        description="""
+        REQUIRED. JSON array containing a list of the JWS signing algorithms (alg values) supported by the OP for the
+        ID Token to encode the Claims in a JWT. The algorithm RS256 MUST be included. The value none MAY be supported
+        but MUST NOT be used unless the Response Type used returns no ID Token from the Authorization Endpoint.
+        CONCESSION: accepted as empty so Dara can fall back to RS256 for non-compliant discovery documents that omit
+        this field.
+        """,
     )
 
     id_token_encryption_alg_values_supported: list[str] | None = Field(

--- a/packages/dara-core/dara/core/auth/oidc/settings.py
+++ b/packages/dara-core/dara/core/auth/oidc/settings.py
@@ -1,11 +1,12 @@
 import os
 from functools import lru_cache
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import Field, model_validator
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 OIDCClientAuthMode = Literal['client_secret_basic', 'pkce_public']
+DEFAULT_ID_TOKEN_SIGNING_ALG = 'RS256'
 
 
 class OIDCSettings(BaseSettings):
@@ -24,7 +25,15 @@ class OIDCSettings(BaseSettings):
     """Token endpoint client authentication mode."""
     issuer_url: str = 'https://login.causalens.com/api/authentication'
     jwks_lifespan: int = 86400  # 1 day
-    jwt_algo: str = 'ES256'
+    # validation_alias bypasses env_prefix, so include full env names here.
+    id_token_signed_response_alg: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            'SSO_ID_TOKEN_SIGNED_RESPONSE_ALG',
+            'SSO_JWT_ALGO',
+        ),
+    )
+    """JWS alg required for ID tokens issued to this client."""
     scopes: str = 'openid'
     group_claim_name: str = 'groups'
     """Name of the claim containing user groups in ID token or userinfo responses."""
@@ -42,7 +51,21 @@ class OIDCSettings(BaseSettings):
     transaction_max_entries: int = Field(default=10000, ge=1)
     """Maximum number of outstanding OIDC login transactions kept in memory."""
 
-    model_config = SettingsConfigDict(env_file='.env', extra='allow', env_prefix='sso_')
+    model_config = SettingsConfigDict(env_file='.env', extra='allow', env_prefix='sso_', populate_by_name=True)
+
+    @model_validator(mode='before')
+    @classmethod
+    def map_legacy_jwt_algo_constructor_alias(cls, data: Any):
+        """
+        Preserve constructor compatibility for jwt_algo without accepting unprefixed JWT_ALGO env vars.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        if data.get('id_token_signed_response_alg') is None and data.get('jwt_algo') is not None:
+            return {**data, 'id_token_signed_response_alg': data['jwt_algo']}
+
+        return data
 
     @model_validator(mode='after')
     def apply_audience_env_overrides(self):
@@ -71,6 +94,47 @@ class OIDCSettings(BaseSettings):
             raise ValueError('SSO_CLIENT_SECRET is required when SSO_CLIENT_AUTH_MODE=client_secret_basic')
 
         return self
+
+    @model_validator(mode='after')
+    def validate_id_token_signing_alg(self):
+        """
+        Validate configured ID token signing algorithm settings.
+        """
+        # OpenID Connect Discovery 1.0 Section 3 permits "none" only for
+        # response types that return no ID Token from the Authorization Endpoint.
+        # Dara's OIDC verifier expects signed ID tokens and always validates them
+        # with the issuer's JWKS, so do not allow an unsigned token policy.
+        configured_alg = self.configured_id_token_signed_response_alg or ''
+        if configured_alg.lower() == 'none':
+            raise ValueError('OIDC ID token signing algorithm "none" is not supported')
+        if configured_alg.upper().startswith('HS'):
+            raise ValueError('OIDC ID token HMAC signing algorithms are not supported')
+
+        return self
+
+    @property
+    def configured_id_token_signed_response_alg(self) -> str | None:
+        """
+        Resolve the explicitly configured ID token signing alg for this relying party.
+        """
+        return self.id_token_signed_response_alg
+
+    @property
+    def jwt_algo(self) -> str | None:
+        """
+        Deprecated compatibility alias for id_token_signed_response_alg.
+        """
+        return self.id_token_signed_response_alg
+
+    @property
+    def fallback_id_token_signed_response_alg(self) -> str:
+        """
+        Resolve the configured ID token signing alg or pre-startup fallback.
+
+        Startup normally resolves verifier algorithms from discovery metadata.
+        SSO_JWT_ALGO is kept as a compatibility alias.
+        """
+        return self.id_token_signed_response_alg or DEFAULT_ID_TOKEN_SIGNING_ALG
 
 
 @lru_cache

--- a/packages/dara-core/dara/core/auth/oidc/utils.py
+++ b/packages/dara-core/dara/core/auth/oidc/utils.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, ConfigDict
 from dara.core.auth.definitions import OTHER_AUTH_ERROR
 from dara.core.logging import dev_logger
 
-from .definitions import JWK_CLIENT_REGISTRY_KEY, IdTokenClaims
+from .definitions import ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY, JWK_CLIENT_REGISTRY_KEY, IdTokenClaims
 from .settings import get_oidc_settings
 
 if TYPE_CHECKING:
@@ -75,6 +75,41 @@ def decode_id_token(id_token: str) -> IdTokenClaims:
 
     jwks_client: jwt.PyJWKClient = utils_registry.get(JWK_CLIENT_REGISTRY_KEY)
     oidc_settings = get_oidc_settings()
+    id_token_signing_algs = (
+        utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY)
+        if utils_registry.has(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY)
+        else [oidc_settings.fallback_id_token_signed_response_alg]
+    )
+    token_alg = jwt.get_unverified_header(id_token).get('alg')
+
+    if not isinstance(token_alg, str):
+        raise jwt.InvalidAlgorithmError('OIDC ID token signing algorithm is missing')
+
+    if token_alg.upper().startswith('HS'):
+        raise jwt.InvalidAlgorithmError('OIDC ID token HMAC signing algorithms are not supported')
+
+    # The JOSE header is attacker-controlled input, so it is not trusted as
+    # policy. It only states the algorithm the token claims was used. RFC 8725
+    # Section 3.1 requires checking that claimed algorithm against a
+    # caller-controlled allow-list; our allow-list comes from explicit env
+    # policy or validated OIDC discovery metadata resolved during startup.
+    if token_alg not in id_token_signing_algs:
+        raise jwt.InvalidAlgorithmError(
+            'OIDC ID token signing algorithm is not allowed: '
+            f'token alg {token_alg}, allowed algs {id_token_signing_algs}'
+        )
+
+    signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+    key_alg = getattr(signing_key, '_jwk_data', {}).get('alg')
+
+    # The JWK "alg" member is optional. When the OP publishes it, treat it as a
+    # trusted key-level constraint from the issuer's jwks_uri and require it to
+    # match the token's claimed operation. When it is omitted, do not use
+    # PyJWT's algorithm_name as policy: PyJWT supplies key-type defaults such
+    # as RS256 for RSA keys, which would incorrectly reject valid PS256/RS384
+    # tokens that were allowed by env/discovery and signed by the selected key.
+    if isinstance(key_alg, str) and key_alg != token_alg:
+        raise jwt.InvalidAlgorithmError(f'OIDC ID token JWK alg {key_alg} does not match token alg {token_alg}')
 
     # Build audience list for verification if enabled
     audience = None
@@ -83,11 +118,10 @@ def decode_id_token(id_token: str) -> IdTokenClaims:
         if oidc_settings.extra_audience:
             audience.extend(oidc_settings.extra_audience)
 
-    # Decode and verify the token
     decoded = jwt.decode(
         id_token,
-        jwks_client.get_signing_key_from_jwt(id_token).key,
-        algorithms=[oidc_settings.jwt_algo],
+        signing_key.key,
+        algorithms=[token_alg],
         audience=audience,
         issuer=oidc_settings.issuer_url,
         options={'verify_aud': oidc_settings.verify_audience},

--- a/packages/dara-core/docs/advanced/authentication.mdx
+++ b/packages/dara-core/docs/advanced/authentication.mdx
@@ -113,7 +113,8 @@ The following environment variables are optional:
 | `SSO_CLIENT_AUTH_MODE`    | `client_secret_basic`   | Token endpoint auth mode. Use `pkce_public` for public clients without a client secret.                      |
 | `SSO_CLIENT_SECRET`       | `None`                  | OAuth 2.0 client secret. Required when `SSO_CLIENT_AUTH_MODE=client_secret_basic`. Ignored for `pkce_public`. |
 | `SSO_JWKS_LIFESPAN`       | `86400`                 | Lifespan of the JWKS cache in seconds (default 1 day)                                                        |
-| `SSO_JWT_ALGO`            | `ES256`                 | Algorithm for verifying identity provider JWTs                                                               |
+| `SSO_ID_TOKEN_SIGNED_RESPONSE_ALG` | `None`        | Optional ID token signing algorithm override for non-compliant providers. If unset, Dara uses JWKS-verifiable non-`none` signing algs from discovery, falling back to `RS256`. HMAC ID token algorithms are not supported by this JWKS-based verifier. |
+| `SSO_JWT_ALGO`            | `None`                  | Deprecated alias for `SSO_ID_TOKEN_SIGNED_RESPONSE_ALG`, used only when the new variable is not set.          |
 | `SSO_SCOPES`              | `openid`                | Space-separated list of OAuth scopes to request                                                              |
 | `SSO_GROUP_CLAIM_NAME`    | `groups`                | Claim name to read group membership from. Use this for providers that return groups under a non-standard claim such as `memberOf`. |
 | `SSO_VERIFY_AUDIENCE`     | `False`                 | Whether to verify the `aud` claim in ID tokens                                                               |

--- a/packages/dara-core/tests/python/test_oidc_auth.py
+++ b/packages/dara-core/tests/python/test_oidc_auth.py
@@ -28,6 +28,7 @@ from dara.core.auth.definitions import (
 )
 from dara.core.auth.oidc.config import OIDCAuthConfig
 from dara.core.auth.oidc.definitions import (
+    ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY,
     JWK_CLIENT_REGISTRY_KEY,
     OIDC_LOGIN_SESSION_COOKIE_NAME,
     IdTokenClaims,
@@ -35,6 +36,7 @@ from dara.core.auth.oidc.definitions import (
 )
 from dara.core.auth.oidc.settings import get_oidc_settings
 from dara.core.auth.oidc.transaction_store import oidc_transaction_store
+from dara.core.auth.oidc.utils import decode_id_token
 from dara.core.auth.session import verify_auth_token
 from dara.core.auth.session_store import AuthSession, AuthSessionStore, ExpiredAuthSession, auth_session_store
 from dara.core.configuration import ConfigurationBuilder
@@ -65,17 +67,34 @@ ENV_OVERRIDE = {
     'SSO_GROUPS': TEST_SSO_GROUPS,
 }
 
-# Sample ES256 key
+# Sample RS256 key
 MOCK_JWK = {
+    'alg': 'RS256',
+    'kty': 'RSA',
+    'n': '0ajtf9xvPKgC24P8d8AOrE91fymB2flnQqgC4U8gHlXPY3NroZsd-0OWG08BjQFYzDPPq9hhDR-XshPCPns4hbRTdE8eccirBUdIWm6kN9mIPh9CP6I2G1tQsgZRijBjrYnj6EbFHWAfwTgx0K6bcvKyFTk7eG7QrCy-Op6GkHbo3WMG3eDTTtoI9Xy4KwBeBrQVz_IIXApxPejEQwYnsNgAPcTRDj_Sxr1dho-MW23JD4Szml0PWPMt_MI6z7jCbqAqRIiLxWTm9DStqCbSSw27_fnjrGgA9ttBfwzcFnSFvFk9esCzJHcGq8zjAHXnjDDd3gyYXxRfXWYqV3Dljw',
+    'e': 'AQAB',
+    'd': 'ZjW57tr6ebIYjoaWNpTxMkycZc1I6ghdsE-y8788070WmQ-kOYkjASLuU0rdYS32abqac9bNXXX44I4kZIxyvi_ufWWy3FqtESoymi-VLEsG0e4wQFBmm0iVmuxcpQc5GNl_u3WA0_TQFkS8eFUfIFczvQgFN42iekVnybENve_v1Jq9veffcDAhvlwo_1s4Bl41bFZmzoJDEaW8pWjJ-2-4cj3qL0G1ek9hBg2L4e8QUiqdWGF--_D4jsc1o2Lo5YDMxhQZLGTI821NOE_Le37vTsaxUL1ANPR2voOuhXD7wJpbRmf6OM-fInKzvDSgKqwl6azr0I9TUytvlr3T3Q',
+    'p': '-Q-SDSDXRysHiSk4XSJ76bLiclDaIc6jkO8Q27D_0b574WxVkESR_fhiky5D5F4akBnCq0zS2vUztQX0IvWbMerZ5p_De8BO5EKeDtUSc30pRJWuF02I-HaMtuh_BuRSW_d2a4zHFSn4rrqGrXJ9mnwxw3C1oaDBXmNmXgfdF_M',
+    'q': '14BUVw9-l-fwb1wrvvNpDVcXFwW8OQb4GtIwL3kfOU_NO1jxCNN8w5MhXXg5sT-R73hdVFS2YzAgeDeHcDb2LRQZxRGgaB50UAWkmvUgC-ELF8yAkaFkRJUWExyaJ-zndwjJzje2omYvSox9Duwen12xTcP6TkH5kU3q5SDrnvU',
+    'dp': 'zVWf9MDhm2QHV3araGV4wWhgtxyfagXh5iiivm0Dy9l-apAVTtapgjgYlP0srgdDYRBL5Ux1_lzvn0vkRjo1FAdqVG_dC5a1tAyUIOhbyOkkb83zdHTQ-v9J7bZqm7T7jaTMdcjfjTxIMU3IoRDmKso_gMDYjgNpyLase9OB3S8',
+    'dq': 'MIcfdvNwSHjcdddFqpxZnb1s36xU9GqTWEbYvvgBhgBocOLYdGpbgBcTvl6ibz2neUubiLAC2lcuGKQ4hZZ63S_Xlb8gZhHlk1eR96sXalVlEBjnIuQ7Fg6Uh_064Z7BiNabyypUoEFuiNUWHFQjmTOaB68IILNOpd_r82j0Zjk',
+    'qi': '4XlwiY0hJuqk3zIWdktPC_lJCCviDmckoui6F4rZqt8khU8W3zyG3si9SrUfucToZoOIOw-KndRxe1RM2wBelBJa6-CD4j_VLg72QYOX9dNFFTlGYGn5bT8iUx71q7O1G2MlKEDBNqZfe8DEIQ9nAMEPgqBaVS5Qp7NHPhP78zQ',
+    'kid': 'test-rs256-key',
+}
+MOCK_JWKS_DATA = {'keys': [{key: MOCK_JWK[key] for key in ('alg', 'kty', 'n', 'e', 'kid')}]}
+MOCK_RSA_JWKS_DATA_WITHOUT_ALG = {'keys': [{key: MOCK_JWK[key] for key in ('kty', 'n', 'e', 'kid')}]}
+
+# Sample ES256 key used by the internal IDP compatibility tests
+MOCK_ES256_JWK = {
     'alg': 'ES256',
     'kty': 'EC',
     'crv': 'P-256',
     'x': 'SVqB4JcUD6lsfvqMr-OKUNUphdNn64Eay60978ZlL74',
     'y': 'lf0u0pMj4lGAzZix5u4Cm5CMQIgMNpkwy163wtKYVKI',
     'd': '0g5vAEKzugrXaRbgKG0Tj2qJ5lMP4Bezds1_sTybkfk',
-    'kid': 'NEE1QURBOTM4MzI5RkFDNTYxOTU1MDg2ODgwQ0UzMTk1QjYyRkRFQw',
+    'kid': 'test-es256-key',
 }
-MOCK_JWKS_DATA = {'keys': [MOCK_JWK]}
+MOCK_ES256_JWKS_DATA = {'keys': [{key: MOCK_ES256_JWK[key] for key in ('alg', 'kty', 'crv', 'x', 'y', 'kid')}]}
 
 MOCK_ID_TOKEN = {
     'sub': 'uuid',
@@ -131,7 +150,7 @@ MOCK_DISCOVERY = OIDCDiscoveryMetadata(
     registration_endpoint='http://test-identity-provider.com/api/authentication/register',
     response_types_supported=['code', 'id_token', 'token id_token'],
     token_endpoint_auth_methods_supported=['client_secret_post', 'client_secret_basic'],
-    id_token_signing_alg_values_supported=['ES256'],
+    id_token_signing_alg_values_supported=['RS256'],
     end_session_endpoint='http://test-identity-provider.com/api/authentication/logout',
 )
 
@@ -234,6 +253,206 @@ async def test_startup_hook_rejects_discovery_issuer_mismatch():
     await auth_config.client.aclose()
 
 
+async def test_startup_hook_uses_discovered_id_token_signing_algs_when_unconfigured():
+    auth_config = make_config()
+    discovery = MOCK_DISCOVERY.model_copy(update={'id_token_signing_alg_values_supported': ['ES256', 'PS256']})
+
+    with mock.patch.object(
+        auth_config.client,
+        'get',
+        mock.AsyncMock(
+            return_value=httpx.Response(
+                status_code=200,
+                json=discovery.model_dump(),
+                request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+            )
+        ),
+    ):
+        cleanup = await auth_config.startup_hook()
+
+    assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['ES256', 'PS256']
+
+    await cleanup()
+
+
+async def test_startup_hook_filters_unsupported_discovered_id_token_signing_algs():
+    auth_config = make_config()
+    discovery = MOCK_DISCOVERY.model_copy(update={'id_token_signing_alg_values_supported': ['none', 'HS256', 'ES256']})
+
+    with mock.patch.object(
+        auth_config.client,
+        'get',
+        mock.AsyncMock(
+            return_value=httpx.Response(
+                status_code=200,
+                json=discovery.model_dump(),
+                request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+            )
+        ),
+    ):
+        cleanup = await auth_config.startup_hook()
+
+    assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['ES256']
+
+    await cleanup()
+
+
+async def test_startup_hook_falls_back_to_rs256_when_discovery_omits_id_token_signing_algs():
+    auth_config = make_config()
+    discovery_data = MOCK_DISCOVERY.model_dump()
+    discovery_data.pop('id_token_signing_alg_values_supported')
+
+    with mock.patch.object(
+        auth_config.client,
+        'get',
+        mock.AsyncMock(
+            return_value=httpx.Response(
+                status_code=200,
+                json=discovery_data,
+                request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+            )
+        ),
+    ):
+        cleanup = await auth_config.startup_hook()
+
+    assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['RS256']
+
+    await cleanup()
+
+
+async def test_startup_hook_warns_when_falling_back_after_discovery_has_no_jwks_verifiable_algs(
+    caplog: pytest.LogCaptureFixture,
+):
+    caplog.set_level(logging.WARNING, logger='dara.dev')
+    auth_config = make_config()
+    discovery = MOCK_DISCOVERY.model_copy(update={'id_token_signing_alg_values_supported': ['none', 'HS256']})
+
+    with mock.patch.object(
+        auth_config.client,
+        'get',
+        mock.AsyncMock(
+            return_value=httpx.Response(
+                status_code=200,
+                json=discovery.model_dump(),
+                request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+            )
+        ),
+    ):
+        cleanup = await auth_config.startup_hook()
+
+    assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['RS256']
+    log_content = get_log_content(
+        caplog, 'OIDC discovery metadata does not advertise any JWKS-verifiable ID token signing algorithms'
+    )
+    assert log_content == {'fallback': 'RS256', 'supported': ['none', 'HS256']}
+
+    await cleanup()
+
+
+async def test_startup_hook_accepts_new_id_token_signing_alg_override():
+    with mock.patch.dict(os.environ, {**os.environ, 'SSO_ID_TOKEN_SIGNED_RESPONSE_ALG': 'ES256'}):
+        get_oidc_settings.cache_clear()
+        auth_config = make_config()
+        discovery = MOCK_DISCOVERY.model_copy(update={'id_token_signing_alg_values_supported': ['ES256']})
+
+        with mock.patch.object(
+            auth_config.client,
+            'get',
+            mock.AsyncMock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json=discovery.model_dump(),
+                    request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+                )
+            ),
+        ):
+            cleanup = await auth_config.startup_hook()
+
+        assert get_oidc_settings().fallback_id_token_signed_response_alg == 'ES256'
+        assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['ES256']
+
+        await cleanup()
+        get_oidc_settings.cache_clear()
+
+
+async def test_startup_hook_uses_new_id_token_signing_alg_when_discovery_omits_it():
+    with mock.patch.dict(os.environ, {**os.environ, 'SSO_ID_TOKEN_SIGNED_RESPONSE_ALG': 'ES256'}):
+        get_oidc_settings.cache_clear()
+        auth_config = make_config()
+
+        with mock.patch.object(
+            auth_config.client,
+            'get',
+            mock.AsyncMock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json=MOCK_DISCOVERY.model_dump(),
+                    request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+                )
+            ),
+        ):
+            cleanup = await auth_config.startup_hook()
+
+        assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['ES256']
+
+        await cleanup()
+        get_oidc_settings.cache_clear()
+
+
+async def test_startup_hook_uses_new_id_token_signing_alg_over_legacy_jwt_algo():
+    with mock.patch.dict(
+        os.environ,
+        {**os.environ, 'SSO_ID_TOKEN_SIGNED_RESPONSE_ALG': 'RS256', 'SSO_JWT_ALGO': 'ES256'},
+    ):
+        get_oidc_settings.cache_clear()
+        auth_config = make_config()
+
+        with mock.patch.object(
+            auth_config.client,
+            'get',
+            mock.AsyncMock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json=MOCK_DISCOVERY.model_dump(),
+                    request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+                )
+            ),
+        ):
+            cleanup = await auth_config.startup_hook()
+
+        assert get_oidc_settings().fallback_id_token_signed_response_alg == 'RS256'
+        assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['RS256']
+
+        await cleanup()
+        get_oidc_settings.cache_clear()
+
+
+async def test_startup_hook_accepts_legacy_jwt_algo_override():
+    with mock.patch.dict(os.environ, {**os.environ, 'SSO_JWT_ALGO': 'ES256'}):
+        get_oidc_settings.cache_clear()
+        auth_config = make_config()
+        discovery = MOCK_DISCOVERY.model_copy(update={'id_token_signing_alg_values_supported': ['ES256']})
+
+        with mock.patch.object(
+            auth_config.client,
+            'get',
+            mock.AsyncMock(
+                return_value=httpx.Response(
+                    status_code=200,
+                    json=discovery.model_dump(),
+                    request=httpx.Request('GET', f'{TEST_SSO_ISSUER_URL}/.well-known/openid-configuration'),
+                )
+            ),
+        ):
+            cleanup = await auth_config.startup_hook()
+
+        assert get_oidc_settings().fallback_id_token_signed_response_alg == 'ES256'
+        assert utils_registry.get(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY) == ['ES256']
+
+        await cleanup()
+        get_oidc_settings.cache_clear()
+
+
 async def test_startup_hook_retries_transient_discovery_request_error():
     auth_config = make_config()
     discovery_response = httpx.Response(
@@ -322,28 +541,68 @@ async def start_oidc_login(client: AsyncClient, redirect_to: str | None = None) 
     return state
 
 
-def make_mock_id_token(state: str, overrides: dict | None = None) -> str:
+def make_mock_id_token(state: str, overrides: dict | None = None, jwk_data: dict | None = None) -> str:
     transaction = oidc_transaction_store.get(state)
     assert transaction is not None
 
+    jwk_data = jwk_data or MOCK_JWK
     claims = {**MOCK_ID_TOKEN, 'nonce': transaction.nonce, **(overrides or {})}
-    jwk = PyJWK(MOCK_JWK)
+    jwk = PyJWK(jwk_data)
     return jwt.encode(
         claims,
         jwk.key,
-        algorithm=MOCK_JWK['alg'],
-        headers={'kid': MOCK_JWK['kid']},
+        algorithm=jwk_data['alg'],
+        headers={'kid': jwk_data['kid']},
     )
 
 
 @contextlib.contextmanager
-def mock_registered_jwks_client():
+def mock_registered_jwks_client(allowed_algs: list[str] | None = None):
     previous_registry = dict(utils_registry.get_all())
+    utils_registry.set(ID_TOKEN_SIGNING_ALGS_REGISTRY_KEY, allowed_algs or [MOCK_JWK['alg']])
     utils_registry.set(JWK_CLIENT_REGISTRY_KEY, PyJWKClient(MOCK_DISCOVERY.jwks_uri))
     try:
         yield
     finally:
         utils_registry.replace(previous_registry, deepcopy=False)
+
+
+def make_raw_mock_id_token(jwk_data: dict, overrides: dict | None = None, algorithm: str | None = None) -> str:
+    claims = {**MOCK_ID_TOKEN, **(overrides or {})}
+    jwk = PyJWK(jwk_data)
+    algorithm = algorithm or jwk_data['alg']
+    return jwt.encode(
+        claims,
+        jwk.key,
+        algorithm=algorithm,
+        headers={'kid': jwk_data['kid']},
+    )
+
+
+async def test_decode_id_token_accepts_es256_discovery_algorithm():
+    with mock_registered_jwks_client(['ES256']), mocked_urllib(MOCK_ES256_JWKS_DATA):
+        decoded = decode_id_token(make_raw_mock_id_token(MOCK_ES256_JWK))
+
+    assert decoded.sub == MOCK_ID_TOKEN['sub']
+
+
+async def test_decode_id_token_rejects_signing_key_algorithm_outside_resolved_policy():
+    with mock_registered_jwks_client(['RS256']), mocked_urllib(MOCK_ES256_JWKS_DATA):
+        with pytest.raises(jwt.InvalidAlgorithmError, match='signing algorithm is not allowed'):
+            decode_id_token(make_raw_mock_id_token(MOCK_ES256_JWK))
+
+
+async def test_decode_id_token_accepts_allowed_rsa_algorithm_when_jwk_omits_alg():
+    with mock_registered_jwks_client(['PS256']), mocked_urllib(MOCK_RSA_JWKS_DATA_WITHOUT_ALG):
+        decoded = decode_id_token(make_raw_mock_id_token(MOCK_JWK, algorithm='PS256'))
+
+    assert decoded.sub == MOCK_ID_TOKEN['sub']
+
+
+async def test_decode_id_token_rejects_explicit_jwk_algorithm_mismatch():
+    with mock_registered_jwks_client(['RS256', 'PS256']), mocked_urllib(MOCK_JWKS_DATA):
+        with pytest.raises(jwt.InvalidAlgorithmError, match='JWK alg RS256 does not match token alg PS256'):
+            decode_id_token(make_raw_mock_id_token(MOCK_JWK, algorithm='PS256'))
 
 
 async def test_session_no_state():
@@ -2009,7 +2268,7 @@ MOCK_DISCOVERY_WITH_USERINFO = OIDCDiscoveryMetadata(
     registration_endpoint='http://test-identity-provider.com/api/authentication/register',
     response_types_supported=['code', 'id_token', 'token id_token'],
     token_endpoint_auth_methods_supported=['client_secret_post', 'client_secret_basic'],
-    id_token_signing_alg_values_supported=['ES256'],
+    id_token_signing_alg_values_supported=['RS256'],
     end_session_endpoint='http://test-identity-provider.com/api/authentication/logout',
     userinfo_endpoint='http://test-identity-provider.com/api/authentication/userinfo',
 )

--- a/packages/dara-core/tests/python/test_oidc_settings.py
+++ b/packages/dara-core/tests/python/test_oidc_settings.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from dara.core.auth.oidc.settings import OIDCSettings, get_oidc_settings
+from dara.core.auth.oidc.settings import DEFAULT_ID_TOKEN_SIGNING_ALG, OIDCSettings, get_oidc_settings
 
 
 @pytest.fixture(autouse=True)
@@ -64,6 +64,129 @@ def test_group_claim_name_defaults_to_groups():
     )
 
     assert s.group_claim_name == 'groups'
+
+
+def test_id_token_signing_alg_defaults_to_rs256():
+    s = OIDCSettings(
+        _env_file=None,  # type: ignore
+        client_id='client-id',
+        client_secret='client-secret',
+        redirect_uri='http://localhost:8000/sso-callback',
+        groups='dev',
+    )
+
+    assert s.id_token_signed_response_alg is None
+    assert s.jwt_algo is None
+    assert s.fallback_id_token_signed_response_alg == DEFAULT_ID_TOKEN_SIGNING_ALG
+
+
+def test_id_token_signing_alg_takes_precedence_over_legacy_jwt_algo():
+    s = OIDCSettings(
+        _env_file=None,  # type: ignore
+        client_id='client-id',
+        client_secret='client-secret',
+        redirect_uri='http://localhost:8000/sso-callback',
+        groups='dev',
+        id_token_signed_response_alg='RS256',
+        jwt_algo='ES256',
+    )
+
+    assert s.fallback_id_token_signed_response_alg == 'RS256'
+
+
+def test_legacy_jwt_algo_is_used_when_id_token_signing_alg_is_not_configured():
+    s = OIDCSettings(
+        _env_file=None,  # type: ignore
+        client_id='client-id',
+        client_secret='client-secret',
+        redirect_uri='http://localhost:8000/sso-callback',
+        groups='dev',
+        jwt_algo='ES256',
+    )
+
+    assert s.fallback_id_token_signed_response_alg == 'ES256'
+
+
+@pytest.mark.parametrize('alg_field', ['id_token_signed_response_alg', 'jwt_algo'])
+def test_none_id_token_signing_alg_is_rejected(alg_field: str):
+    with pytest.raises(ValidationError, match='OIDC ID token signing algorithm "none" is not supported'):
+        OIDCSettings(
+            _env_file=None,  # type: ignore
+            client_id='client-id',
+            client_secret='client-secret',
+            redirect_uri='http://localhost:8000/sso-callback',
+            groups='dev',
+            **{alg_field: 'none'},
+        )
+
+
+@pytest.mark.parametrize('alg_field', ['id_token_signed_response_alg', 'jwt_algo'])
+def test_hmac_id_token_signing_alg_is_rejected(alg_field: str):
+    with pytest.raises(ValidationError, match='OIDC ID token HMAC signing algorithms are not supported'):
+        OIDCSettings(
+            _env_file=None,  # type: ignore
+            client_id='client-id',
+            client_secret='client-secret',
+            redirect_uri='http://localhost:8000/sso-callback',
+            groups='dev',
+            **{alg_field: 'HS256'},
+        )
+
+
+def test_id_token_signing_alg_prefers_new_prefixed_env_alias(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        m.setenv('SSO_ID_TOKEN_SIGNED_RESPONSE_ALG', 'RS256')
+        m.setenv('SSO_JWT_ALGO', 'ES256')
+
+        s = OIDCSettings(
+            _env_file=None,  # type: ignore
+            client_id='client-id',
+            client_secret='client-secret',
+            redirect_uri='http://localhost:8000/sso-callback',
+            groups='dev',
+        )
+
+        assert s.id_token_signed_response_alg == 'RS256'
+        assert s.jwt_algo == 'RS256'
+        assert s.fallback_id_token_signed_response_alg == 'RS256'
+
+
+def test_id_token_signing_alg_accepts_legacy_prefixed_env_alias(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        m.delenv('SSO_ID_TOKEN_SIGNED_RESPONSE_ALG', raising=False)
+        m.setenv('SSO_JWT_ALGO', 'ES256')
+
+        s = OIDCSettings(
+            _env_file=None,  # type: ignore
+            client_id='client-id',
+            client_secret='client-secret',
+            redirect_uri='http://localhost:8000/sso-callback',
+            groups='dev',
+        )
+
+        assert s.id_token_signed_response_alg == 'ES256'
+        assert s.jwt_algo == 'ES256'
+        assert s.fallback_id_token_signed_response_alg == 'ES256'
+
+
+def test_id_token_signing_alg_ignores_unprefixed_env_aliases(monkeypatch: pytest.MonkeyPatch):
+    with monkeypatch.context() as m:
+        m.delenv('SSO_ID_TOKEN_SIGNED_RESPONSE_ALG', raising=False)
+        m.delenv('SSO_JWT_ALGO', raising=False)
+        m.setenv('ID_TOKEN_SIGNED_RESPONSE_ALG', 'ES256')
+        m.setenv('JWT_ALGO', 'ES256')
+
+        s = OIDCSettings(
+            _env_file=None,  # type: ignore
+            client_id='client-id',
+            client_secret='client-secret',
+            redirect_uri='http://localhost:8000/sso-callback',
+            groups='dev',
+        )
+
+        assert s.id_token_signed_response_alg is None
+        assert s.jwt_algo is None
+        assert s.fallback_id_token_signed_response_alg == DEFAULT_ID_TOKEN_SIGNING_ALG
 
 
 def test_group_claim_name_can_be_configured_from_env(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Motivation and Context

The OIDC ID token verifier was selecting its accepted signing algorithm purely from the legacy `SSO_JWT_ALGO` setting, with an ES256 default. That did not line up with OIDC provider discovery and made the verification policy too detached from the configured issuer metadata.

OpenID Connect Discovery 1.0 Section 3 defines `id_token_signing_alg_values_supported` as provider capability metadata and says `RS256` must be included. Our internal IDP currently advertises only `ES256`, so the implementation uses the provider's discovered JWKS-verifiable non-`none` signing algorithms when no env override is configured, rather than rejecting startup solely because `RS256` is absent.

Explicit env configuration still represents Dara's local verifier policy and remains exact. This avoids treating the JWT `alg` header as verification policy. RFC 8725 Section 3.1 requires callers to perform algorithm verification, so the verifier now checks the token's claimed algorithm against the startup-resolved allow-list before decoding. If the selected JWK explicitly declares an `alg`, that key-level constraint must also match the token header.

## Implementation Description

Added `SSO_ID_TOKEN_SIGNED_RESPONSE_ALG` as the preferred env var and kept `SSO_JWT_ALGO` as a deprecated compatibility alias. Both settings default to `None`; explicit precedence is new env var, then legacy env var. Constructor compatibility for `jwt_algo` remains, but unprefixed env names like `JWT_ALGO` are not accepted.

If neither env var is configured, OIDC startup uses the JWKS-verifiable non-`none` algorithms advertised by `id_token_signing_alg_values_supported`, falling back to `RS256` only if discovery does not provide a usable signed algorithm. The discovery model accepts an omitted `id_token_signing_alg_values_supported` field as a compatibility concession so that fallback is reachable for non-compliant IDPs.

OIDC startup resolves and registers the allowed ID token signing algorithm list next to the JWKS client. Discovery is used as provider metadata, with `none` and HMAC algorithms filtered out because Dara verifies signed ID tokens using issuer JWKS. OpenID Connect Core 1.0 Section 10.1 uses client-secret-based HMAC for MAC-based signatures, which this verifier does not implement.

ID token verification now treats the JWT header `alg` as an untrusted claim of which cryptographic operation to perform. It is accepted only if it is in the startup-resolved env/discovery policy. The selected JWK's optional `alg` member is enforced when present, but PyJWT's key-type default is not used as policy when the OP omits `alg` from JWKS, preserving providers that use allowed RSA algorithms such as `PS256` with bare RSA JWKs.

Updated OIDC docs, changelog, and backend tests for the new precedence/default/discovery behavior, ES256 verification, malformed discovery fallback, algorithm/key mismatch rejection, and RSA JWKs that omit `alg`.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `cd packages/dara-core && poetry run ruff format dara/core/auth/oidc/settings.py dara/core/auth/oidc/config.py dara/core/auth/oidc/utils.py dara/core/auth/oidc/definitions.py tests/python/test_oidc_auth.py tests/python/test_oidc_settings.py`
- `cd packages/dara-core && poetry run ruff check --select I dara/core/auth/oidc/settings.py dara/core/auth/oidc/config.py dara/core/auth/oidc/utils.py dara/core/auth/oidc/definitions.py tests/python/test_oidc_auth.py tests/python/test_oidc_settings.py`
- `cd packages/dara-core && DARA_TEST_FLAG=True poetry run pytest tests/python/test_oidc_settings.py tests/python/test_oidc_auth.py`
- `poetry anthology run lint`
- `poetry anthology run format-check`
- `git diff --check -- packages/dara-core/changelog.md packages/dara-core/dara/core/auth/oidc/config.py packages/dara-core/dara/core/auth/oidc/definitions.py packages/dara-core/dara/core/auth/oidc/settings.py packages/dara-core/dara/core/auth/oidc/utils.py packages/dara-core/docs/advanced/authentication.mdx packages/dara-core/tests/python/test_oidc_auth.py packages/dara-core/tests/python/test_oidc_settings.py`

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have added/updated the changelog for the relevant package.

## Screenshots (if appropriate):

N/A