### PR TITLE
Fix: DO-11699 avoid Link resuspension with deferred fallback

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fixed a case where the `Link` component would resuspend despite `suspend_render=False`.
+
 ## 1.28.4
 
 - Fixed StreamVariable inner HTTP connections not being cancelled when the client disconnects, preventing connection leaks when generators are blocked on upstream requests

--- a/packages/dara-core/js/components/link.tsx
+++ b/packages/dara-core/js/components/link.tsx
@@ -8,6 +8,7 @@ import { DisplayCtx } from '@/shared/context';
 import DynamicComponent from '@/shared/dynamic-component/dynamic-component';
 import { useVariable } from '@/shared/interactivity';
 import useComponentStyles from '@/shared/utils/use-component-styles';
+import { getVariableHookSignature } from '@/shared/utils/variable-hook-signature';
 import { type ComponentInstance, type RouterPath, type StyledComponentProps, type Variable } from '@/types';
 
 type MaybeVariable<T> = T | Variable<T>;
@@ -30,6 +31,14 @@ type ResolvedLinkProps = Omit<LinkProps, 'to'> & {
     to: string | Partial<RouterPath>;
     children: Array<ComponentInstance>;
 };
+
+function getResolvedToHookKey(to: string | Partial<RouterPath>): string {
+    if (typeof to === 'string' || !to.pathname || !to.params || Object.keys(to.params).length === 0) {
+        return 'no-param-hooks';
+    }
+
+    return JSON.stringify(Object.entries(to.params).map(([key, value]) => [key, getVariableHookSignature(value)]));
+}
 
 const NavLinkWrapper = React.forwardRef(
     (
@@ -176,9 +185,10 @@ function LinkResolveImpl(props: ResolvedLinkProps): React.ReactNode {
 function Link(props: LinkProps): React.ReactNode {
     // unwrap variable -> value
     const [to] = useVariable(props.to);
+    const linkKey = getResolvedToHookKey(to);
 
-    // key required to ensure we remount since we call hooks in a loop on props.to
-    return <LinkResolveImpl {...props} to={to} key={JSON.stringify(to)} />;
+    // key required to remount when resolved params would change useResolvedTo's hook order
+    return <LinkResolveImpl {...props} to={to} key={linkKey} />;
 }
 
 export default Link;

--- a/packages/dara-core/js/shared/utils/index.tsx
+++ b/packages/dara-core/js/shared/utils/index.tsx
@@ -12,6 +12,8 @@ export { default as getIcon } from './get-icon';
 export { default as useComponentStyles, parseRawCss } from './use-component-styles';
 export { default as useUrlSync } from './use-url-sync';
 export { normalizeRequest } from './normalization';
+export { getVariableHookSignature } from './variable-hook-signature';
+export type { VariableHookSignature } from './variable-hook-signature';
 export { injectCss } from './inject-css';
 export * from './deferred';
 export type { RawCssProp };

--- a/packages/dara-core/js/shared/utils/variable-hook-signature.ts
+++ b/packages/dara-core/js/shared/utils/variable-hook-signature.ts
@@ -1,0 +1,63 @@
+import { isCondition, isDerivedVariable, isVariable } from '@/types';
+
+export type VariableHookSignature = string | Array<VariableHookSignature>;
+
+/**
+ * Build a stable signature for the hook structure used to resolve a value through useVariable/useConditionOrVariable.
+ *
+ * Literal values intentionally collapse to the same signature. Variable values include their kind and uid because
+ * useVariable performs variable subscription bookkeeping by uid in addition to selecting a hook branch by kind.
+ */
+export function getVariableHookSignature(value: unknown, seenVariables = new Set<string>()): VariableHookSignature {
+    if (isCondition(value)) {
+        return [
+            'Condition',
+            getVariableHookSignature(value.variable, seenVariables),
+            getVariableHookSignature(value.other, seenVariables),
+        ];
+    }
+
+    if (!isVariable(value)) {
+        return 'literal';
+    }
+
+    const variableKey = `${value.__typename}:${value.uid}`;
+    if (seenVariables.has(variableKey)) {
+        return `${variableKey}:seen`;
+    }
+
+    const nextSeenVariables = new Set(seenVariables);
+    nextSeenVariables.add(variableKey);
+
+    switch (value.__typename) {
+        case 'Variable':
+            return ['Variable', value.uid, isDerivedVariable(value.default) ? 'derived-default' : 'literal-default'];
+        case 'DerivedVariable':
+            return [
+                'DerivedVariable',
+                value.uid,
+                getVariableHookSignature(value.polling_interval ?? null, nextSeenVariables),
+            ];
+        case 'SwitchVariable':
+            return [
+                'SwitchVariable',
+                value.uid,
+                getVariableHookSignature(value.value, nextSeenVariables),
+                getVariableHookSignature(value.value_map, nextSeenVariables),
+                getVariableHookSignature(value.default, nextSeenVariables),
+            ];
+        case 'StateVariable':
+            return [
+                'StateVariable',
+                value.uid,
+                value.property_name,
+                getVariableHookSignature(value.parent_variable, nextSeenVariables),
+            ];
+        case 'ServerVariable':
+            return ['ServerVariable', value.uid];
+        case 'StreamVariable':
+            return ['StreamVariable', value.uid];
+        default:
+            return variableKey;
+    }
+}

--- a/packages/dara-core/js/types/core.tsx
+++ b/packages/dara-core/js/types/core.tsx
@@ -490,6 +490,7 @@ export enum ConditionOperator {
 }
 
 export interface Condition<T> {
+    __typename: 'Condition';
     operator: ConditionOperator;
     other: any;
     variable: Variable<T>;

--- a/packages/dara-core/tests/js/variable-hook-signature.spec.tsx
+++ b/packages/dara-core/tests/js/variable-hook-signature.spec.tsx
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { getVariableHookSignature } from '@/shared/utils/variable-hook-signature';
+import {
+    type Condition,
+    ConditionOperator,
+    type DerivedVariable,
+    type SingleVariable,
+    type SwitchVariable,
+} from '@/types';
+
+function singleVariable(uid: string, defaultValue: any = `${uid}-default`): SingleVariable<any> {
+    return {
+        __typename: 'Variable',
+        default: defaultValue,
+        nested: [],
+        uid,
+    };
+}
+
+function derivedVariable(uid: string, overrides: Partial<DerivedVariable> = {}): DerivedVariable {
+    return {
+        __typename: 'DerivedVariable',
+        deps: [],
+        nested: [],
+        uid,
+        variables: [],
+        ...overrides,
+    };
+}
+
+function switchVariable(uid: string, overrides: Partial<SwitchVariable<any>> = {}): SwitchVariable<any> {
+    return {
+        __typename: 'SwitchVariable',
+        default: 'fallback',
+        uid,
+        value: 'selected',
+        value_map: {
+            selected: 'target',
+        },
+        ...overrides,
+    };
+}
+
+function condition(variable: Condition<any>['variable'], other: unknown): Condition<any> {
+    return {
+        __typename: 'Condition',
+        operator: ConditionOperator.EQUAL,
+        other,
+        variable,
+    };
+}
+
+function getParamHookKey(params: Record<string, unknown>): string {
+    if (Object.keys(params).length === 0) {
+        return 'no-param-hooks';
+    }
+
+    return JSON.stringify(Object.entries(params).map(([key, value]) => [key, getVariableHookSignature(value)]));
+}
+
+describe('getVariableHookSignature', () => {
+    it('collapses literal values to one hook signature', () => {
+        expect(getVariableHookSignature('page-a')).toEqual(getVariableHookSignature('page-b'));
+        expect(getVariableHookSignature({ page: 'a' })).toEqual(getVariableHookSignature({ page: 'b' }));
+        expect(getParamHookKey({ slug: 'run-history' })).toEqual(getParamHookKey({ slug: 'details' }));
+    });
+
+    it('distinguishes variable hook branches and variable identities', () => {
+        expect(getVariableHookSignature(singleVariable('selected-page', 'run-history'))).toEqual(
+            getVariableHookSignature(singleVariable('selected-page', 'details'))
+        );
+        expect(getVariableHookSignature(singleVariable('page-a'))).not.toEqual(
+            getVariableHookSignature(singleVariable('page-b'))
+        );
+        expect(getVariableHookSignature(singleVariable('selected-page'))).not.toEqual(
+            getVariableHookSignature(singleVariable('selected-page', derivedVariable('derived-default')))
+        );
+        expect(getVariableHookSignature(derivedVariable('delayed', { polling_interval: 500 }))).toEqual(
+            getVariableHookSignature(derivedVariable('delayed', { polling_interval: 1000 }))
+        );
+        expect(
+            getVariableHookSignature(derivedVariable('delayed', { polling_interval: singleVariable('poll') }))
+        ).not.toEqual(getVariableHookSignature(derivedVariable('delayed', { polling_interval: null })));
+    });
+
+    it('captures nested condition and switch variable hook structure', () => {
+        const selectedPage = singleVariable('selected-page');
+        const defaultPage = singleVariable('default-page');
+
+        const switchWithLiteralConditionOther = switchVariable('next-page', {
+            default: defaultPage,
+            value: condition(selectedPage, 'run-history'),
+        });
+        const switchWithChangedLiteralConditionOther = switchVariable('next-page', {
+            default: defaultPage,
+            value: condition(selectedPage, 'details'),
+            value_map: {
+                details: 'other-target',
+            },
+        });
+        const switchWithVariableConditionOther = switchVariable('next-page', {
+            default: defaultPage,
+            value: condition(selectedPage, singleVariable('selected-other')),
+        });
+        const switchWithVariableMap = switchVariable('next-page', {
+            default: defaultPage,
+            value: condition(selectedPage, 'run-history'),
+            value_map: singleVariable('page-map'),
+        });
+
+        expect(getVariableHookSignature(switchWithLiteralConditionOther)).toEqual(
+            getVariableHookSignature(switchWithChangedLiteralConditionOther)
+        );
+        expect(getVariableHookSignature(switchWithLiteralConditionOther)).not.toEqual(
+            getVariableHookSignature(switchWithVariableConditionOther)
+        );
+        expect(getVariableHookSignature(switchWithLiteralConditionOther)).not.toEqual(
+            getVariableHookSignature(switchWithVariableMap)
+        );
+    });
+
+    it('represents Link param hook order and nesting', () => {
+        const selectedPage = singleVariable('selected-page');
+        const plainParam = singleVariable('plain-param');
+        const derivedParam = derivedVariable('derived-param', {
+            variables: [selectedPage],
+        });
+        const switchParam = switchVariable('switch-param', {
+            value: selectedPage,
+        });
+
+        expect(getParamHookKey({ slug: 'run-history' })).toEqual(getParamHookKey({ slug: 'details' }));
+        expect(getParamHookKey({ slug: plainParam })).not.toEqual(getParamHookKey({ slug: selectedPage }));
+        expect(getParamHookKey({ first: 'literal', second: plainParam })).not.toEqual(
+            getParamHookKey({ first: plainParam, second: 'literal' })
+        );
+        expect(getParamHookKey({ first: plainParam, second: derivedParam })).not.toEqual(
+            getParamHookKey({ first: plainParam, second: switchParam })
+        );
+    });
+
+    it('does not recursively expand cyclic variable graphs', () => {
+        const cyclic = switchVariable('cyclic');
+        cyclic.default = cyclic;
+
+        expect(getVariableHookSignature(cyclic)).toEqual([
+            'SwitchVariable',
+            'cyclic',
+            'literal',
+            'literal',
+            'SwitchVariable:cyclic:seen',
+        ]);
+    });
+});


### PR DESCRIPTION
## Motivation and Context

`Link` used `JSON.stringify(to)` as the key for the subtree that calls `useResolvedTo`. When `to` was a derived value, ordinary value changes could remount that subtree even when the param hook structure had not changed. That meant dependent variables such as dynamic styles could lose their deferred stale value and briefly resuspend despite `suspend_render=False`.

## Implementation Description

This changes the `Link` key to represent the hook structure of `to.params` instead of the resolved runtime value. Literal param value changes now keep the same key, while changes that affect hook order or variable identity still remount the `useResolvedTo` subtree.

A reusable `getVariableHookSignature` utility captures variable kind, uid, and nested variable-bearing fields. `Condition` is also typed with `__typename: 'Condition'` to match the runtime guard.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `pnpm --dir /Users/kbiel/code/dara/packages/dara-core exec vitest --run tests/js/variable-hook-signature.spec.tsx`
- `pnpm --dir /Users/kbiel/code/dara/packages/dara-core exec eslint js/components/link.tsx js/shared/utils/variable-hook-signature.ts js/shared/utils/index.tsx tests/js/variable-hook-signature.spec.tsx`
- `pnpm --dir /Users/kbiel/code/dara/packages/dara-core exec prettier --check js/components/link.tsx js/shared/utils/variable-hook-signature.ts js/shared/utils/index.tsx js/types/core.tsx tests/js/variable-hook-signature.spec.tsx`
- `pnpm --dir /Users/kbiel/code/dara/packages/dara-core exec tsc --noEmit --pretty false`
- `pnpm --dir /Users/kbiel/code/dara exec lerna run lint --scope @darajs/core`
- `pnpm --dir /Users/kbiel/code/dara exec lerna run format:check --scope @darajs/core`

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

N/A
