### PR TITLE
Fix: DO-11693 - fix test failures in task progress and DV error reuse

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,11 +2,6 @@
 title: Changelog
 ---
 
-## NEXT
-
-- Fixed a race condition where the COMPLETE notification was sent after resolving the pending task, causing consumers awaiting the result to miss the completion message
-- Fixed `ExceptionGroup` handling in DerivedVariable error reuse test assertions for Python 3.10 compatibility
-
 ## 1.28.3
 
 - Fixed StreamVariable SSE connections accumulating when dependency values changed, causing stale data fetching and degraded performance
@@ -106,215 +101,214 @@ title: Changelog
 
 ## 1.24.1
 
--  Fixed an issue where using `.get` on a `DerivedVariable` would not resolve when passed to `DerivedVariable`, `py_component` or `action`
+- Fixed an issue where using `.get` on a `DerivedVariable` would not resolve when passed to `DerivedVariable`, `py_component` or `action`
 
 ## 1.24.0
 
--  Fixed an issue where `DerivedVariable`s returning `DataFrame`s would cause error logs during route data loading
--  Attempting to use `@py_component`s inside a `For` component will now raise an error at startup time as it's a very inefficient pattern. The recommended usage is to instead precompute fields in a `DerivedVariable` passed to `For.items`, the docs now include a section on those best practices.
--  Fixed an issue where `.get()` calls on a variable would not be resolved when a variable was passed as an input to a `DerivedVariable`, `py_component` or `action`
+- Fixed an issue where `DerivedVariable`s returning `DataFrame`s would cause error logs during route data loading
+- Attempting to use `@py_component`s inside a `For` component will now raise an error at startup time as it's a very inefficient pattern. The recommended usage is to instead precompute fields in a `DerivedVariable` passed to `For.items`, the docs now include a section on those best practices.
+- Fixed an issue where `.get()` calls on a variable would not be resolved when a variable was passed as an input to a `DerivedVariable`, `py_component` or `action`
 
 ## 1.23.0-alpha.1
 
--  Added a new generic `OIDCAuthConfig` that can be used to configure any OIDC provider. See new "Authentication" docs page for more details.
+- Added a new generic `OIDCAuthConfig` that can be used to configure any OIDC provider. See new "Authentication" docs page for more details.
 
 ## 1.22.4
 
--  Relaxed `cachetools` dependency to `>=5.0.0`
+- Relaxed `cachetools` dependency to `>=5.0.0`
 
 ## 1.22.0
 
--  Internal: overhaul of the asset handling system. Dara no longer relies on external CDN assets, they are now bundled with the wheels and served together with the framework assets. See Custom JS docs page for more details
+- Internal: overhaul of the asset handling system. Dara no longer relies on external CDN assets, they are now bundled with the wheels and served together with the framework assets. See Custom JS docs page for more details
 
 ## 1.21.25
 
--  Added `default_path` property to the Router instance to allow overriding a default path for the router. If not set, Dara infers the first navigatable path in the router.
+- Added `default_path` property to the Router instance to allow overriding a default path for the router. If not set, Dara infers the first navigatable path in the router.
 
 ## 1.21.24
 
--  Added 3 new accent colors to the base theme definition and existing Light and Dark themes: `carrot`, `kale` and `chestnut`
--  Added `is_first`, `is_last` and `index` properties to the `LoopVariable` class exposed as `Variable().list_item`. These "meta" properties can be useful inside the `For` component renderer
--  Added support for parametrized routes in the `Link` component and `navigate` action by passing optional dynamic `params` kwarg
--  Added `route_matches` property to the Router instance which lets users access the current route matches as a `Variable`. This can be useful for e.g. dynamic breadcrumb components
--  Implemented `Match` component to allow conditional rendering based on a variable value without needing to use multiple `If` components
+- Added 3 new accent colors to the base theme definition and existing Light and Dark themes: `carrot`, `kale` and `chestnut`
+- Added `is_first`, `is_last` and `index` properties to the `LoopVariable` class exposed as `Variable().list_item`. These "meta" properties can be useful inside the `For` component renderer
+- Added support for parametrized routes in the `Link` component and `navigate` action by passing optional dynamic `params` kwarg
+- Added `route_matches` property to the Router instance which lets users access the current route matches as a `Variable`. This can be useful for e.g. dynamic breadcrumb components
+- Implemented `Match` component to allow conditional rendering based on a variable value without needing to use multiple `If` components
 
 ## 1.21.23
 
--  Added a new `CopyToClipboard` action (also available as `ctx.copy_to_clipboard`) to copy a given value to the user's clipboard
+- Added a new `CopyToClipboard` action (also available as `ctx.copy_to_clipboard`) to copy a given value to the user's clipboard
 
 ## 1.21.22
 
--  Allow passing a `ClientVariable` to the `DynamicComponent` component
+- Allow passing a `ClientVariable` to the `DynamicComponent` component
 
 ## 1.21.21
 
--  Relaxed `fastapi` dependency to `>=0.115.0, <0.121.0`
+- Relaxed `fastapi` dependency to `>=0.115.0, <0.121.0`
 
 ## 1.21.20
 
--  Bump `croniter` dependency to `^6.0.0`
+- Bump `croniter` dependency to `^6.0.0`
 
 ## 1.21.18
 
--  Fixed a regression where `Variable`'s `store` property was not serialized correctly
--  Internal: improve efficiency of the component resolution system by only using the registry fallback for py_components and moving the py_component resolution retry logic to the server.
--  Component resolution system now displays a more user-friendly error when a component is not found due to e.g. not being registered
+- Fixed a regression where `Variable`'s `store` property was not serialized correctly
+- Internal: improve efficiency of the component resolution system by only using the registry fallback for py_components and moving the py_component resolution retry logic to the server.
+- Component resolution system now displays a more user-friendly error when a component is not found due to e.g. not being registered
 
 ## 1.21.17
 
--  Unlock `click` dependency from `8.1.3` to `^8.1.3`
--  Bumped minimum required Python version to `3.10`, dropping support for Python 3.9 as it reached end-of-life as of October 2025
+- Unlock `click` dependency from `8.1.3` to `^8.1.3`
+- Bumped minimum required Python version to `3.10`, dropping support for Python 3.9 as it reached end-of-life as of October 2025
 
 ## 1.21.16
 
--  Lower minimum version of `pydantic` from `2.12.0` to `2.11.7` to fix compatibility issues with other internal packages
+- Lower minimum version of `pydantic` from `2.12.0` to `2.11.7` to fix compatibility issues with other internal packages
 
 ## 1.21.15
 
--  Routes now hold navigation by default while `on_load` actions run. Users can provide a `fallback` component (e.g. default `Fallback.Default()` or any custom component) to opt-out and immediately show the fallback instead.
--  Fixed an issue where `NavigateTo` `new_tab` option was ignored for internal links
+- Routes now hold navigation by default while `on_load` actions run. Users can provide a `fallback` component (e.g. default `Fallback.Default()` or any custom component) to opt-out and immediately show the fallback instead.
+- Fixed an issue where `NavigateTo` `new_tab` option was ignored for internal links
 
 ## 1.21.14
 
--  Bump `pydantic` to `^2.12.0`, fixing runtime issues that started appearing in 2.12.0
+- Bump `pydantic` to `^2.12.0`, fixing runtime issues that started appearing in 2.12.0
 
 ## 1.21.13
 
--  Fixed an issue where tasks could sometimes be notified about their completion before the task had actually completed in nested task scenarios
+- Fixed an issue where tasks could sometimes be notified about their completion before the task had actually completed in nested task scenarios
 
 ## 1.21.12
 
--  The `navigate` action now properly handles relative links including e.g. `./`,  `../` or bare `{path}` paths
--  The `navigate` action now detects same-origin absolute URLs and uses a client-side navigation instead of a full page reload
--  Added missing anchor props to the `Link` component: `rel`, `target`, `download`, `referrer_policy`. The component can now be used as both an internal link and standard anchor tag.
--  Allowed passing a `RouterPath` object to the `navigate` action instead of a string URL
--  Added support for extra `NavigateOptions` to the `navigate` action, now supports the `replace` and `relative` options analogous to the respective `Link` props
+- The `navigate` action now properly handles relative links including e.g. `./`,  `../` or bare `{path}` paths
+- The `navigate` action now detects same-origin absolute URLs and uses a client-side navigation instead of a full page reload
+- Added missing anchor props to the `Link` component: `rel`, `target`, `download`, `referrer_policy`. The component can now be used as both an internal link and standard anchor tag.
+- Allowed passing a `RouterPath` object to the `navigate` action instead of a string URL
+- Added support for extra `NavigateOptions` to the `navigate` action, now supports the `replace` and `relative` options analogous to the respective `Link` props
 
 ## 1.21.11
 
