### PR TITLE
Improvement: DO-11698 Expose more controls around the dara task pool

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Added `DARA_POOL_MIN_WORKERS` env var to keep a minimum number of warm task pool workers alive at all times, avoiding repeated cold worker spawns for apps with expensive task-module imports.
+- Added `DARA_POOL_WORKER_TIMEOUT` env var (float seconds) to configure how long idle excess task pool workers are kept alive before being reaped.
+
 ## 1.28.4
 
 - Fixed StreamVariable inner HTTP connections not being cancelled when the client disconnects, preventing connection leaks when generators are blocked on upstream requests

--- a/packages/dara-core/dara/core/internal/pool/task_pool.py
+++ b/packages/dara-core/dara/core/internal/pool/task_pool.py
@@ -57,6 +57,9 @@ class TaskPool:
     task_group: TaskGroup
     status: PoolStatus
     max_workers: int
+    min_workers: int
+    """Minimum number of warm workers to keep alive at all times, regardless of idle time"""
+
     worker_timeout: float
     """Number of seconds worker is allowed to be idle before it is killed, if there are too many workers alive"""
 
@@ -65,12 +68,18 @@ class TaskPool:
     tasks: dict[str, TaskDefinition] = {}
 
     def __init__(
-        self, task_group: TaskGroup, worker_parameters: WorkerParameters, max_workers: int, worker_timeout: float = 5
+        self,
+        task_group: TaskGroup,
+        worker_parameters: WorkerParameters,
+        max_workers: int,
+        worker_timeout: float = 5,
+        min_workers: int = 0,
     ):
         self.task_group = task_group
         self.status = PoolStatus.CREATED
         self.loop_stopped = anyio.Event()
         self.max_workers = max_workers
+        self.min_workers = min_workers
         self.worker_parameters = worker_parameters
         self.worker_timeout = worker_timeout
 
@@ -90,7 +99,7 @@ class TaskPool:
         """
         Get the desired number of workers based on the current workload
         """