--  Internal: fixed an issue where `useRouterContext` was not exported from the `dara-core` package
+- Internal: fixed an issue where `useRouterContext` was not exported from the `dara-core` package
 
 ## 1.21.10
 
--  Fixed an issue where trying to run an action with an input of a `ServerVariable` which is otherwise unused on the page would cause the action to not run
+- Fixed an issue where trying to run an action with an input of a `ServerVariable` which is otherwise unused on the page would cause the action to not run
 
 ## 1.21.9
 
--  Lock `react-router` version to a minor version and upgrade to `~7.9` - fixing a bug where production build would install a newer, incompatible version
--  Fixed an issue where derived variables with different `nested` values (i.e. obtained via `.get(key)`) would recompute multiple times and not reuse precomputed route data
+- Lock `react-router` version to a minor version and upgrade to `~7.9` - fixing a bug where production build would install a newer, incompatible version
+- Fixed an issue where derived variables with different `nested` values (i.e. obtained via `.get(key)`) would recompute multiple times and not reuse precomputed route data
 
 ## 1.21.7
 
--  Fixed an issue where syncing variables with path params would sometimes fail if the route has a longer running action attached
+- Fixed an issue where syncing variables with path params would sometimes fail if the route has a longer running action attached
 
 ## 1.21.6
 
--  Fixed an issue where instantiating actions would fail during route preloading
+- Fixed an issue where instantiating actions would fail during route preloading
 
 ## 1.21.5
 
--  Allow `Link` components to accept `ClientVariable` as the `to` prop
--  Exposed the React Router `Navigate` component for advanced routing cases
+- Allow `Link` components to accept `ClientVariable` as the `to` prop
+- Exposed the React Router `Navigate` component for advanced routing cases
 
 ## 1.21.4
 
--  Fixed an issue where preloading derived values for a page would use `null` as the value for variables bound to path params
--  Fixed an issue where the `/login` page would not correctly redirect back to the first available route after successful login or token validation
--  Fixed an issue where `Link` components with `prefetch=True` would run prefetch logic too often, e.g. even when hovering over the link to the page just navigated to
+- Fixed an issue where preloading derived values for a page would use `null` as the value for variables bound to path params
+- Fixed an issue where the `/login` page would not correctly redirect back to the first available route after successful login or token validation
+- Fixed an issue where `Link` components with `prefetch=True` would run prefetch logic too often, e.g. even when hovering over the link to the page just navigated to
 
 ## 1.21.2
 
--  Fixed an issue where changing the theme's base font size would not properly apply
--  `ConfigurationBuilder.set_theme` now accepts any `Variable` as the theme value to dynamically change the base theme
--  Added a new `ThemeProvider` component to `dara.core.visual.components` that can be used to provide a different theme to a subtree of components
+- Fixed an issue where changing the theme's base font size would not properly apply
+- `ConfigurationBuilder.set_theme` now accepts any `Variable` as the theme value to dynamically change the base theme
+- Added a new `ThemeProvider` component to `dara.core.visual.components` that can be used to provide a different theme to a subtree of components
 
 ## 1.21.1
 
--  Added a new `prefetch` property to `Link` that allows for prefetching the navigation data when the user intends to navigate to the link. The data is kept in a short-lived cache to speed up the perceived performance of the navigation.
--  Implemented router optimizations by preloading top-level derived values (DerivedVariables and py_components) on a page when navigating to it. This saves us having to make multiple requests to the backend when navigating to a page with a lot of derived values; especially when combined with link prefetching, this can make a big difference in UX.
--  Added a new `in_place` parameter to `write_partial` on `Variable` and `BackendStore` to allow for more performant in-place application of patches. This is opt-in as to preserve old behaviour but is recommended for performance critical updates of large structures.
+- Added a new `prefetch` property to `Link` that allows for prefetching the navigation data when the user intends to navigate to the link. The data is kept in a short-lived cache to speed up the perceived performance of the navigation.
+- Implemented router optimizations by preloading top-level derived values (DerivedVariables and py_components) on a page when navigating to it. This saves us having to make multiple requests to the backend when navigating to a page with a lot of derived values; especially when combined with link prefetching, this can make a big difference in UX.
+- Added a new `in_place` parameter to `write_partial` on `Variable` and `BackendStore` to allow for more performant in-place application of patches. This is opt-in as to preserve old behaviour but is recommended for performance critical updates of large structures.
 
 ## 1.21.0
 
--  Implemented a new `router` API on `ConfigurationBuilder` that allows for more flexible routing configurations. Check out the new `Getting Started -> Routing` docs page for an overview. Note that mixing the new API and the old `add_page()` API is disallowed and will raise an error on startup.
--  Deprecated the following APIs on `ConfigurationBuilder`:
-    - `add_page` -> migrate to `router.add_page`
-    - `template` and `add_template_renderer` -> migrate templates to a layout on `router.add_layout`
-    - `powered_by_causalens` -> exposed as a custom `PoweredByCausalens` component as well as a `powered_by_causalens` property on `SideBarFrame`
+- Implemented a new `router` API on `ConfigurationBuilder` that allows for more flexible routing configurations. Check out the new `Getting Started -> Routing` docs page for an overview. Note that mixing the new API and the old `add_page()` API is disallowed and will raise an error on startup.
+- Deprecated the following APIs on `ConfigurationBuilder`:
+  - `add_page` -> migrate to `router.add_page`
+  - `template` and `add_template_renderer` -> migrate templates to a layout on `router.add_layout`
+  - `powered_by_causalens` -> exposed as a custom `PoweredByCausalens` component as well as a `powered_by_causalens` property on `SideBarFrame`
 
 ## 1.20.1
 
- - Fixed URLVariable and Variable with a ParamStore loading of data at first load of the page
-
+- Fixed URLVariable and Variable with a ParamStore loading of data at first load of the page
 
 ## 1.20.0-alpha.1
 
--  Deprecated `UrlVariable` in favour of using `Variable(store=QueryParamStore(query=...))`
--  Deprecated `persist_value` on `Variable` in favour of using `Variable(store=BrowserStore(...))` instead
--  Added `read`, `write`, `delete`, `get_all` shortcut methods on `Variable` that pass through to the corresponding methods on the attached `BackendStore` instance. This allows for a more concise API when using `BackendStore` but raise if the attached store is not of the `BackendStore` type
--  Deprecated `DataVariable` in favour of new generalized `ServerVariable`. It represents server-side data. Server variables can store tabular data and be consumed by e.g. `Table` component if required as a special case,
+- Deprecated `UrlVariable` in favour of using `Variable(store=QueryParamStore(query=...))`
+- Deprecated `persist_value` on `Variable` in favour of using `Variable(store=BrowserStore(...))` instead
+- Added `read`, `write`, `delete`, `get_all` shortcut methods on `Variable` that pass through to the corresponding methods on the attached `BackendStore` instance. This allows for a more concise API when using `BackendStore` but raise if the attached store is not of the `BackendStore` type
+- Deprecated `DataVariable` in favour of new generalized `ServerVariable`. It represents server-side data. Server variables can store tabular data and be consumed by e.g. `Table` component if required as a special case,
 otherwise they are considered unserializable and do not get sent to the client. `DataVariable` acts as effectively an alias for `ServerVariable`.
--  Deprecated `DerivedDataVariable`. `DerivedVariable` can return tabular data if needed, the automatic data filtering and pagination is now handled seamlessly when consumed by e.g. `Table` component.
--  Added optional `filter_resolver` to `DerivedVariable` which can be used to customize the filtering logic of the derived variable. The default filter resolver assumes the derived function returns `DataFrame` and applies the default filtering logic.
+- Deprecated `DerivedDataVariable`. `DerivedVariable` can return tabular data if needed, the automatic data filtering and pagination is now handled seamlessly when consumed by e.g. `Table` component.
+- Added optional `filter_resolver` to `DerivedVariable` which can be used to customize the filtering logic of the derived variable. The default filter resolver assumes the derived function returns `DataFrame` and applies the default filtering logic.
 Custom filter resolver can be used to e.g. return a data reference from the derived function and offload filtering logic to remote API in the filtering part.
 
 ## 1.19.1
 
--  Added StateVariable feature for tracking DerivedVariable states (loading, error, hasValue) via `dv.is_loading`, `dv.has_error`, and `dv.has_value` properties
--  `If` components and `SwitchVariable`s now operate similar to the `suspend: False` setting - when used with `DerivedVariable`s, they will suspend the component initially until they have the initial value; for further changes, they will use the prior value rather than suspend again
--  Fixed an issue where a race condition in the task pool could cause it to no longer be able to process tasks
--  Unlock `packaging` dependency in `dara-core`
--  Fixed an issue where using `DownloadVariable` on a `DataVariable` would include internally transformed column names
--  Fixed various data races related to the `DerivedVariable` caching and task system. This should improve their reliability and improve performance as it will minimize the number of times the same computation is performed.
--  `DerivedVariable`, action and `py_component` dependency resolution is now parallelized to improve performance
--  Docs: Add more examples of using `raw_css` in more places
+- Added StateVariable feature for tracking DerivedVariable states (loading, error, hasValue) via `dv.is_loading`, `dv.has_error`, and `dv.has_value` properties
+- `If` components and `SwitchVariable`s now operate similar to the `suspend: False` setting - when used with `DerivedVariable`s, they will suspend the component initially until they have the initial value; for further changes, they will use the prior value rather than suspend again
+- Fixed an issue where a race condition in the task pool could cause it to no longer be able to process tasks
+- Unlock `packaging` dependency in `dara-core`
+- Fixed an issue where using `DownloadVariable` on a `DataVariable` would include internally transformed column names
+- Fixed various data races related to the `DerivedVariable` caching and task system. This should improve their reliability and improve performance as it will minimize the number of times the same computation is performed.
+- `DerivedVariable`, action and `py_component` dependency resolution is now parallelized to improve performance
+- Docs: Add more examples of using `raw_css` in more places
 
 ## 1.19.0
 
--  Internal: upgraded production build to use Vite v7. The minimum version of Node required for production builds is now 20.19.0
--  Docs: Improve documentation metadata for all Getting Started guides
+- Internal: upgraded production build to use Vite v7. The minimum version of Node required for production builds is now 20.19.0
+- Docs: Improve documentation metadata for all Getting Started guides
 
 ## 1.18.5
 
--  Fixed an issue where WS_CHANNEL context var wasn't set within the websocket handler itself
+- Fixed an issue where WS_CHANNEL context var wasn't set within the websocket handler itself
 
 ## 1.18.4
 
--  Added a `placeholder` prop to the `For` component which allows you to specify a component to render when the data source is empty
+- Added a `placeholder` prop to the `For` component which allows you to specify a component to render when the data source is empty
 
 ## 1.18.3
 
--  Added a new `Fallback.Custom` option which allows you to specify a custom component to render when while suspended. The `fallback=` props for components now also supports passing any non-fallback component directly which implicitly wraps it in `Fallback.Custom`
+- Added a new `Fallback.Custom` option which allows you to specify a custom component to render when while suspended. The `fallback=` props for components now also supports passing any non-fallback component directly which implicitly wraps it in `Fallback.Custom`
 
 ## 1.18.3
 
--  Fixed an issue where `UrlVariable` would be wiped in some cases. The variable now doesn't sync the default value to query params by default
+- Fixed an issue where `UrlVariable` would be wiped in some cases. The variable now doesn't sync the default value to query params by default
 
 ## 1.18.2
 
--  Internal: added `GENERATE_CODE_OVERRIDE` context variable to allow overriding the download code generation logic
+- Internal: added `GENERATE_CODE_OVERRIDE` context variable to allow overriding the download code generation logic
 
 ## 1.18.1
 
--  Fixed missing `cachetools` dependency
+- Fixed missing `cachetools` dependency
 
 ## 1.18.0
 
--  Fixed an issue where using `trigger()` on a DerivedVariable would behave inconsistently and cause extra recomputations in some cases
--  Fixed an issue where `None` values were being interpreted as cache misses for DerivedVariables
--  Internal: added `RegistryLookup` key for `DOWNLOAD_CODE` to allow overriding the download code logic
+- Fixed an issue where using `trigger()` on a DerivedVariable would behave inconsistently and cause extra recomputations in some cases
+- Fixed an issue where `None` values were being interpreted as cache misses for DerivedVariables
+- Internal: added `RegistryLookup` key for `DOWNLOAD_CODE` to allow overriding the download code logic
 
 ## 1.17.6
 
--  Fixed an issue with the handleAuthErrors function when it's used with a non-json, streaming response.
+- Fixed an issue with the handleAuthErrors function when it's used with a non-json, streaming response.
 
 ## 1.17.5
 
--  Fixed an issue with websockets being force closed on token refresh. This would cause certain elements of the application to hang until the page was refreshed.
+- Fixed an issue with websockets being force closed on token refresh. This would cause certain elements of the application to hang until the page was refreshed.
 
 ## 1.17.3
 
--  Fixed an issue where in some cases actions consuming DerivedVariables would cause extra calculations of the derived variable to be performed even if a cached value was available
+- Fixed an issue where in some cases actions consuming DerivedVariables would cause extra calculations of the derived variable to be performed even if a cached value was available
 
 ## 1.17.2
 
@@ -322,202 +316,201 @@ Custom filter resolver can be used to e.g. return a data reference from the deri
 
 ## 1.17.1
 
--  Fixed an issue where `ComponentInstance` would fail validation if `raw_css` was explicitly set to `None`
--  Fixed an issue where setting `raw_css` to a `Variable` with an object value would not update the component's styles
+- Fixed an issue where `ComponentInstance` would fail validation if `raw_css` was explicitly set to `None`
+- Fixed an issue where setting `raw_css` to a `Variable` with an object value would not update the component's styles
 
 ## 1.17.0
 
--  Added `SwitchVariable` for frontend-only conditional logic. Use `SwitchVariable.when()` for boolean conditions and `SwitchVariable.match()` for value mappings. Provides better performance than `DerivedVariable` for simple conditional logic by avoiding backend roundtrips.
+- Added `SwitchVariable` for frontend-only conditional logic. Use `SwitchVariable.when()` for boolean conditions and `SwitchVariable.match()` for value mappings. Provides better performance than `DerivedVariable` for simple conditional logic by avoiding backend roundtrips.
 
 ## 1.16.23
 
--  Added support for passing a `NonDataVariable` to `raw_css` in any `ComponentInstance`
+- Added support for passing a `NonDataVariable` to `raw_css` in any `ComponentInstance`
 
 ## 1.16.22
 
--  Added a new `run_task` method to `ActionCtx` to imperatively run a task in a separate process.
+- Added a new `run_task` method to `ActionCtx` to imperatively run a task in a separate process.
 
 ## 1.16.21
 
--  JS: Fixed an issue where passing a nullish component to `DynamicComponent` would cause the component to error out, it will now render `null` instead.
+- JS: Fixed an issue where passing a nullish component to `DynamicComponent` would cause the component to error out, it will now render `null` instead.
 
 ## 1.16.20
 
--  Replaced `ignore_current_channel` parameter with `ignore_channel` in `BackendStore.write`. Only sync writes now prevent loopback by default.
--  Fixed an issue where sequence numbers would get out of sync on the first refresh due to sending a loopback write request.
--  Reintroduced a `For` component that can be used to render a list of items. Note: this is an initial release of the component and we reserve the right to make (potentially breaking) changes to it in the next few releases as we roll it out internally.
--  Added a `list_item` property to the `NonDataVariable` class (so `Variable`, `DerivedVariable`, `UrlVariable`) which can be used to access the current item's data within a `For` component renderer.
+- Replaced `ignore_current_channel` parameter with `ignore_channel` in `BackendStore.write`. Only sync writes now prevent loopback by default.
+- Fixed an issue where sequence numbers would get out of sync on the first refresh due to sending a loopback write request.
+- Reintroduced a `For` component that can be used to render a list of items. Note: this is an initial release of the component and we reserve the right to make (potentially breaking) changes to it in the next few releases as we roll it out internally.
+- Added a `list_item` property to the `NonDataVariable` class (so `Variable`, `DerivedVariable`, `UrlVariable`) which can be used to access the current item's data within a `For` component renderer.
 
 ## 1.16.19
 
--  Added `write_partial` method to `BackendStore` for partial updates using JSON Patch
+- Added `write_partial` method to `BackendStore` for partial updates using JSON Patch
 
 ## 1.16.18
 
--  Fixed a regression where nested property on Variables created via `Variable.get` wasn't being serialized correctly
+- Fixed a regression where nested property on Variables created via `Variable.get` wasn't being serialized correctly
 
 ## 1.16.16
 