-        return min(len(self.running_tasks) + 1, self.max_workers)
+        return min(max(len(self.running_tasks) + 1, self.min_workers), self.max_workers)
 
     async def start(self, timeout: float = 5):
         """

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -177,10 +177,14 @@ def _start_application(config: Configuration):
                 # Default to number of CPUs - 1 (with minimum of 1)
                 cpu_count = get_cpu_count()
                 max_workers = int(os.environ.get('DARA_POOL_MAX_WORKERS', max(1, cpu_count - 1)))
+                worker_timeout = float(os.environ.get('DARA_POOL_WORKER_TIMEOUT', '5'))
+                min_workers = int(os.environ.get('DARA_POOL_MIN_WORKERS', '0'))
                 dev_logger.info(
                     'Initializing task pool...',
                     {
                         'max_workers': max_workers,
+                        'min_workers': min_workers,
+                        'worker_timeout': worker_timeout,
                         'task_module': config.task_module,
                     },
                 )
@@ -188,6 +192,8 @@ def _start_application(config: Configuration):
                     task_group=task_group,
                     worker_parameters={'task_module': config.task_module},
                     max_workers=max_workers,
+                    worker_timeout=worker_timeout,
+                    min_workers=min_workers,
                 )
                 await task_pool.start(60)  # timeout after 60s
                 utils_registry.set('TaskPool', task_pool)

--- a/packages/dara-core/docs/getting-started/interactivity.mdx
+++ b/packages/dara-core/docs/getting-started/interactivity.mdx
@@ -578,6 +578,27 @@ If you have long-running tasks, it helps to let the end-user know the progress t
 
 Alternatively, you can use the `run_task` action to run a task imperatively upon a user action. Check out [run_task](./actions#run_task) to learn more.
 
+#### Configuring the task worker pool
+
+Tasks run in a pool of worker processes that Dara manages for you. The pool is elastic: it scales workers up as tasks are submitted and reaps idle workers back down when the app is quiet. You can tune this behavior with the following environment variables:
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `DARA_POOL_MAX_WORKERS` | number of CPUs - 1 (minimum 1) | Maximum number of worker processes the pool can scale up to under load. |
+| `DARA_POOL_MIN_WORKERS` | `0` | Minimum number of "warm" workers to keep alive at all times, regardless of idle time. The pool starts these on startup and never reaps below this floor. |
+| `DARA_POOL_WORKER_TIMEOUT` | `5` | Number of seconds an idle excess worker (above `DARA_POOL_MIN_WORKERS`) is kept alive before it is reaped. |
+
+Each worker imports your `task_module` when it spawns. If that module is expensive to import (for example, it loads a large dataset at import time), then frequently spawning fresh workers means repeatedly paying that import cost, which can make interactive task submissions feel sluggish.
+
+To keep workers warm and avoid these repeated cold starts, set a minimum number of workers and a long idle timeout:
+
+```bash
+# Keep 2 workers alive at all times, and don't reap idle excess workers for an hour
+export DARA_POOL_MIN_WORKERS=2
+export DARA_POOL_WORKER_TIMEOUT=3600
+```
+
+The defaults preserve the original elastic behavior (collapse to a single worker when idle, reap excess workers after 5 seconds).
 
 </details>
 

--- a/packages/dara-core/tests/python/test_pool.py
+++ b/packages/dara-core/tests/python/test_pool.py
@@ -643,3 +643,67 @@ async def test_dynamic_worker_spawn():
             task_3 = pool.submit('test_uid3', 'add', (2, 4), {'delay': 1})
             await wait_assert(lambda: task_3.worker_id is not None, timeout=2)
             assert await task_3 == 6
+
+
+async def test_min_workers_floor_on_startup():
+    """
+    Test that min_workers warm floor brings up the pool to min_workers on startup
+    even with zero running tasks.
+    """
+    async with create_task_group() as tg:
+        async with TaskPool(task_group=tg, max_workers=4, worker_parameters=WORKER_PARAMS, min_workers=3) as pool:
+            # desired_workers should respect the floor with no running tasks
+            assert pool.desired_workers == 3
+            await wait_assert(lambda: assert_workers_started(pool, 3), timeout=5)
+
+
+async def test_no_reaping_below_min_workers():
+    """
+    Test that idle excess workers reap back down to min_workers (not 1) after the timeout.
+    """
+    async with create_task_group() as tg:
+        async with TaskPool(
+            task_group=tg, max_workers=4, worker_parameters=WORKER_PARAMS, worker_timeout=2, min_workers=2
+        ) as pool:
+            # Floor of 2 on startup
+            await wait_assert(lambda: assert_workers_started(pool, 2), timeout=5)
+            assert pool.desired_workers == 2
+
+            # Fire off tasks to scale up
+            task_1 = pool.submit('test_uid', 'add', (1, 2), {'delay': 2})
+            await wait_assert(lambda: task_1.worker_id is not None, timeout=2)
+            task_2 = pool.submit('test_uid2', 'add', (2, 3), {'delay': 2})
+            await wait_assert(lambda: task_2.worker_id is not None, timeout=2)
+
+            # Scaled up above the floor
+            await wait_assert(lambda: len(pool.workers) == 3, timeout=2)
+
+            # Tasks complete
+            assert await task_1 == 3
+            assert await task_2 == 5
+
+            # Excess workers reaped, but never below the floor of 2
+            await wait_assert(lambda: len(pool.workers) == 2, timeout=4)
+            await sleep_for(3)
+            assert len(pool.workers) == 2
+
+
+async def test_worker_timeout_override_prevents_reaping():
+    """
+    Test that a high worker_timeout prevents idle excess workers from being reaped.
+    """
+    async with create_task_group() as tg:
+        async with TaskPool(task_group=tg, max_workers=4, worker_parameters=WORKER_PARAMS, worker_timeout=3600) as pool:
+            # Starts at 1 with default min_workers=0
+            await wait_assert(lambda: len(pool.workers) == 1, timeout=5)
+
+            # Fire off a task to scale up
+            task_1 = pool.submit('test_uid', 'add', (1, 2), {'delay': 1})
+            await wait_assert(lambda: task_1.worker_id is not None, timeout=2)
+            await wait_assert(lambda: len(pool.workers) == 2, timeout=2)
+
+            assert await task_1 == 3
+
+            # Idle excess worker should NOT be reaped due to high timeout
+            await sleep_for(3)
+            assert len(pool.workers) == 2


### PR DESCRIPTION
## Motivation and Context
Expose a couple of extra options from the dara worker pool so that we can keep more warm workers around if there is a startup cost to them. Also makes the timeout configureable so extra workers can be kept for more than 5 seconds.

## Implementation Description
* Exposes a min worker count as well which allows developers to keep a warm pool of workersaround if their spin up time takes a while.
* Added tests and changelog entry

## Any new dependencies Introduced
No

## How Has This Been Tested?
Locally

## PR Checklist:
<!--- Go over all the following points, and ensure it has all been checked with an `x` -->

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.