--  Fixed an issue where import discovery would not register a component if it was imported as a component *instance* defined in another file
--  Internal: add `add_module_dependency` API to `ConfigurationBuilder` to allow for explicit module dependencies to be defined by plugins to ensure dependend on assets are included even if they weren't included via e.g. import discovery
+- Fixed an issue where import discovery would not register a component if it was imported as a component *instance* defined in another file
+- Internal: add `add_module_dependency` API to `ConfigurationBuilder` to allow for explicit module dependencies to be defined by plugins to ensure dependend on assets are included even if they weren't included via e.g. import discovery
 
 ## 1.16.15
 
--  Bump minimum version of `pyjwt` to `2.3.0`
--  Added support for custom logging in `DaraDevFormatter` by defaulting to `logging.INFO` colors for any undefined level.
+- Bump minimum version of `pyjwt` to `2.3.0`
+- Added support for custom logging in `DaraDevFormatter` by defaulting to `logging.INFO` colors for any undefined level.
 
 ## 1.16.14
 
--  Fixed an issue where a `BackendStore` created within a `py_component` would not notify its creator about subscribed updates
+- Fixed an issue where a `BackendStore` created within a `py_component` would not notify its creator about subscribed updates
 
 ## 1.16.13
 
--  Add a new `subscribe` method to base `PersistenceBackend` for `BackendStore`s to allow for the storage layer to trigger updates
--  Added a `readonly` flag to `BackendStore` to mark the storage layer to be read-only and skip writing to the backend
+- Add a new `subscribe` method to base `PersistenceBackend` for `BackendStore`s to allow for the storage layer to trigger updates
+- Added a `readonly` flag to `BackendStore` to mark the storage layer to be read-only and skip writing to the backend
 
 ## 1.16.11
 
--   Fix an issue with base_url handling during redirection in the authentication flow
+- Fix an issue with base_url handling during redirection in the authentication flow
 
 ## 1.16.10
 
--   Unlock the `python-multipart` dependency, is now `>=0.0.7`
+- Unlock the `python-multipart` dependency, is now `>=0.0.7`
 
 ## 1.16.9
 
--   Bump minimum `h11` verson to `0.16.0` to fix security vulnerability
+- Bump minimum `h11` verson to `0.16.0` to fix security vulnerability
 
 ## 1.16.8
 
--   Fix a bug in static_url handling when running the local dev server.
+- Fix a bug in static_url handling when running the local dev server.
 
 ## 1.16.7
 
--   Update how base_urls are handled so that Dara apps with custom JS can be run behind a proxy.
-
+- Update how base_urls are handled so that Dara apps with custom JS can be run behind a proxy.
 
 ## 1.16.4
 
--   Fix a typo in `action.Ctx` typing
+- Fix a typo in `action.Ctx` typing
 
 ## 1.16.3
 
--   Fix `fastapi_vite_dara` environment variables to enable HMR mode
--   Improve serialization of `ActionImpl` to automatically serialize nested fields
--   Unlock `uvicorn` version to `>=0.23`, bump FastAPI to `^0.115.0`
+- Fix `fastapi_vite_dara` environment variables to enable HMR mode
+- Improve serialization of `ActionImpl` to automatically serialize nested fields
+- Unlock `uvicorn` version to `>=0.23`, bump FastAPI to `^0.115.0`
 
 ## 1.16.2
 
--   Fix an issue where `Fallback` components would fail to serialize correctly
--   Allow extra fields in the `Settings` model.
--   Improve serialization of `Variable.default` to handle more common scenarios
+- Fix an issue where `Fallback` components would fail to serialize correctly
+- Allow extra fields in the `Settings` model.
+- Improve serialization of `Variable.default` to handle more common scenarios
 
 ## 1.16.0
 
--   Updated Dara to use `pydantic` v2.
--   BREAKING: removed `@template` markers and the `For` component due to incompatibility with pydantic v2 and very low usage.
+- Updated Dara to use `pydantic` v2.
+- BREAKING: removed `@template` markers and the `For` component due to incompatibility with pydantic v2 and very low usage.
 
 ## 1.15.7
 
--   Add support for setting a base_url in `dara start` so it can run behind a path prefixed proxy. e.g. `dara start --base-url https://my.app.com/proxy/`
+- Add support for setting a base_url in `dara start` so it can run behind a path prefixed proxy. e.g. `dara start --base-url https://my.app.com/proxy/`
 
 ## 1.15.6
 
--   Changed the verification process of websockets to be the same as the http endpoints
+- Changed the verification process of websockets to be the same as the http endpoints
 
 ## 1.15.2
 
--   Fix an issue where the internal `eng_logger` would be enabled even when `DARA_DEV_LOG_LEVEL` was set to `NONE` (which is the default).
+- Fix an issue where the internal `eng_logger` would be enabled even when `DARA_DEV_LOG_LEVEL` was set to `NONE` (which is the default).
 
 ## 1.15.0
 
--   Fix a bug where when using `store=BackendStore(...)` kwarg with a `Variable`, the originating session would also be notified of the change causing rare desyncs and race conditions.
+- Fix a bug where when using `store=BackendStore(...)` kwarg with a `Variable`, the originating session would also be notified of the change causing rare desyncs and race conditions.
 
 ## 1.14.9
 
--   Fix a bug in the websocket token refresh logic that caused it to get stuck in a repeating failure state.
+- Fix a bug in the websocket token refresh logic that caused it to get stuck in a repeating failure state.
 
 ## 1.14.8
 
--   Fix a bug in the fastapi_vite_dara dependency that broke HMR mode for local development of custom JS packages
+- Fix a bug in the fastapi_vite_dara dependency that broke HMR mode for local development of custom JS packages
 
 ## 1.14.7
 
--   Loosen dependency requirement on Jinja2 to allow 3.1.x versions
+- Loosen dependency requirement on Jinja2 to allow 3.1.x versions
 
 ## 1.14.6
 
--   Fixed an issue with websocket token updates during an SSO driven token refresh. Tokens are now correctly updated in the websocket handler and in the UI.
+- Fixed an issue with websocket token updates during an SSO driven token refresh. Tokens are now correctly updated in the websocket handler and in the UI.
 
 ## 1.14.2
 
--   Internal (JS): remove redundant body from the token refresh request
+- Internal (JS): remove redundant body from the token refresh request
 
 ## 1.14.1
 
--   Internal (JS): make request() helper options default to empty object
+- Internal (JS): make request() helper options default to empty object
 
 ## 1.14.0
 
--   Added support for seamless token refresh mechanism. A provided auth config can be configured to support token refresh by:
-    -   implement the `refresh_token` method to sign a new token, reusing the previous session_id for continuity
-    -   adding some mechanism to set a `dara_refresh_token` cookie, e.g. via custom `components_config` and endpoints such as `/sso-callback` for SSO auth
+- Added support for seamless token refresh mechanism. A provided auth config can be configured to support token refresh by:
+  - implement the `refresh_token` method to sign a new token, reusing the previous session_id for continuity
+  - adding some mechanism to set a `dara_refresh_token` cookie, e.g. via custom `components_config` and endpoints such as `/sso-callback` for SSO auth
 
 ## 1.13.1
 
--   Fixed an issue where data passed to `Table` component within a column of `dtype` `object` did not display correctly for datetime values.
--   Fixed an issue where `Variable`s with many properties could result in components crashing.
+- Fixed an issue where data passed to `Table` component within a column of `dtype` `object` did not display correctly for datetime values.
+- Fixed an issue where `Variable`s with many properties could result in components crashing.
 
 ## 1.13.0
 
--   Fixed `DerivedDataVariable` cache retrieving schema from the wrong registry type.
+- Fixed `DerivedDataVariable` cache retrieving schema from the wrong registry type.
 
 ## 1.12.7
 
--   Fixed a crash in `Table` pagination where rows containing non-unique index values would cause a slicing error.
--   Fixed an issue in `Table` where sorting by an unnamed index would not work.
--   Fixed a crash in `Table` when rendering the result of a `DerivedDataVariable` due to a missing `cache_key`.
+- Fixed a crash in `Table` pagination where rows containing non-unique index values would cause a slicing error.
+- Fixed an issue in `Table` where sorting by an unnamed index would not work.
+- Fixed a crash in `Table` when rendering the result of a `DerivedDataVariable` due to a missing `cache_key`.
 
 ## 1.12.6
 
--   Fix an issue where LRU cache could result in a `KeyError`
+- Fix an issue where LRU cache could result in a `KeyError`
 
 ## 1.12.5
 
--   Internal (PY): improve support for synchronous custom WS handlers added with `config.add_ws_handler`, they are now guaranteed to be processed synchronously before the next WS message is handled.
--   Internal (JS): extend `sendCustomMessage` WS client method to return the response as a promise if a new third argument `awaitResponse` is true.
+- Internal (PY): improve support for synchronous custom WS handlers added with `config.add_ws_handler`, they are now guaranteed to be processed synchronously before the next WS message is handled.
+- Internal (JS): extend `sendCustomMessage` WS client method to return the response as a promise if a new third argument `awaitResponse` is true.
 
 ## 1.12.1
 
--   Added index columns to the response of `DataVariable`/`DerivedDataVariable`.
--   Added a schema endpoint for `DataVariable`/`DerivedDataVariable`. The schema is returned when passing `{ schema: true }` as an options field when calling `useDataVariable`/`useDerivedDataVariable`.
--   Fixed a crash when DataFrame with duplicate column names is passed into `DataVariable`/`DerivedDataVariable`.
+- Added index columns to the response of `DataVariable`/`DerivedDataVariable`.
+- Added a schema endpoint for `DataVariable`/`DerivedDataVariable`. The schema is returned when passing `{ schema: true }` as an options field when calling `useDataVariable`/`useDerivedDataVariable`.
+- Fixed a crash when DataFrame with duplicate column names is passed into `DataVariable`/`DerivedDataVariable`.
 
 ## 1.11.0
 
--   Dropped support for Python 3.8.
--   Added support for Python 3.12.
+- Dropped support for Python 3.8.
+- Added support for Python 3.12.
 
 ## 1.10.5
 
--   Fixed an issue where an empty '.npmrc' would be written to the static files directory even when no custom registry is specified
+- Fixed an issue where an empty '.npmrc' would be written to the static files directory even when no custom registry is specified
 
 ## 1.10.4
 
--   Fixed an issue where `EventBus` were not fired for `Variable`s updated via actions but not subscribed to in the component tree
+- Fixed an issue where `EventBus` were not fired for `Variable`s updated via actions but not subscribed to in the component tree
 
 ## 1.10.2
 
--   Fixed an issue where if a `Variable` was created from a `DerivedVariable` and had `persist_value=True` that its value was not unwrapped.
--   Added "Powered by causaLens" to the sidebar when `powered_by_causaLens` is set to `True` in the configuration.
--   Added a github link to "Built with Dara" in the sidebar.
--   Fixed an infinite loop in `useVariable` when using a nested selector inside a Select.
--   Added a `for_` and `id_` property to the `ComponentInstance`
+- Fixed an issue where if a `Variable` was created from a `DerivedVariable` and had `persist_value=True` that its value was not unwrapped.
+- Added "Powered by causaLens" to the sidebar when `powered_by_causaLens` is set to `True` in the configuration.
+- Added a github link to "Built with Dara" in the sidebar.
+- Fixed an infinite loop in `useVariable` when using a nested selector inside a Select.
+- Added a `for_` and `id_` property to the `ComponentInstance`
 
 ## 1.10.0
 
--   Fixed an issue where in some cases a `DerivedDataVariable` would be invoked with an internal `PendingValue`
--   Implement `Variable.init_override` static method to allow overriding how variables are initialized within a given context.
+- Fixed an issue where in some cases a `DerivedDataVariable` would be invoked with an internal `PendingValue`
+- Implement `Variable.init_override` static method to allow overriding how variables are initialized within a given context.
 
 ```python
 from dara.core import Variable
@@ -528,16 +521,16 @@ with Variable.init_override(lambda kwargs: {**kwargs, 'default': 'foo'}):
 assert var.default == 'foo'
 ```
 
--   Internal (JS): `EventBus` now also emits events for `UrlVariable` changes
+- Internal (JS): `EventBus` now also emits events for `UrlVariable` changes
 
 ## 1.9.1
 
--   Fixed an issue where desired pathname + search params were not retained when redirected to the login page and then back to the original page
+- Fixed an issue where desired pathname + search params were not retained when redirected to the login page and then back to the original page
 
 ## 1.9.0
 
--   Further fix for the websocket reconnection logic that meant the socket class wasn't updated after re-initialization which meant that message sends were routed to the old socket rather than the new one.
--   Updated AnnotatedAction to have a `loading` property that is automatically set to be a Variable[bool] instance tracking the loading state of the action. The example below shows how you can disable a button whilst the action it triggers is running.
+- Further fix for the websocket reconnection logic that meant the socket class wasn't updated after re-initialization which meant that message sends were routed to the old socket rather than the new one.
+- Updated AnnotatedAction to have a `loading` property that is automatically set to be a Variable[bool] instance tracking the loading state of the action. The example below shows how you can disable a button whilst the action it triggers is running.
 
 ```python
 from dara.core import action
@@ -551,65 +544,65 @@ on_click_action = on_click()
 Button('Click Me', onclick=on_click_action, disabled=on_click_action.loading)
 ```
 
--   On the JS Api side the `useAction` hook has been changed to only return the action function rather than a tuple of `[action_fn, isLoading]`. To retrieve the loading state a new hook `useActionIsLoading` now returns the isLoading state of the action as a piece of react state that will trigger redraws when its value changes.
+- On the JS Api side the `useAction` hook has been changed to only return the action function rather than a tuple of `[action_fn, isLoading]`. To retrieve the loading state a new hook `useActionIsLoading` now returns the isLoading state of the action as a piece of react state that will trigger redraws when its value changes.
 
 ## 1.8.5
 
--   Internal (JS): add `EventBus` events for resolving data variables
+- Internal (JS): add `EventBus` events for resolving data variables
 
 ## 1.8.4
 
--   Internal (JS): Typing fix for `EventBus`
+- Internal (JS): Typing fix for `EventBus`
 
 ## 1.8.3
 
--   Internal (JS): implement a global `EventBus`, Dara internals now fire events to the EventBus which can be subscribed to.
+- Internal (JS): implement a global `EventBus`, Dara internals now fire events to the EventBus which can be subscribed to.
     Accompanying `EventCapturer` component can be wrapped around a part of the component tree to capture and handle these events.
--   Fixed websocket reconnection logic so that it correctly retries for 10 seconds before bailing out and then retries the connection if the document becomes visible again.
+- Fixed websocket reconnection logic so that it correctly retries for 10 seconds before bailing out and then retries the connection if the document becomes visible again.
 
 ## 1.8.1
 
--   Added missing interface definition to the WebsocketClientInterface in the ui code
--   Fix an issue where internal requests did not handle auth errors properly so users would not immediately
+- Added missing interface definition to the WebsocketClientInterface in the ui code
+- Fix an issue where internal requests did not handle auth errors properly so users would not immediately
     be logged out when their session expired
 
 ## 1.7.7
 
--   Fixed an issue where `DataFrame`s with multiple indexes would fail to serialize correctly
--   Improved logging within the authentication system
--   Added the ability to handle chunked responses to internal dara messages used by the `WebsocketHandler.send_and_wait` method. The messages will be gathered into a list before being returned to the caller.
+- Fixed an issue where `DataFrame`s with multiple indexes would fail to serialize correctly
+- Improved logging within the authentication system
+- Added the ability to handle chunked responses to internal dara messages used by the `WebsocketHandler.send_and_wait` method. The messages will be gathered into a list before being returned to the caller.
 
 ## 1.7.4
 
--   Added the ability to pass an asynchronous function to `ConfigurationBuilder.on_startup(...)`.
--   Fix an issue where `get_settings` would crash when attempting to generate a missing `.env` file. It now
+- Added the ability to pass an asynchronous function to `ConfigurationBuilder.on_startup(...)`.
+- Fix an issue where `get_settings` would crash when attempting to generate a missing `.env` file. It now
     instead warns and falls back to using an in-memory set of default settings.
--   Fix an issue where the `BackendStore` would not respect existing value and overwrite it with the variable default,
+- Fix an issue where the `BackendStore` would not respect existing value and overwrite it with the variable default,
     e.g. when an existing JSON file was present on disk with the `FileBackend`
 
 ## 1.7.3
 
--   Implement `FileBackend` for `BackendStore` in `dara.core.persistence` to allow for persistent file-based storage of `Variable` state in a JSON file
--   Add `scope` param to `BackendStore` which accepts either `'global'` or `'user'`. When scope=user, the store methods read/write/delete state for the current user only.
--   Add `get_all` to `BackendStore` to retrieve a key-value map of all state stored in the store. For user-scoped stores, this will be in the form of `{'user_id': 'value'}`; for global-scoped stores, this will be a dict of `{'global': 'value'}`
--   Resolve an issue with a previous fix to reconnect the websocket that prevented it from working on the 2nd/3rd/... times that the websocket was disconnected.
+- Implement `FileBackend` for `BackendStore` in `dara.core.persistence` to allow for persistent file-based storage of `Variable` state in a JSON file
+- Add `scope` param to `BackendStore` which accepts either `'global'` or `'user'`. When scope=user, the store methods read/write/delete state for the current user only.
+- Add `get_all` to `BackendStore` to retrieve a key-value map of all state stored in the store. For user-scoped stores, this will be in the form of `{'user_id': 'value'}`; for global-scoped stores, this will be a dict of `{'global': 'value'}`
+- Resolve an issue with a previous fix to reconnect the websocket that prevented it from working on the 2nd/3rd/... times that the websocket was disconnected.
 
 ## 1.7.2
 
--   Fix an edge case where `Variable` state would not be initialized properly if previously registered under a different set of `RequestExtras`
+- Fix an edge case where `Variable` state would not be initialized properly if previously registered under a different set of `RequestExtras`
 
 ## 1.7.1
 
--   Add defaults to `BackendStore` arguments - `uid` now defaults to a random UUID, `backend` defaults to `InMemoryBackend`
--   Add support for `BackendStore` in `config.add_registry_lookup`
--   Prevent `BackendStore` from serializing its backend implementation to the client
--   Internal: exclude `BackendStore` from being normalized
--   Internal: move `BackendStore` registration step from constructor to connected variable's constructor to allow for `RegistryLookup` to create another instance without registering
--   Internal (JS): fix `BackendStore` read requests not using custom `RequestExtras` provided in a context
+- Add defaults to `BackendStore` arguments - `uid` now defaults to a random UUID, `backend` defaults to `InMemoryBackend`
+- Add support for `BackendStore` in `config.add_registry_lookup`
+- Prevent `BackendStore` from serializing its backend implementation to the client
+- Internal: exclude `BackendStore` from being normalized
+- Internal: move `BackendStore` registration step from constructor to connected variable's constructor to allow for `RegistryLookup` to create another instance without registering
+- Internal (JS): fix `BackendStore` read requests not using custom `RequestExtras` provided in a context
 
 ## 1.7.0
 
--   Add `store` prop to (plain, i.e. non-derived/data) `Variable`. This enables customizing the "source of truth" for the `Variable`. By default it is stored in browser memory. In the initial implementation there is only one store available: `dara.core.persistence.BackendStore`. This enables making the variable server-side, where the client-side state is automatically synchronized with the backend state. The backend store accepts any backend implementation for storage, the initial implementation includes a simple `InMemoryBackend`.
+- Add `store` prop to (plain, i.e. non-derived/data) `Variable`. This enables customizing the "source of truth" for the `Variable`. By default it is stored in browser memory. In the initial implementation there is only one store available: `dara.core.persistence.BackendStore`. This enables making the variable server-side, where the client-side state is automatically synchronized with the backend state. The backend store accepts any backend implementation for storage, the initial implementation includes a simple `InMemoryBackend`.
 
 Note that the details of the API such as methods and their signatures on the BackendStore or PersistenceBackend are subject to change as the feature is being developed and finalized.
 
@@ -633,53 +626,53 @@ await store.write('new value')
 value = await store.read()
 ```
 
--   Deps: upgrade FastAPI to `0.109.0`, fixes security vulnerability in `starlette` dependency
+- Deps: upgrade FastAPI to `0.109.0`, fixes security vulnerability in `starlette` dependency
 
 ## 1.6.5
 
--   **Backported** Resolve an issue with a previous fix to reconnect the websocket that prevented it from working on the 2nd/3rd/... times that the websocket was disconnected.
+- **Backported** Resolve an issue with a previous fix to reconnect the websocket that prevented it from working on the 2nd/3rd/... times that the websocket was disconnected.
 
 ## 1.6.3
 
--   Fix and issue where an error being thrown when processing a get_current_value request would crash the stream and prevent all future requests from being handled.
+- Fix and issue where an error being thrown when processing a get_current_value request would crash the stream and prevent all future requests from being handled.
 
 ## 1.6.2
 
--   Fix an issue where `Node` is required even if the JS build is skipped explicitly via `--skip-jsbuild` flag
--   Fix an issue where the websocket connection was not properly recreated on reconnection
+- Fix an issue where `Node` is required even if the JS build is skipped explicitly via `--skip-jsbuild` flag
+- Fix an issue where the websocket connection was not properly recreated on reconnection
 
 ## 1.6.1
 
--   Address action execution blocking new requests due to an issue around BackgroundTask processing in starlette
--   Fix `get_current_value` not working for `DerivedDataVariable`
+- Address action execution blocking new requests due to an issue around BackgroundTask processing in starlette
+- Fix `get_current_value` not working for `DerivedDataVariable`
 
 ## 1.6.0
 
--   Fixed an issue where import discovery would consider the same symbols repeatedly causing it to run much longer than necessary
--   `suspend_render` setting on `fallback` provided to components is now inherited by all children of the component which the fallback is provided to, unless overriden by a different value.
+- Fixed an issue where import discovery would consider the same symbols repeatedly causing it to run much longer than necessary
+- `suspend_render` setting on `fallback` provided to components is now inherited by all children of the component which the fallback is provided to, unless overriden by a different value.
 
 ## 1.5.3
 
--   Fixed an issue where the websocket channel would fail to be set correctly when using get_current_value after the user has reconnected their browser on a different websocket channel.
+- Fixed an issue where the websocket channel would fail to be set correctly when using get_current_value after the user has reconnected their browser on a different websocket channel.
 
 ## 1.5.1
 
--   Fixed an issue where Local storage was not being cleared between sessions
--   Fixed an issue where the `@action` decorator would not work properly for instance methods, or class methods
--   Changed the session tie up to websocket channels to allow a single session to be tied to multiple channels
--   Add `--skip-jsbuild` cli flag, which skip the building JS assets process.
+- Fixed an issue where Local storage was not being cleared between sessions
+- Fixed an issue where the `@action` decorator would not work properly for instance methods, or class methods
+- Changed the session tie up to websocket channels to allow a single session to be tied to multiple channels
+- Add `--skip-jsbuild` cli flag, which skip the building JS assets process.
 
 ## 1.5.0
 
--   Internal (JS): added `RequestExtras` context to allow injecting additional e.g. headers into requests made by Dara in different parts of the component tree
--   Move import discovery warnings to the `--debug` logger
+- Internal (JS): added `RequestExtras` context to allow injecting additional e.g. headers into requests made by Dara in different parts of the component tree
+- Move import discovery warnings to the `--debug` logger
 
 ## 1.4.6
 
--   Added `execute_action` convenience function to `ActionCtx` to allow for executing an arbitrary `ActionImpl` instance. This can be useful in certain situations when an external API returns an action impl object to be executed, or for custom action implementations.
--   Internal: update `onUnhandledAction` API on `useAction` hook to be invoked for each action without a registered implementation rather than halting execution after the first unhandled action
--   The `--reload` flag on the `dara start` command will now correctly infer the parent directory of the module containing the configuration module in order to watch that directory for changes, rather than defaulting to the current working directory
--   Added `--reload-dir` flag which can be used multiple times to specify the exact folders to watch; when provided it will override the inferred watched directory
+- Added `execute_action` convenience function to `ActionCtx` to allow for executing an arbitrary `ActionImpl` instance. This can be useful in certain situations when an external API returns an action impl object to be executed, or for custom action implementations.
+- Internal: update `onUnhandledAction` API on `useAction` hook to be invoked for each action without a registered implementation rather than halting execution after the first unhandled action
+- The `--reload` flag on the `dara start` command will now correctly infer the parent directory of the module containing the configuration module in order to watch that directory for changes, rather than defaulting to the current working directory
+- Added `--reload-dir` flag which can be used multiple times to specify the exact folders to watch; when provided it will override the inferred watched directory
 
 ```
 # Example structure
@@ -698,34 +691,34 @@ dara start --reload-dir decision_app/pages
 dara start --reload-dir decision_app/pages decision_app/utils
 ```
 
--   Fixed an issue where the client app would refresh on WebSocket error&reconnect even without the `--reload` flag enabled
--   Moved WebSocket server-side errors to be displayed on the default dev logger rather than the opt-in `--debug` logger
+- Fixed an issue where the client app would refresh on WebSocket error&reconnect even without the `--reload` flag enabled
+- Moved WebSocket server-side errors to be displayed on the default dev logger rather than the opt-in `--debug` logger
 
 ## 1.4.5
 
--   Relax `python-dotenv` dependency from `^0.19.2` to `>=0.19.2`
--   Added `add_middleware` to `ConfigurationBuilder` to allow users to add custom middleware
+- Relax `python-dotenv` dependency from `^0.19.2` to `>=0.19.2`
+- Added `add_middleware` to `ConfigurationBuilder` to allow users to add custom middleware
 
 ## 1.4.4
 
--   Fixed an issue where the update action would fail if the updated variable was not already registered on the client. The action now registers the variable if it is not already registered.
+- Fixed an issue where the update action would fail if the updated variable was not already registered on the client. The action now registers the variable if it is not already registered.
 
 ## 1.4.3
 
--   `py_component` results are now normalized, which means multiple instances of the same variables within the returned components will be deduplicated. This should significantly reduce the amount of data sent over the wire in some cases.
+- `py_component` results are now normalized, which means multiple instances of the same variables within the returned components will be deduplicated. This should significantly reduce the amount of data sent over the wire in some cases.
 
 ## 1.4.2
 
--   Fixed an issue where `.get()` API on `Variable` would not behave correctly when used as the update target within actions (either legacy `UpdateVariable` or new `ActionCtx.update` method)
+- Fixed an issue where `.get()` API on `Variable` would not behave correctly when used as the update target within actions (either legacy `UpdateVariable` or new `ActionCtx.update` method)
 
 ## 1.4.1
 
--   Fixed an issue where argument restoration for actions, derived variables and `py_component`s would attempt to restore a value to the annotated type even when the value was already of the correct type
--   Fixed an issue where Dara would fail to serialize responses including `NaN` or `inf` values, those are now serialized as `null` in the JSON response
+- Fixed an issue where argument restoration for actions, derived variables and `py_component`s would attempt to restore a value to the annotated type even when the value was already of the correct type
+- Fixed an issue where Dara would fail to serialize responses including `NaN` or `inf` values, those are now serialized as `null` in the JSON response
 
 ## 1.4.0
 
--   Implement new action API in the form of the `@action` decorator. This decorator takes a function and returns an action that can be passed to a component's callback. It injects an `ActionCtx` object (aliased as `action.Ctx`) as the first argument of the function, which contains the input sent from the component and exposes action methods. This allows for full control over the action's behaviour, including the ability to conditionally execute specific actions with control flow, error handling etc. See the updated `actions` documentation page for more details on the new API and migration guide for the existing APIs.
+- Implement new action API in the form of the `@action` decorator. This decorator takes a function and returns an action that can be passed to a component's callback. It injects an `ActionCtx` object (aliased as `action.Ctx`) as the first argument of the function, which contains the input sent from the component and exposes action methods. This allows for full control over the action's behaviour, including the ability to conditionally execute specific actions with control flow, error handling etc. See the updated `actions` documentation page for more details on the new API and migration guide for the existing APIs.
 
 ```python
 from dara.core import action, Variable
@@ -750,36 +743,36 @@ Select(
 )
 ```
 
--   Added more shortcut actions for common operations, similar to existing `DerivedVariable.trigger()` - `AnyVariable.reset()`, `Variable.sync()`, `Variable.toggle()`, `Variable.update()`. See the updated `actions` documentation page for a full list of available actions.
+- Added more shortcut actions for common operations, similar to existing `DerivedVariable.trigger()` - `AnyVariable.reset()`, `Variable.sync()`, `Variable.toggle()`, `Variable.update()`. See the updated `actions` documentation page for a full list of available actions.
 
--   Added `on_load` prop on the `ConfigurationBuilder.add_page` method. It accepts any valid action which will be executed as the page is loaded
--   **Deprecation Notice**: using `reset_vars_on_load` on `ConfigurationBuilder.add_page` is now deprecated, use `on_load` instead. The existing API will continue to work and will be removed in a future release.
+- Added `on_load` prop on the `ConfigurationBuilder.add_page` method. It accepts any valid action which will be executed as the page is loaded
+- **Deprecation Notice**: using `reset_vars_on_load` on `ConfigurationBuilder.add_page` is now deprecated, use `on_load` instead. The existing API will continue to work and will be removed in a future release.
 
--   **Deprecation Notice**: Passing in resolvers to the existing actions (`UpdateVariable`, `DownloadContent`, `NavigateTo`) is now deprecated and will be removed in a future release. The existing API should continue to work as-is, but users are encouraged to migrate to the new API.
+- **Deprecation Notice**: Passing in resolvers to the existing actions (`UpdateVariable`, `DownloadContent`, `NavigateTo`) is now deprecated and will be removed in a future release. The existing API should continue to work as-is, but users are encouraged to migrate to the new API.
 
 ## 1.3.1
 
--   Fixed usage of `resource` package which is not supported on Windows. Attempting to use `CGROUP_MEMORY_LIMIT_ENABLED` on Windows is now a noop and emits a warning.
+- Fixed usage of `resource` package which is not supported on Windows. Attempting to use `CGROUP_MEMORY_LIMIT_ENABLED` on Windows is now a noop and emits a warning.
 
 ## 1.3.0
 
--   Internal: allow handler implementation substitution for variables, `py_component`, upload resolver and action resolver on a registry entry level
+- Internal: allow handler implementation substitution for variables, `py_component`, upload resolver and action resolver on a registry entry level
 
 ## 1.2.3
 
--   **Backported** Fixed usage of `resource` package which is not supported on Windows. Attempting to use `CGROUP_MEMORY_LIMIT_ENABLED` on Windows is now a noop and emits a warning.
+- **Backported** Fixed usage of `resource` package which is not supported on Windows. Attempting to use `CGROUP_MEMORY_LIMIT_ENABLED` on Windows is now a noop and emits a warning.
 
 ## 1.2.2
 
--   Fixed an issue where the default encoders for certain types such as `pandas.Timeseries`, `numpy.complex64` and `numpy.complex128` would output unserializable values
+- Fixed an issue where the default encoders for certain types such as `pandas.Timeseries`, `numpy.complex64` and `numpy.complex128` would output unserializable values
 
 ## 1.2.1
 
--   Fixed an issue where `DataVariable` would fail to initialize with data when created within a synchronous handler function
+- Fixed an issue where `DataVariable` would fail to initialize with data when created within a synchronous handler function
 
 ## 1.2.0
 
--   Introduced more granular cache configuration for Derived and Data variables. In addition to previously supported 'cache type' (i.e. `'global'`, `'session'`, `'user'` scopes as per `dara.core.CacheType` enum), you can now also specify a cache policy. Available cache policies are:
+- Introduced more granular cache configuration for Derived and Data variables. In addition to previously supported 'cache type' (i.e. `'global'`, `'session'`, `'user'` scopes as per `dara.core.CacheType` enum), you can now also specify a cache policy. Available cache policies are:
 
 1. `keep-all` - previous default, keeps all cached values without clearing them. Useful for small-sized results that are used frequently, ideally with a known range of results. Should be used with caution for large-sized results.
 2. `lru`: least-recently-used cache; can be configured to hold `max_size` values (globally or per user/session depending on `cache_type` set). This is the new default with `max_size=10`, as it will keep the most often accessed values in cache and discard the least often accessed ones.
@@ -834,34 +827,34 @@ some_dv = DerivedVariable(..., cache='user')
 
 ## 1.1.9
 
--   Added serialize/deserialize support to numpy/pandas datatype
--   Added custom encoder support. User can add encoder to handle serialization/deserialization of a type
+- Added serialize/deserialize support to numpy/pandas datatype
+- Added custom encoder support. User can add encoder to handle serialization/deserialization of a type
 
 ## 1.1.6
 
--   Internal: dedupe custom registry lookup calls
+- Internal: dedupe custom registry lookup calls
 
 ## 1.1.5
 
--   Lock `anyio` to `>=4.0.0`
--   Internal: added a ContextVar in the `dara.core.visual.dynamic_component` module to keep track of currently executed `py_component`
+- Lock `anyio` to `>=4.0.0`
+- Internal: added a ContextVar in the `dara.core.visual.dynamic_component` module to keep track of currently executed `py_component`
 
 ## 1.1.4
 
--   Fixed an issue where the sidebar logo path would be incorrect in embedded environments
+- Fixed an issue where the sidebar logo path would be incorrect in embedded environments
 
 ## 1.1.3
 
--   Internal: added a ContextVar in the `any_variable` module to customize `get_current_value` behaviour.
--   Fixed `ComponentInstance`'s `__repr__` not being able to correctly serialize components in some cases
+- Internal: added a ContextVar in the `any_variable` module to customize `get_current_value` behaviour.
+- Fixed `ComponentInstance`'s `__repr__` not being able to correctly serialize components in some cases
 
 ## 1.1.2
 
--   Internal: fix auth logic consistency in embedded environments
+- Internal: fix auth logic consistency in embedded environments
 
 ## 1.1.1
 
--   Exposed `DynamicComponent` as a Python class. Normally used under-the-hood by `@darajs/core` to render dynamic components, it can now be used directly in advanced use cases to serialize components and render them dynamically.
+- Exposed `DynamicComponent` as a Python class. Normally used under-the-hood by `@darajs/core` to render dynamic components, it can now be used directly in advanced use cases to serialize components and render them dynamically.
 
 ```python
 from dara.core.visual.components import DynamicComponent
@@ -873,17 +866,17 @@ text_cmp = Text(text=derived_text).dict()
 config.add_page(name='Dynamic Render', content=DynamicComponent(component=text_cmp))
 ```
 
--   Experimental: added `config.add_registry_lookup` API. This is an experimental API that allows you to register a function that will be called when a certain registry is being accessed, meant to be use for advanced use cases where some registry data needs to be fetched from an external source.
+- Experimental: added `config.add_registry_lookup` API. This is an experimental API that allows you to register a function that will be called when a certain registry is being accessed, meant to be use for advanced use cases where some registry data needs to be fetched from an external source.
 
 ## 1.1.0
 
--   Internal asset build system refactor, the generated build cache file now stores complete information required to run an asset build.
--   Fixed an issue where static assets were only being copied once when the output (e.g. `dist`) folder is created. They are now copied over at each server start.
--   Static assets are no longer copied over to the `static` folder before being copied into the output folder. The migration process now copies assets from each static folder directly into the output folder in the order the static folders were added.
+- Internal asset build system refactor, the generated build cache file now stores complete information required to run an asset build.
+- Fixed an issue where static assets were only being copied once when the output (e.g. `dist`) folder is created. They are now copied over at each server start.
+- Static assets are no longer copied over to the `static` folder before being copied into the output folder. The migration process now copies assets from each static folder directly into the output folder in the order the static folders were added.
 
 ## 1.0.1
 
--   Added custom websocket message support. Custom messages can be sent from custom JS components to the server and vice versa.
+- Added custom websocket message support. Custom messages can be sent from custom JS components to the server and vice versa.
 
 ```python
 from typing import Any
@@ -930,9 +923,9 @@ function MyCustomComponent(props: any) {
 
 ## 1.0.0-a.2
 
--   Added 'Built with Dara' to sidebars.
--   Removed extra dependency on `create-dara-app`
+- Added 'Built with Dara' to sidebars.
+- Removed extra dependency on `create-dara-app`
 
 ## 1.0.0-a.1
 
--   Initial release
+- Initial release

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fixed a race condition where the COMPLETE notification was sent after resolving the pending task, causing consumers awaiting the result to miss the completion message
+- Fixed `ExceptionGroup` handling in DerivedVariable error reuse test assertions for Python 3.10 compatibility
+
 ## 1.28.3
 
 - Fixed StreamVariable SSE connections accumulating when dependency values changed, causing stale data fetching and degraded performance

--- a/packages/dara-core/dara/core/internal/tasks.py
+++ b/packages/dara-core/dara/core/internal/tasks.py
@@ -655,12 +655,7 @@ class TaskManager:
                             if isinstance(task, Task) and task.on_progress:
                                 await run_user_handler(task.on_progress, args=(message,))
                         elif isinstance(message, TaskResult):
-                            # Handle dual coordination patterns:
-                            # 1. Direct-coordinated tasks: resolve via active_tasks registry
-                            if message.task_id in self.tasks:
-                                self.tasks[message.task_id].resolve(message.result)
-
-                            # 2. Cache-coordinated tasks: resolve via cache store (CacheStore.set handles PendingTask resolution)
+                            # 1. Cache-coordinated tasks: resolve via cache store (CacheStore.set handles PendingTask resolution)
                             if (
                                 message.cache_key is not None
                                 and message.reg_entry is not None
@@ -683,6 +678,12 @@ class TaskManager:
                                 ],
                                 variable_task_id=False,
                             )
+
+                            # Resolve the pending task AFTER sending the COMPLETE notification
+                            # so that any code awaiting the result sees the notification in the buffer
+                            # 2. Direct-coordinated tasks: resolve via active_tasks registry
+                            if message.task_id in self.tasks:
+                                self.tasks[message.task_id].resolve(message.result)
 
                             # Remove the task from the registered tasks - it finished running
                             self.tasks.pop(message.task_id, None)

--- a/packages/dara-core/tests/python/test_derived_variable.py
+++ b/packages/dara-core/tests/python/test_derived_variable.py
@@ -35,6 +35,15 @@ from tests.python.utils import (
 pytestmark = pytest.mark.anyio
 
 
+def _exception_contains(exc: BaseException, text: str) -> bool:
+    """Check if an exception (or any sub-exception in an ExceptionGroup) contains the given text."""
+    if text in str(exc):
+        return True
+    if isinstance(exc, ExceptionGroup):
+        return any(_exception_contains(sub, text) for sub in exc.exceptions)
+    return False
+
+
 class MockComponent(ComponentInstance):
     text: str | Variable | DerivedVariable
 
@@ -1414,10 +1423,10 @@ async def test_non_task_immediate_reuse():
             await tg.start(run_coro_until_result, response_1_coro, 'response_1')
             tg.start_soon(run_coro_until_result, response_2_coro, 'response_2')
 
-        assert isinstance(results['response_1'], Exception)
-        assert 'test exception' in str(results['response_1'])
-        assert isinstance(results['response_2'], Exception)
-        assert 'test exception' in str(results['response_2'])
+        assert isinstance(results['response_1'], BaseException)
+        assert _exception_contains(results['response_1'], 'test exception')
+        assert isinstance(results['response_2'], BaseException)
+        assert _exception_contains(results['response_2'], 'test exception')
 
 
 async def test_force_key_prevents_double_execution():

--- a/packages/dara-core/tests/python/test_derived_variable.py
+++ b/packages/dara-core/tests/python/test_derived_variable.py
@@ -39,7 +39,7 @@ def _exception_contains(exc: BaseException, text: str) -> bool:
     """Check if an exception (or any sub-exception in an ExceptionGroup) contains the given text."""
     if text in str(exc):
         return True
-    if isinstance(exc, ExceptionGroup):
+    if hasattr(exc, 'exceptions'):
         return any(_exception_contains(sub, text) for sub in exc.exceptions)
     return False
 


### PR DESCRIPTION
## Motivation and Context

Two test failures in `dara-core`:

1. `test_task_manager_run_task_track_progress` - the COMPLETE notification was missing from the message buffer because `resolve()` unblocked the awaiting test before `_multicast_notification` sent the COMPLETE message.
2. `test_non_task_immediate_reuse` - `str(ExceptionGroup(...))` does not include sub-exception messages, so the assertion `"test exception" in str(exc)` failed when the exception was wrapped in an `ExceptionGroup` by anyio task groups.

## Implementation Description

### Task completion race condition (`tasks.py`)
Reordered operations in `TaskManager._run_task_and_notify` so that the COMPLETE notification is sent via `_multicast_notification` **before** `resolve()` unblocks any code awaiting the pending task result. Previously `resolve()` was called first, allowing consumers to read the websocket buffer before the COMPLETE message arrived.

### ExceptionGroup handling (`test_derived_variable.py`)
- Added a `_exception_contains` helper that recursively checks an exception's message and, for `ExceptionGroup`, all sub-exceptions
- Uses `hasattr(exc, "exceptions")` instead of `isinstance(exc, ExceptionGroup)` for Python 3.10 compatibility
- Changed `isinstance(_, Exception)` to `isinstance(_, BaseException)` since `ExceptionGroup` is a `BaseException` subclass

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `test_task_manager_run_task_track_progress` passes
- All 9 tests in `test_tasks.py` pass
- All tests in `test_derived_variable.py` pass

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

N/A - test fixes only.