### PR TITLE
Feat: DO-11744 - implicit batch updates in @action

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Added implicit batching for `@action` handlers: all `ctx.update()`, `ctx.trigger()`, and `ctx.reset_variables()` calls within a single action execution are now collected and applied as one atomic React render on the client, instead of N separate re-renders for N updates.
+- Added `ctx.flush()` escape hatch to `ActionCtx` for actions that need progressive UI feedback (e.g. showing a loading state before slow work). Calling `flush()` delivers all buffered updates immediately and starts a new batch.
+
 ## 1.28.5
 
 - Added `DARA_POOL_MIN_WORKERS` env var to keep a minimum number of warm task pool workers alive at all times, avoiding repeated cold worker spawns for apps with expensive task-module imports.

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## NEXT
 
-- Added implicit batching for `@action` handlers: all `ctx.update()`, `ctx.trigger()`, and `ctx.reset_variables()` calls within a single action execution are now collected and applied as one atomic React render on the client, instead of N separate re-renders for N updates.
+- Added implicit batching for `@action` handlers: all actions within a single action execution are now collected and applied as one atomic React render on the client, instead of N separate re-renders for N updates.
 - Added `ctx.flush()` escape hatch to `ActionCtx` for actions that need progressive UI feedback (e.g. showing a loading state before slow work). Calling `flush()` delivers all buffered updates immediately and starts a new batch.
 
 ## 1.28.5

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## NEXT
 
-- Added implicit batching for `@action` handlers: all actions within a single action execution are now collected and applied as one atomic React render on the client, instead of N separate re-renders for N updates.
+- Added implicit batching for `@action` handlers: all actions within a single action execution are now collected and applied atomically, so dependent `DerivedVariable` chains only recompute once against the final consistent state.
 - Added `ctx.flush()` escape hatch to `ActionCtx` for actions that need progressive UI feedback (e.g. showing a loading state before slow work). Calling `flush()` delivers all buffered updates immediately and starts a new batch.
 
 ## 1.28.5

--- a/packages/dara-core/dara/core/interactivity/actions.py
+++ b/packages/dara-core/dara/core/interactivity/actions.py
@@ -731,6 +731,24 @@ class DownloadVariable(ActionImpl):
 CopyToClipboardDef = ActionDef(name='CopyToClipboard', js_module='@darajs/core', py_module='dara.core')
 
 
+class BatchStart(ActionImpl):
+    """
+    Batch framing marker sent before an action handler runs.
+    Signals the client to start buffering state-mutating actions.
+    """
+
+    py_name = 'BatchStart'
+
+
+class BatchEnd(ActionImpl):
+    """
+    Batch framing marker sent after an action handler completes.
+    Signals the client to apply all buffered state-mutating actions atomically.
+    """
+
+    py_name = 'BatchEnd'
+
+
 class CopyToClipboard(ActionImpl):
     """
     CopyToClipboard action copies the provided value to the user's clipboard.
@@ -1331,6 +1349,44 @@ class ActionCtx:
         task_mgr.register_task(task)
         pending_task = await task_mgr.run_task(task)
         return await pending_task.value()
+
+    async def flush(self):
+        """
+        Flush buffered updates to the client immediately.
+
+        Within an ``@action`` handler, all ``ctx.update()`` calls are implicitly batched --
+        they are collected and applied as a single atomic unit on the client, producing one
+        React re-render instead of N.
+
+        Calling ``ctx.flush()`` ends the current batch (delivering all buffered updates) and
+        starts a new one. This is useful for actions that need progressive UI feedback, e.g.
+        showing a loading state before performing slow work:
+
+        ```python
+
+        from dara.core import action, Variable
+        from dara.components import Button
+
+        loading = Variable(False)
+        result = Variable(None)
+
+        @action
+        async def load_data(ctx: action.Ctx):
+            # Show loading state immediately
+            await ctx.update(loading, True)
+            await ctx.flush()
+
+            # ... slow work ...
+
+            await ctx.update(loading, False)
+            await ctx.update(result, 'done')
+            # These two updates are delivered together at the end of the action
+
+        Button('Load', onclick=load_data())
+        ```
+        """
+        await self._push_action(BatchEnd())
+        await self._push_action(BatchStart())
 
     async def execute_action(self, action: ActionImpl):
         """

--- a/packages/dara-core/dara/core/interactivity/actions.py
+++ b/packages/dara-core/dara/core/interactivity/actions.py
@@ -1352,13 +1352,13 @@ class ActionCtx:
 
     async def flush(self):
         """
-        Flush buffered updates to the client immediately.
+        Flush buffered actions to the client immediately.
 
-        Within an ``@action`` handler, all ``ctx.update()`` calls are implicitly batched --
-        they are collected and applied as a single atomic unit on the client, producing one
-        React re-render instead of N.
+        Within an ``@action`` handler, all actions are implicitly batched --
+        they are collected and applied as a single atomic unit on the client,
+        so dependent variable chains only recompute once.
 
-        Calling ``ctx.flush()`` ends the current batch (delivering all buffered updates) and
+        Calling ``ctx.flush()`` ends the current batch (delivering all buffered actions) and
         starts a new one. This is useful for actions that need progressive UI feedback, e.g.
         showing a loading state before performing slow work:
 
@@ -1366,6 +1366,7 @@ class ActionCtx:
 
         from dara.core import action, Variable
         from dara.components import Button
+        from .tasks import expensive_computation
 
         loading = Variable(False)
         result = Variable(None)
@@ -1376,10 +1377,11 @@ class ActionCtx:
             await ctx.update(loading, True)
             await ctx.flush()
 
-            # ... slow work ...
+            # Run slow work as a task
+            data = await ctx.run_task(expensive_computation)
 
             await ctx.update(loading, False)
-            await ctx.update(result, 'done')
+            await ctx.update(result, data)
             # These two updates are delivered together at the end of the action
 
         Button('Load', onclick=load_data())

--- a/packages/dara-core/dara/core/internal/execute_action.py
+++ b/packages/dara-core/dara/core/internal/execute_action.py
@@ -31,6 +31,8 @@ from dara.core.interactivity.actions import (
     BOUND_PREFIX,
     ActionCtx,
     ActionImpl,
+    BatchEnd,
+    BatchStart,
 )
 from dara.core.internal.cache_store import CacheStore
 from dara.core.internal.dependency_resolution import resolve_dependency
@@ -93,16 +95,28 @@ async def _stream_action(
     - The handler itself
     - A stream consumer which sends the results to the frontend
 
+    All updates from the action handler are implicitly batched: a BatchStart marker is sent
+    before the handler runs, and a BatchEnd marker is sent after it completes. The client
+    buffers state-mutating actions (UpdateVariable, ResetVariables, TriggerVariable) received
+    between these markers and applies them atomically in a single React render cycle.
+
+    The handler can call ``ctx.flush()`` to end the current batch early and start a new one,
+    for progressive UI feedback (e.g. showing a loading state before slow work).
+
     :param handler: the action handler to execute
     :param ctx: the action context to use
     :param values: the resolved values to pass to the handler
     """
     try:
+        # Open an implicit batch before the handler runs
+        await ctx._on_action(BatchStart())
         async with anyio.create_task_group() as tg:
             # Execute the handler and a stream consumer in parallel
             tg.start_soon(partial(_execute_action, _on_error=_on_error), handler, ctx, values)
             tg.start_soon(ctx._handle_results)
     finally:
+        # Close the implicit batch, then send the sentinel to signal completion
+        await ctx._on_action(BatchEnd())
         # None is treated as a sentinel value to stop waiting for new actions to come in on the client
         await ctx._on_action(None)
 
@@ -131,9 +145,11 @@ async def execute_action_sync(
 
     results = []
 
-    # Construct a context which handles action messages by accumulating them in an array
+    # Construct a context which handles action messages by accumulating them in an array.
+    # Batch framing markers are filtered out since on_load results are sent to the client
+    # all at once (batching is handled at the WS streaming level, not here).
     async def handle_action(act_impl: ActionImpl | None):
-        if act_impl is not None:
+        if act_impl is not None and not isinstance(act_impl, (BatchStart, BatchEnd)):
             results.append(act_impl)
 
     ctx = ActionCtx(inp, handle_action)

--- a/packages/dara-core/dara/core/internal/execute_action.py
+++ b/packages/dara-core/dara/core/internal/execute_action.py
@@ -103,7 +103,8 @@ async def _stream_action(
     When ``batch`` is True (the default), all actions from the handler are implicitly
     batched: a BatchStart marker is sent before the handler runs, and a BatchEnd marker
     is sent after it completes. The client buffers all actions received between these
-    markers and applies them atomically in a single React render cycle.
+    markers and applies them atomically, so dependent variable chains only recompute once
+    against the final consistent state.
 
     The handler can call ``ctx.flush()`` to end the current batch early and start a new one,
     for progressive UI feedback (e.g. showing a loading state before slow work).

--- a/packages/dara-core/dara/core/internal/execute_action.py
+++ b/packages/dara-core/dara/core/internal/execute_action.py
@@ -87,7 +87,12 @@ async def _execute_action(
 
 
 async def _stream_action(
-    handler: Callable, ctx: ActionCtx, _on_error: Literal['raise', 'notify'] = 'notify', **values: Mapping[str, Any]
+    handler: Callable,
+    ctx: ActionCtx,
+    _on_error: Literal['raise', 'notify'] = 'notify',
+    *,
+    batch: bool = True,
+    **values: Mapping[str, Any],
 ):
     """
     Run the action handler and stream the results to the frontend.
@@ -95,28 +100,33 @@ async def _stream_action(
     - The handler itself
     - A stream consumer which sends the results to the frontend
 
-    All updates from the action handler are implicitly batched: a BatchStart marker is sent
-    before the handler runs, and a BatchEnd marker is sent after it completes. The client
-    buffers state-mutating actions (UpdateVariable, ResetVariables, TriggerVariable) received
-    between these markers and applies them atomically in a single React render cycle.
+    When ``batch`` is True (the default), all actions from the handler are implicitly
+    batched: a BatchStart marker is sent before the handler runs, and a BatchEnd marker
+    is sent after it completes. The client buffers all actions received between these
+    markers and applies them atomically in a single React render cycle.
 
     The handler can call ``ctx.flush()`` to end the current batch early and start a new one,
     for progressive UI feedback (e.g. showing a loading state before slow work).
 
+    When ``batch`` is False, no batch framing markers are emitted. This is used by
+    ``execute_action_sync`` where results are accumulated and sent in one HTTP response,
+    making client-side batching unnecessary.
+
     :param handler: the action handler to execute
     :param ctx: the action context to use
+    :param batch: whether to emit batch framing markers (default True)
     :param values: the resolved values to pass to the handler
     """
     try:
-        # Open an implicit batch before the handler runs
-        await ctx._on_action(BatchStart())
+        if batch:
+            await ctx._on_action(BatchStart())
         async with anyio.create_task_group() as tg:
             # Execute the handler and a stream consumer in parallel
             tg.start_soon(partial(_execute_action, _on_error=_on_error), handler, ctx, values)
             tg.start_soon(ctx._handle_results)
     finally:
-        # Close the implicit batch, then send the sentinel to signal completion
-        await ctx._on_action(BatchEnd())
+        if batch:
+            await ctx._on_action(BatchEnd())
         # None is treated as a sentinel value to stop waiting for new actions to come in on the client
         await ctx._on_action(None)
 
@@ -145,11 +155,9 @@ async def execute_action_sync(
 
     results = []
 
-    # Construct a context which handles action messages by accumulating them in an array.
-    # Batch framing markers are filtered out since on_load results are sent to the client
-    # all at once (batching is handled at the WS streaming level, not here).
+    # Construct a context which handles action messages by accumulating them in an array
     async def handle_action(act_impl: ActionImpl | None):
-        if act_impl is not None and not isinstance(act_impl, (BatchStart, BatchEnd)):
+        if act_impl is not None:
             results.append(act_impl)
 
     ctx = ActionCtx(inp, handle_action)
@@ -177,8 +185,9 @@ async def execute_action_sync(
     if has_tasks:
         raise ValueError('This action does not support tasks')
 
-    # Run until completion, raising on errors
-    await _stream_action(action, ctx, _on_error='raise', **resolved_kwargs)
+    # Run until completion, raising on errors.
+    # batch=False since results are accumulated and sent in one HTTP response.
+    await _stream_action(action, ctx, _on_error='raise', batch=False, **resolved_kwargs)
 
     return results
 

--- a/packages/dara-core/docs/advanced/progress-tracking.md
+++ b/packages/dara-core/docs/advanced/progress-tracking.md
@@ -149,8 +149,11 @@ status = Variable('Not started')
 @action
 async def run_my_task(ctx: ActionCtx):
     # whenever a status update is sent from the task, update the status message
+    # flush() delivers each progress update to the UI immediately rather than
+    # waiting until the action finishes (updates are batched by default)
     async def on_progress(update: TaskProgressUpdate):
         await ctx.update(status, f'Progress: {update.progress}% - {update.message}')
+        await ctx.flush()
 
     # Run the task with 5 as kwarg and update the status message with the result or error
     try:

--- a/packages/dara-core/docs/getting-started/actions.mdx
+++ b/packages/dara-core/docs/getting-started/actions.mdx
@@ -57,8 +57,8 @@ Similarly to `py_component`s, the `@action`-decorated function can take a mixtur
 
 All actions within a single `@action` execution are **automatically batched**.
 Instead of each action being applied to the client independently, the framework collects them and applies them
-as a single atomic operation when the action finishes. This means an action that updates N variables only causes **one** React render cycle
-instead of N, which can significantly improve performance for actions that update multiple variables.
+as a single atomic operation when the action finishes. This means that any `DerivedVariable` chains depending on updated variables
+only recompute once against the final consistent state, rather than recomputing for each intermediate update.
 
 If you need progressive UI feedback (e.g. showing a loading state before slow work), use [`ctx.flush()`](#flush) to deliver all buffered actions immediately and start a new batch.
 
@@ -509,13 +509,14 @@ config.router.add_page(path='task', content=task_page)
 async def flush()
 ```
 
-`flush` ends the current implicit batch and starts a new one. All actions buffered since the start of the action (or the last `flush`) are delivered to the client immediately and applied as a single atomic React render.
+`flush` ends the current implicit batch and starts a new one. All actions buffered since the start of the action (or the last `flush`) are delivered to the client immediately and applied as a single atomic update.
 
 This is useful when you need the user to see an intermediate state before the action finishes. Without `flush`, all updates are held until the action completes.
 
 ```python
 from dara.core import action, Variable
 from dara.components import Button, Stack, Text
+from .tasks import expensive_computation
 
 loading = Variable(False)
 result = Variable(None)
@@ -526,8 +527,8 @@ async def load_data(ctx: action.Ctx):
     await ctx.update(loading, True)
     await ctx.flush()
 
-    # ... slow work (e.g. API call, computation) ...
-    data = expensive_computation()
+    # Run slow work as a task (recommended for CPU-bound operations)
+    data = await ctx.run_task(expensive_computation)
 
     # These updates are delivered together when the action finishes
     await ctx.update(loading, False)

--- a/packages/dara-core/docs/getting-started/actions.mdx
+++ b/packages/dara-core/docs/getting-started/actions.mdx
@@ -55,14 +55,12 @@ Similarly to `py_component`s, the `@action`-decorated function can take a mixtur
 
 :::tip Automatic Batching
 
-All `ctx.update()`, `ctx.trigger()`, and `ctx.reset_variables()` calls within a single `@action` execution are **automatically batched**.
-Instead of each call triggering a separate React re-render on the client, the framework collects all state-mutating updates and applies them
+All actions within a single `@action` execution are **automatically batched**.
+Instead of each action being applied to the client independently, the framework collects them and applies them
 as a single atomic operation when the action finishes. This means an action that updates N variables only causes **one** React render cycle
 instead of N, which can significantly improve performance for actions that update multiple variables.
 
-Non-state-mutating methods like `ctx.notify()`, `ctx.navigate()`, `ctx.download_file()` etc. are not affected by batching and are applied immediately.
-
-If you need progressive UI feedback (e.g. showing a loading state before slow work), use [`ctx.flush()`](#flush) to send all buffered updates immediately and start a new batch.
+If you need progressive UI feedback (e.g. showing a loading state before slow work), use [`ctx.flush()`](#flush) to deliver all buffered actions immediately and start a new batch.
 
 :::
 
@@ -511,7 +509,7 @@ config.router.add_page(path='task', content=task_page)
 async def flush()
 ```
 
-`flush` ends the current implicit batch and starts a new one. All state-mutating updates buffered since the start of the action (or the last `flush`) are delivered to the client immediately and applied as a single atomic React render.
+`flush` ends the current implicit batch and starts a new one. All actions buffered since the start of the action (or the last `flush`) are delivered to the client immediately and applied as a single atomic React render.
 
 This is useful when you need the user to see an intermediate state before the action finishes. Without `flush`, all updates are held until the action completes.
 

--- a/packages/dara-core/docs/getting-started/actions.mdx
+++ b/packages/dara-core/docs/getting-started/actions.mdx
@@ -53,6 +53,19 @@ The example above shows how to use the `@action` decorator to create an action t
 
 Similarly to `py_component`s, the `@action`-decorated function can take a mixture of regular Python variables and Dara `Variable`-based arguments in any combination. The `@action` decorator will automatically resolve the `Variable`-based arguments so your function will receive the current value of the `Variable` instead of the `Variable` instance.
 
+:::tip Automatic Batching
+
+All `ctx.update()`, `ctx.trigger()`, and `ctx.reset_variables()` calls within a single `@action` execution are **automatically batched**.
+Instead of each call triggering a separate React re-render on the client, the framework collects all state-mutating updates and applies them
+as a single atomic operation when the action finishes. This means an action that updates N variables only causes **one** React render cycle
+instead of N, which can significantly improve performance for actions that update multiple variables.
+
+Non-state-mutating methods like `ctx.notify()`, `ctx.navigate()`, `ctx.download_file()` etc. are not affected by batching and are applied immediately.
+
+If you need progressive UI feedback (e.g. showing a loading state before slow work), use [`ctx.flush()`](#flush) to send all buffered updates immediately and start a new batch.
+
+:::
+
 The `ActionCtx` instance injected into the decorated function has the following attributes:
 
 ### `input`
@@ -473,8 +486,11 @@ status = Variable('Not started')
 @action
 async def my_task(ctx: ActionCtx):
     # whenever a status update is sent from the task, update the status message
+    # flush() delivers each progress update to the UI immediately rather than
+    # waiting until the action finishes (updates are batched by default)
     async def on_progress(update: TaskProgressUpdate):
         await ctx.update(status, f'Progress: {update.progress}% - {update.message}')
+        await ctx.flush()
 
     # Run the task with [1, 10] as arguments and update the status message with the result or error
     try:
@@ -488,6 +504,52 @@ def task_page():
 
 config.router.add_page(path='task', content=task_page)
 ```
+
+### `flush`
+
+```python
+async def flush()
+```
+
+`flush` ends the current implicit batch and starts a new one. All state-mutating updates buffered since the start of the action (or the last `flush`) are delivered to the client immediately and applied as a single atomic React render.
+
+This is useful when you need the user to see an intermediate state before the action finishes. Without `flush`, all updates are held until the action completes.
+
+```python
+from dara.core import action, Variable
+from dara.components import Button, Stack, Text
+
+loading = Variable(False)
+result = Variable(None)
+
+@action
+async def load_data(ctx: action.Ctx):
+    # Show loading state immediately
+    await ctx.update(loading, True)
+    await ctx.flush()
+
+    # ... slow work (e.g. API call, computation) ...
+    data = expensive_computation()
+
+    # These updates are delivered together when the action finishes
+    await ctx.update(loading, False)
+    await ctx.update(result, data)
+
+def page():
+    return Stack(
+        Text(loading),
+        Text(result),
+        Button('Load', onclick=load_data()),
+    )
+```
+
+In the example above, the first `ctx.update(loading, True)` is delivered to the client immediately when `ctx.flush()` is called. The subsequent updates to `loading` and `result` are batched together and delivered as a single atomic update when the action finishes.
+
+:::note
+
+Most actions do not need `flush`. It is only necessary when you want the user to see an intermediate visual state (e.g. a loading spinner) before the action completes.
+
+:::
 
 
 ## Shortcut actions

--- a/packages/dara-core/js/shared/interactivity/use-action.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-action.tsx
@@ -2,7 +2,7 @@ import groupBy from 'lodash/groupBy';
 import { nanoid } from 'nanoid';
 import { useContext, useLayoutEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import { type CallbackInterface, useRecoilCallback } from 'recoil';
+import { type CallbackInterface, type RecoilState, useRecoilCallback } from 'recoil';
 import { Subscription } from 'rxjs';
 import { concatMap, takeWhile } from 'rxjs/operators';
 
@@ -28,6 +28,111 @@ import { useEventBus } from '../event-bus/event-bus';
 import { normalizeRequest } from '../utils/normalization';
 import { cleanKwargs, getOrRegisterPlainVariable, resolveVariable } from './internal';
 import { useVariable } from './use-variable';
+
+// Names of batch framing markers sent by the server
+const BATCH_START = 'BatchStart';
+const BATCH_END = 'BatchEnd';
+
+// Action names whose handlers mutate Recoil state (ctx.set / ctx.reset) and should
+// be buffered during a batch so they can be applied atomically in a single render cycle.
+const STATE_MUTATING_ACTIONS = new Set(['UpdateVariable', 'ResetVariables', 'TriggerVariable']);
+
+/**
+ * A recorded `set` or `reset` call captured during a batch.
+ * Replayed inside `transact_UNSTABLE` when the batch ends.
+ */
+type RecordedRecoilOp =
+    | { type: 'set'; atom: RecoilState<unknown>; value: unknown }
+    | { type: 'reset'; atom: RecoilState<unknown> };
+
+/**
+ * Mutable batch state shared across an action execution.
+ * When `active` is true, state-mutating action handlers write to `ops`
+ * and side-effect handlers (Notify, NavigateTo, etc.) are forwarded to
+ * `deferredSideEffects` to be run after the batch is applied.
+ */
+interface BatchState {
+    /** Whether we are currently inside a batch (between BatchStart and BatchEnd). */
+    active: boolean;
+    /** Recorded Recoil set/reset operations to replay atomically. */
+    ops: RecordedRecoilOp[];
+    /** Side-effect callbacks (from event bus publishes etc.) deferred until after the batch is applied. */
+    deferredCallbacks: Array<() => void>;
+}
+
+/**
+ * Recording `set` implementation for batching.
+ * Uses `function` declaration to avoid TSX generic-arrow-function ambiguity.
+ */
+function recordingSet(realCtx: ActionContext, batch: BatchState): ActionContext['set'] {
+    return function batchSet<T>(atom: RecoilState<T>, valOrUpdater: T | ((prev: T) => T)): void {
+        if (typeof valOrUpdater === 'function') {
+            // Updater form: evaluate against the latest batched value or snapshot
+            const updater = valOrUpdater as (prev: T) => T;
+            // Check if we already have a pending set for this atom
+            const existingIdx = batch.ops.findLastIndex(
+                (op) => op.type === 'set' && op.atom === (atom as RecoilState<unknown>)
+            );
+            if (existingIdx >= 0) {
+                const existing = batch.ops[existingIdx] as { type: 'set'; atom: RecoilState<unknown>; value: unknown };
+                existing.value = updater(existing.value as T);
+            } else {
+                // Read current value from snapshot for the updater
+                const currentValue = realCtx.snapshot.getLoadable(atom).getValue();
+                batch.ops.push({ type: 'set', atom: atom as RecoilState<unknown>, value: updater(currentValue) });
+            }
+        } else {
+            batch.ops.push({ type: 'set', atom: atom as RecoilState<unknown>, value: valOrUpdater });
+        }
+    };
+}
+
+/**
+ * Create an `ActionContext` that records `set` / `reset` calls into `batch.ops`
+ * instead of applying them immediately. All other fields are forwarded from `realCtx`.
+ */
+function createBatchingContext(realCtx: ActionContext, batch: BatchState): ActionContext {
+    return {
+        ...realCtx,
+        set: recordingSet(realCtx, batch),
+        reset: (atom: RecoilState<unknown>) => {
+            batch.ops.push({ type: 'reset', atom });
+        },
+        // eventBus is wrapped so that publishes are deferred until after the batch
+        eventBus: {
+            ...realCtx.eventBus,
+            publish: (...args: Parameters<typeof realCtx.eventBus.publish>) => {
+                batch.deferredCallbacks.push(() => realCtx.eventBus.publish(...args));
+            },
+        },
+    };
+}
+
+/**
+ * Apply all recorded operations atomically via `transact_UNSTABLE`, then run deferred callbacks.
+ */
+function applyBatch(realCtx: ActionContext, batch: BatchState): void {
+    if (batch.ops.length > 0) {
+        realCtx.transact_UNSTABLE(({ set, reset }) => {
+            for (const op of batch.ops) {
+                if (op.type === 'set') {
+                    set(op.atom, op.value);
+                } else {
+                    reset(op.atom);
+                }
+            }
+        });
+    }
+
+    // Run deferred side-effect callbacks (event bus publishes, etc.)
+    for (const cb of batch.deferredCallbacks) {
+        cb();
+    }
+
+    // Clear the batch
+    batch.ops = [];
+    batch.deferredCallbacks = [];
+}
 
 /**
  * Invoke a server-side action.
@@ -209,6 +314,9 @@ async function executeAction(
 
         let sub: Subscription;
 
+        // Batch state: when active, state-mutating actions are buffered and applied atomically on BatchEnd
+        const batch: BatchState = { active: false, ops: [], deferredCallbacks: [] };
+
         const checkForCompletion = (): void => {
             if (!isSettled && streamCompleted && activeTasks === 0) {
                 isSettled = true;
@@ -230,8 +338,7 @@ async function executeAction(
                 // eslint-disable-next-line @typescript-eslint/require-await
                 concatMap(async (actionImpl) => {
                     if (actionImpl) {
-                        const handler = resolveActionImpl(actionImpl, actionCtx);
-                        return [handler, actionImpl] as const;
+                        return actionImpl;
                     }
 
                     return null;
@@ -244,15 +351,40 @@ async function executeAction(
                     checkForCompletion();
                 },
                 error: onError, // Reject the promise if there's an error in the stream
-                next: async ([handler, actionImpl]) => {
+                next: async (actionImpl) => {
                     try {
+                        // Handle batch framing markers
+                        if (actionImpl.name === BATCH_START) {
+                            batch.active = true;
+                            return;
+                        }
+
+                        if (actionImpl.name === BATCH_END) {
+                            applyBatch(actionCtx, batch);
+                            batch.active = false;
+                            return;
+                        }
+
                         activeTasks += 1;
 
-                        const result = handler(actionCtx, actionImpl);
+                        // Decide whether to buffer or execute immediately
+                        const isStateMutating = STATE_MUTATING_ACTIONS.has(actionImpl.name);
+                        const handler = resolveActionImpl(actionImpl, actionCtx);
 
-                        // If it's a promise, await it to ensure sequential execution
-                        if (result instanceof Promise) {
-                            await result;
+                        if (batch.active && isStateMutating) {
+                            // Execute the handler with a batching context that records set/reset calls
+                            const batchCtx = createBatchingContext(actionCtx, batch);
+                            const result = handler(batchCtx, actionImpl);
+                            if (result instanceof Promise) {
+                                await result;
+                            }
+                        } else {
+                            // Non-state-mutating actions (Notify, NavigateTo, etc.) or
+                            // actions outside a batch are executed immediately
+                            const result = handler(actionCtx, actionImpl);
+                            if (result instanceof Promise) {
+                                await result;
+                            }
                         }
                     } catch (error) {
                         onError(error as Error);

--- a/packages/dara-core/js/shared/interactivity/use-action.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-action.tsx
@@ -2,7 +2,7 @@ import groupBy from 'lodash/groupBy';
 import { nanoid } from 'nanoid';
 import { useContext, useLayoutEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
-import { type CallbackInterface, type RecoilState, useRecoilCallback } from 'recoil';
+import { type CallbackInterface, type RecoilState, type Snapshot, useRecoilCallback } from 'recoil';
 import { Subscription } from 'rxjs';
 import { concatMap, takeWhile } from 'rxjs/operators';
 
@@ -38,8 +38,8 @@ const BATCH_END = 'BatchEnd';
  *
  * Between BatchStart and BatchEnd, ActionImpl objects are buffered without
  * executing their handlers. On BatchEnd, all buffered handlers are executed
- * sequentially with a recording `ActionContext`, then all recorded Recoil
- * operations are committed atomically via `transact_UNSTABLE`.
+ * sequentially with a batching `ActionContext`, then final atom values are
+ * committed atomically via `transact_UNSTABLE`.
  *
  * This ensures **all** side effects are deferred -- not just Recoil state
  * mutations but also notifications, navigation, clipboard operations, etc.
@@ -50,39 +50,29 @@ const BATCH_END = 'BatchEnd';
  * UpdateVariable with TOGGLE reads current value via
  * `await ctx.snapshot.getLoadable(atom).toPromise()`). Instead we use a
  * two-phase approach:
+ *
  *   1. On BatchEnd, run all buffered handlers sequentially (supporting async)
- *      with a recording ActionContext that captures `set` / `reset` /
- *      `eventBus.publish` calls into arrays.
- *   2. After all handlers have run, replay all recorded Recoil operations
- *      inside a single synchronous `transact_UNSTABLE` call, then run
- *      deferred callbacks (event bus publishes, etc.).
+ *      with a batching ActionContext. Handlers' `set` / `reset` calls are
+ *      applied to a transaction snapshot (via `snapshot.map`) rather than to
+ *      the live Recoil store. Handlers read from this transaction snapshot, so
+ *      reads within the batch see writes from earlier handlers -- including
+ *      correct defaults after `reset` (since `MutableSnapshot.reset` knows
+ *      atom defaults natively). `eventBus.publish` calls are deferred.
  *
- * ── Stale snapshot reads ─────────────────────────────────────────────────────
+ *   2. After all handlers have run, read the final value of each touched atom
+ *      from the transaction snapshot and apply them atomically to the live
+ *      store via a single `transact_UNSTABLE` call. This avoids using
+ *      `gotoSnapshot` which would replace the entire store state and could
+ *      clobber concurrent modifications (e.g. server variable pushes, stream
+ *      updates). Then run deferred callbacks (event bus publishes, etc.).
  *
- * Because `set` / `reset` calls are recorded rather than applied, the `snapshot`
- * on the recording context reflects pre-batch state. A handler that writes an
- * atom and then reads it back via `ctx.snapshot.getLoadable(atom)` within the
- * same batch will see a stale value. This pattern does not occur in any built-in
- * handler and is unlikely in custom ones (Python @action code cannot read client
- * state at all), but as a safeguard the recording context wraps `snapshot` to
- * emit a dev warning when `getLoadable` or `getPromise` is called on an atom
- * that has a pending batched write.
+ * ── snapshot.map cost ────────────────────────────────────────────────────────
+ *
+ * Each `set` / `reset` call creates a new snapshot via `snapshot.map`. This
+ * could be expensive with many mutations, but in practice actions update a
+ * handful of variables, not hundreds. Recoil snapshots are structurally
+ * shared so each `map` call is a lightweight clone.
  */
-
-/**
- * A recorded Recoil operation captured during a batch.
- * Replayed inside `transact_UNSTABLE` when the batch ends.
- *
- * - `set`: direct value assignment, e.g. `ctx.set(atom, 42)`
- * - `set-update`: updater function, e.g. `ctx.set(atom, prev => prev + 1)`.
- *    The updater is stored as-is and resolved at replay time via the transaction's
- *    `get`, which correctly chains multiple updaters on the same atom.
- * - `reset`: atom reset to default value
- */
-type RecordedRecoilOp =
-    | { type: 'set'; atom: RecoilState<unknown>; value: unknown }
-    | { type: 'set-update'; atom: RecoilState<unknown>; updater: (prev: unknown) => unknown }
-    | { type: 'reset'; atom: RecoilState<unknown> };
 
 /**
  * Mutable batch state shared across an action execution.
@@ -94,70 +84,40 @@ interface BatchState {
     active: boolean;
     /** Buffered ActionImpl objects awaiting handler execution on BatchEnd. */
     bufferedActions: ActionImpl[];
-    /** Recorded Recoil set/reset operations to replay atomically (populated during handler execution on BatchEnd). */
-    ops: RecordedRecoilOp[];
-    /** Atoms that have pending writes in this batch, used to warn on stale snapshot reads. */
-    dirtyAtoms: Set<RecoilState<unknown>>;
+    /** Transaction snapshot maintained via `snapshot.map`. Handlers read from and write to this. */
+    txSnapshot: Snapshot | null;
+    /** Atoms modified during this batch. Used to read final values from txSnapshot on BatchEnd. */
+    touchedAtoms: Set<RecoilState<unknown>>;
     /** Side-effect callbacks (from event bus publishes etc.) deferred until after the batch is applied. */
     deferredCallbacks: Array<() => void>;
 }
 
 /**
- * Create an `ActionContext` that records `set` / `reset` / `eventBus.publish`
- * calls into `batch` instead of applying them immediately.
+ * Create an `ActionContext` backed by a transaction snapshot.
  *
- * The recording is intentionally simple: values and updater functions are stored
- * as-is with no attempt to resolve or chain them here. Resolution happens at
- * replay time inside `transact_UNSTABLE` (see `applyBatch`), where the
- * transaction's `get` provides correct read-after-write semantics for chained
- * updaters on the same atom.
+ * `set` and `reset` calls update the transaction snapshot (via `snapshot.map`)
+ * so that subsequent reads within the same batch see the updated values.
+ * `eventBus.publish` calls are deferred until after the batch is applied.
  */
 function createBatchingContext(realCtx: ActionContext, batch: BatchState): ActionContext {
     // `function` declaration (not arrow) to avoid TSX generic-arrow-function ambiguity with <T>
     function batchSet<T>(atom: RecoilState<T>, valOrUpdater: T | ((prev: T) => T)): void {
-        const typedAtom = atom as RecoilState<unknown>;
-        batch.dirtyAtoms.add(typedAtom);
-        if (typeof valOrUpdater === 'function') {
-            batch.ops.push({
-                type: 'set-update',
-                atom: typedAtom,
-                updater: valOrUpdater as (prev: unknown) => unknown,
-            });
-        } else {
-            batch.ops.push({ type: 'set', atom: typedAtom, value: valOrUpdater });
-        }
+        batch.touchedAtoms.add(atom as RecoilState<unknown>);
+        // eslint-disable-next-line array-callback-return -- Snapshot.map, not Array.map
+        batch.txSnapshot = batch.txSnapshot!.map((ms) => {
+            ms.set(atom, valOrUpdater);
+        });
     }
 
-    // Wrap snapshot to warn when reading an atom that has a pending batched write.
-    // The snapshot reflects pre-batch state, so the read would return a stale value.
-    const wrappedSnapshot = new Proxy(realCtx.snapshot, {
-        get(target, prop, receiver) {
-            if (prop === 'getLoadable' || prop === 'getPromise') {
-                const original = Reflect.get(target, prop, receiver) as (...args: unknown[]) => unknown;
-                return function warnOnStaleRead(recoilValue: RecoilState<unknown>, ...rest: unknown[]) {
-                    if (batch.dirtyAtoms.has(recoilValue)) {
-                        // eslint-disable-next-line no-console
-                        console.warn(
-                            `[Dara] Reading atom "${String(recoilValue.key)}" via snapshot inside a batch, ` +
-                                'but this atom has a pending batched write. The snapshot reflects pre-batch state ' +
-                                'so the value returned will be stale. Use ctx.flush() before this read if you need ' +
-                                'the updated value.'
-                        );
-                    }
-                    return original.call(target, recoilValue, ...rest);
-                };
-            }
-            return Reflect.get(target, prop, receiver);
-        },
-    });
-
-    return {
+    const ctx: ActionContext = {
         ...realCtx,
-        snapshot: wrappedSnapshot,
         set: batchSet,
         reset: (atom: RecoilState<unknown>) => {
-            batch.dirtyAtoms.add(atom);
-            batch.ops.push({ type: 'reset', atom });
+            batch.touchedAtoms.add(atom);
+            // eslint-disable-next-line array-callback-return -- Snapshot.map, not Array.map
+            batch.txSnapshot = batch.txSnapshot!.map((ms) => {
+                ms.reset(atom);
+            });
         },
         // eventBus is wrapped so that publishes are deferred until after the batch
         eventBus: {
@@ -167,22 +127,27 @@ function createBatchingContext(realCtx: ActionContext, batch: BatchState): Actio
             },
         },
     };
+
+    // snapshot must be a live getter so handlers always read the latest transaction snapshot,
+    // not the one captured at context creation time
+    Object.defineProperty(ctx, 'snapshot', { get: () => batch.txSnapshot! });
+
+    return ctx;
 }
 
 /**
- * Flush the batch: run all buffered handlers, then commit Recoil ops atomically.
+ * Flush the batch: run all buffered handlers, then commit final atom values atomically.
  *
- * Phase 1: Execute each buffered handler sequentially with a recording context.
- *   Handlers may be async (awaited one at a time). Their `set` / `reset` /
- *   `eventBus.publish` calls are captured, not applied.
+ * Phase 1: Execute each buffered handler sequentially with a batching context.
+ *   Handlers may be async (awaited one at a time). Their `set` / `reset` calls
+ *   update the transaction snapshot. Their `eventBus.publish` calls are deferred.
  *
- * Phase 2: Replay all recorded Recoil ops inside a single `transact_UNSTABLE`.
- *   Inside the transaction, `get` reads the latest value *within the transaction*,
- *   so chained updaters on the same atom resolve correctly.
+ * Phase 2: Read final values of all touched atoms from the transaction snapshot
+ *   and apply them atomically via a single `transact_UNSTABLE` call.
  *
  * Phase 3: Run deferred side-effect callbacks (event bus publishes, etc.).
  *
- * @param realCtx the real (non-recording) ActionContext
+ * @param realCtx the real (non-batching) ActionContext
  * @param batch the batch state to flush
  * @param resolver function to resolve an ActionImpl into its handler
  */
@@ -191,7 +156,7 @@ async function applyBatch(
     batch: BatchState,
     resolver: (actionImpl: ActionImpl, ctx: ActionContext) => ActionHandler<ActionImpl>
 ): Promise<void> {
-    // Phase 1: run buffered handlers with recording context
+    // Phase 1: run buffered handlers with batching context
     const batchCtx = createBatchingContext(realCtx, batch);
     for (const actionImpl of batch.bufferedActions) {
         const handler = resolver(actionImpl, realCtx);
@@ -202,18 +167,13 @@ async function applyBatch(
         }
     }
 
-    // Phase 2: commit all Recoil operations atomically
-    if (batch.ops.length > 0) {
-        realCtx.transact_UNSTABLE(({ set, reset, get }) => {
-            for (const op of batch.ops) {
-                if (op.type === 'set') {
-                    set(op.atom, op.value);
-                } else if (op.type === 'set-update') {
-                    const current = get(op.atom);
-                    set(op.atom, op.updater(current));
-                } else {
-                    reset(op.atom);
-                }
+    // Phase 2: read final values from transaction snapshot, apply atomically
+    if (batch.touchedAtoms.size > 0) {
+        const txSnap = batch.txSnapshot!;
+        realCtx.transact_UNSTABLE(({ set }) => {
+            for (const atom of batch.touchedAtoms) {
+                const finalValue = txSnap.getLoadable(atom).getValue();
+                set(atom, finalValue);
             }
         });
     }
@@ -225,8 +185,8 @@ async function applyBatch(
 
     // Clear the batch
     batch.bufferedActions = [];
-    batch.ops = [];
-    batch.dirtyAtoms.clear();
+    batch.txSnapshot = null;
+    batch.touchedAtoms.clear();
     batch.deferredCallbacks = [];
 }
 
@@ -414,8 +374,8 @@ async function executeAction(
         const batch: BatchState = {
             active: false,
             bufferedActions: [],
-            ops: [],
-            dirtyAtoms: new Set(),
+            txSnapshot: null,
+            touchedAtoms: new Set(),
             deferredCallbacks: [],
         };
 
@@ -458,6 +418,8 @@ async function executeAction(
                         // Handle batch framing markers
                         if (actionImpl.name === BATCH_START) {
                             batch.active = true;
+                            // Capture the current snapshot as the transaction starting point
+                            batch.txSnapshot = actionCtx.snapshot;
                             return;
                         }
 

--- a/packages/dara-core/js/shared/interactivity/use-action.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-action.tsx
@@ -36,19 +36,37 @@ const BATCH_END = 'BatchEnd';
 /*
  * ── Batch buffering ──────────────────────────────────────────────────────────
  *
- * `transact_UNSTABLE` requires a **synchronous** callback, and some action
- * handlers are async so we cannot buffer all ActionImpl objects and execute
- * them inside a single `transact_UNSTABLE` call.
+ * Between BatchStart and BatchEnd, ActionImpl objects are buffered without
+ * executing their handlers. On BatchEnd, all buffered handlers are executed
+ * sequentially with a recording `ActionContext`, then all recorded Recoil
+ * operations are committed atomically via `transact_UNSTABLE`.
  *
- * Instead we:
- *   1. Run handlers normally as they arrive, but with a recording `ActionContext`
- *      that captures `set` / `reset` / `eventBus.publish` calls into arrays
- *      instead of applying them.
- *   2. On `BatchEnd`, replay all recorded Recoil operations inside a single
- *      synchronous `transact_UNSTABLE` call, then run deferred callbacks.
+ * This ensures **all** side effects are deferred -- not just Recoil state
+ * mutations but also notifications, navigation, clipboard operations, etc.
+ * Nothing executes until the batch ends (or `ctx.flush()` is called).
  *
- * This gives us atomic Recoil updates (one React render) while still supporting
- * async handlers.
+ * We cannot run handlers directly inside `transact_UNSTABLE` because it
+ * requires a synchronous callback and some handlers are async (e.g.
+ * UpdateVariable with TOGGLE reads current value via
+ * `await ctx.snapshot.getLoadable(atom).toPromise()`). Instead we use a
+ * two-phase approach:
+ *   1. On BatchEnd, run all buffered handlers sequentially (supporting async)
+ *      with a recording ActionContext that captures `set` / `reset` /
+ *      `eventBus.publish` calls into arrays.
+ *   2. After all handlers have run, replay all recorded Recoil operations
+ *      inside a single synchronous `transact_UNSTABLE` call, then run
+ *      deferred callbacks (event bus publishes, etc.).
+ *
+ * ── Stale snapshot reads ─────────────────────────────────────────────────────
+ *
+ * Because `set` / `reset` calls are recorded rather than applied, the `snapshot`
+ * on the recording context reflects pre-batch state. A handler that writes an
+ * atom and then reads it back via `ctx.snapshot.getLoadable(atom)` within the
+ * same batch will see a stale value. This pattern does not occur in any built-in
+ * handler and is unlikely in custom ones (Python @action code cannot read client
+ * state at all), but as a safeguard the recording context wraps `snapshot` to
+ * emit a dev warning when `getLoadable` or `getPromise` is called on an atom
+ * that has a pending batched write.
  */
 
 /**
@@ -68,14 +86,18 @@ type RecordedRecoilOp =
 
 /**
  * Mutable batch state shared across an action execution.
- * When `active` is true, all action handlers write to `ops` via a recording
- * context, and side-effect callbacks are deferred until the batch is applied.
+ * When `active` is true, incoming ActionImpl objects are buffered and their
+ * handlers are deferred until BatchEnd.
  */
 interface BatchState {
     /** Whether we are currently inside a batch (between BatchStart and BatchEnd). */
     active: boolean;
-    /** Recorded Recoil set/reset operations to replay atomically. */
+    /** Buffered ActionImpl objects awaiting handler execution on BatchEnd. */
+    bufferedActions: ActionImpl[];
+    /** Recorded Recoil set/reset operations to replay atomically (populated during handler execution on BatchEnd). */
     ops: RecordedRecoilOp[];
+    /** Atoms that have pending writes in this batch, used to warn on stale snapshot reads. */
+    dirtyAtoms: Set<RecoilState<unknown>>;
     /** Side-effect callbacks (from event bus publishes etc.) deferred until after the batch is applied. */
     deferredCallbacks: Array<() => void>;
 }
@@ -93,21 +115,48 @@ interface BatchState {
 function createBatchingContext(realCtx: ActionContext, batch: BatchState): ActionContext {
     // `function` declaration (not arrow) to avoid TSX generic-arrow-function ambiguity with <T>
     function batchSet<T>(atom: RecoilState<T>, valOrUpdater: T | ((prev: T) => T)): void {
+        const typedAtom = atom as RecoilState<unknown>;
+        batch.dirtyAtoms.add(typedAtom);
         if (typeof valOrUpdater === 'function') {
             batch.ops.push({
                 type: 'set-update',
-                atom: atom as RecoilState<unknown>,
+                atom: typedAtom,
                 updater: valOrUpdater as (prev: unknown) => unknown,
             });
         } else {
-            batch.ops.push({ type: 'set', atom: atom as RecoilState<unknown>, value: valOrUpdater });
+            batch.ops.push({ type: 'set', atom: typedAtom, value: valOrUpdater });
         }
     }
 
+    // Wrap snapshot to warn when reading an atom that has a pending batched write.
+    // The snapshot reflects pre-batch state, so the read would return a stale value.
+    const wrappedSnapshot = new Proxy(realCtx.snapshot, {
+        get(target, prop, receiver) {
+            if (prop === 'getLoadable' || prop === 'getPromise') {
+                const original = Reflect.get(target, prop, receiver) as (...args: unknown[]) => unknown;
+                return function warnOnStaleRead(recoilValue: RecoilState<unknown>, ...rest: unknown[]) {
+                    if (batch.dirtyAtoms.has(recoilValue)) {
+                        // eslint-disable-next-line no-console
+                        console.warn(
+                            `[Dara] Reading atom "${String(recoilValue.key)}" via snapshot inside a batch, ` +
+                                'but this atom has a pending batched write. The snapshot reflects pre-batch state ' +
+                                'so the value returned will be stale. Use ctx.flush() before this read if you need ' +
+                                'the updated value.'
+                        );
+                    }
+                    return original.call(target, recoilValue, ...rest);
+                };
+            }
+            return Reflect.get(target, prop, receiver);
+        },
+    });
+
     return {
         ...realCtx,
+        snapshot: wrappedSnapshot,
         set: batchSet,
         reset: (atom: RecoilState<unknown>) => {
+            batch.dirtyAtoms.add(atom);
             batch.ops.push({ type: 'reset', atom });
         },
         // eventBus is wrapped so that publishes are deferred until after the batch
@@ -121,13 +170,39 @@ function createBatchingContext(realCtx: ActionContext, batch: BatchState): Actio
 }
 
 /**
- * Apply all recorded operations atomically via `transact_UNSTABLE`, then run deferred callbacks.
+ * Flush the batch: run all buffered handlers, then commit Recoil ops atomically.
  *
- * Inside the transaction, `get` reads the latest value *within the transaction*,
- * so chained updaters on the same atom resolve correctly: the first updater sets
- * the value, and the second updater's `get` sees the first's result.
+ * Phase 1: Execute each buffered handler sequentially with a recording context.
+ *   Handlers may be async (awaited one at a time). Their `set` / `reset` /
+ *   `eventBus.publish` calls are captured, not applied.
+ *
+ * Phase 2: Replay all recorded Recoil ops inside a single `transact_UNSTABLE`.
+ *   Inside the transaction, `get` reads the latest value *within the transaction*,
+ *   so chained updaters on the same atom resolve correctly.
+ *
+ * Phase 3: Run deferred side-effect callbacks (event bus publishes, etc.).
+ *
+ * @param realCtx the real (non-recording) ActionContext
+ * @param batch the batch state to flush
+ * @param resolver function to resolve an ActionImpl into its handler
  */
-function applyBatch(realCtx: ActionContext, batch: BatchState): void {
+async function applyBatch(
+    realCtx: ActionContext,
+    batch: BatchState,
+    resolver: (actionImpl: ActionImpl, ctx: ActionContext) => ActionHandler<ActionImpl>
+): Promise<void> {
+    // Phase 1: run buffered handlers with recording context
+    const batchCtx = createBatchingContext(realCtx, batch);
+    for (const actionImpl of batch.bufferedActions) {
+        const handler = resolver(actionImpl, realCtx);
+        const result = handler(batchCtx, actionImpl);
+        if (result instanceof Promise) {
+            // eslint-disable-next-line no-await-in-loop
+            await result;
+        }
+    }
+
+    // Phase 2: commit all Recoil operations atomically
     if (batch.ops.length > 0) {
         realCtx.transact_UNSTABLE(({ set, reset, get }) => {
             for (const op of batch.ops) {
@@ -143,13 +218,15 @@ function applyBatch(realCtx: ActionContext, batch: BatchState): void {
         });
     }
 
-    // Run deferred side-effect callbacks (event bus publishes, etc.)
+    // Phase 3: run deferred side-effect callbacks (event bus publishes, etc.)
     for (const cb of batch.deferredCallbacks) {
         cb();
     }
 
     // Clear the batch
+    batch.bufferedActions = [];
     batch.ops = [];
+    batch.dirtyAtoms.clear();
     batch.deferredCallbacks = [];
 }
 
@@ -333,8 +410,14 @@ async function executeAction(
 
         let sub: Subscription;
 
-        // Batch state: when active, state-mutating actions are buffered and applied atomically on BatchEnd
-        const batch: BatchState = { active: false, ops: [], deferredCallbacks: [] };
+        // Batch state: when active, ActionImpl objects are buffered and their handlers deferred until BatchEnd
+        const batch: BatchState = {
+            active: false,
+            bufferedActions: [],
+            ops: [],
+            dirtyAtoms: new Set(),
+            deferredCallbacks: [],
+        };
 
         const checkForCompletion = (): void => {
             if (!isSettled && streamCompleted && activeTasks === 0) {
@@ -379,18 +462,22 @@ async function executeAction(
                         }
 
                         if (actionImpl.name === BATCH_END) {
-                            applyBatch(actionCtx, batch);
+                            // Run all buffered handlers and commit Recoil ops atomically
+                            await applyBatch(actionCtx, batch, resolveActionImpl);
                             batch.active = false;
                             return;
                         }
 
-                        activeTasks += 1;
+                        if (batch.active) {
+                            // Buffer the ActionImpl; handler execution is deferred until BatchEnd
+                            batch.bufferedActions.push(actionImpl);
+                            return;
+                        }
 
+                        // Outside a batch, execute immediately (fallback for unbatched messages)
+                        activeTasks += 1;
                         const handler = resolveActionImpl(actionImpl, actionCtx);
-                        // When inside a batch, all handlers receive a recording context that
-                        // captures set/reset/eventBus calls for atomic application on BatchEnd
-                        const ctx = batch.active ? createBatchingContext(actionCtx, batch) : actionCtx;
-                        const result = handler(ctx, actionImpl);
+                        const result = handler(actionCtx, actionImpl);
                         if (result instanceof Promise) {
                             await result;
                         }

--- a/packages/dara-core/js/shared/interactivity/use-action.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-action.tsx
@@ -33,10 +33,6 @@ import { useVariable } from './use-variable';
 const BATCH_START = 'BatchStart';
 const BATCH_END = 'BatchEnd';
 
-// Action names whose handlers mutate Recoil state (ctx.set / ctx.reset) and should
-// be buffered during a batch so they can be applied atomically in a single render cycle.
-const STATE_MUTATING_ACTIONS = new Set(['UpdateVariable', 'ResetVariables', 'TriggerVariable']);
-
 /**
  * A recorded `set` or `reset` call captured during a batch.
  * Replayed inside `transact_UNSTABLE` when the batch ends.
@@ -47,9 +43,8 @@ type RecordedRecoilOp =
 
 /**
  * Mutable batch state shared across an action execution.
- * When `active` is true, state-mutating action handlers write to `ops`
- * and side-effect handlers (Notify, NavigateTo, etc.) are forwarded to
- * `deferredSideEffects` to be run after the batch is applied.
+ * When `active` is true, all action handlers write to `ops` via a recording
+ * context, and side-effect callbacks are deferred until the batch is applied.
  */
 interface BatchState {
     /** Whether we are currently inside a batch (between BatchStart and BatchEnd). */
@@ -367,24 +362,13 @@ async function executeAction(
 
                         activeTasks += 1;
 
-                        // Decide whether to buffer or execute immediately
-                        const isStateMutating = STATE_MUTATING_ACTIONS.has(actionImpl.name);
                         const handler = resolveActionImpl(actionImpl, actionCtx);
-
-                        if (batch.active && isStateMutating) {
-                            // Execute the handler with a batching context that records set/reset calls
-                            const batchCtx = createBatchingContext(actionCtx, batch);
-                            const result = handler(batchCtx, actionImpl);
-                            if (result instanceof Promise) {
-                                await result;
-                            }
-                        } else {
-                            // Non-state-mutating actions (Notify, NavigateTo, etc.) or
-                            // actions outside a batch are executed immediately
-                            const result = handler(actionCtx, actionImpl);
-                            if (result instanceof Promise) {
-                                await result;
-                            }
+                        // When inside a batch, all handlers receive a recording context that
+                        // captures set/reset/eventBus calls for atomic application on BatchEnd
+                        const ctx = batch.active ? createBatchingContext(actionCtx, batch) : actionCtx;
+                        const result = handler(ctx, actionImpl);
+                        if (result instanceof Promise) {
+                            await result;
                         }
                     } catch (error) {
                         onError(error as Error);

--- a/packages/dara-core/js/shared/interactivity/use-action.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-action.tsx
@@ -33,12 +33,37 @@ import { useVariable } from './use-variable';
 const BATCH_START = 'BatchStart';
 const BATCH_END = 'BatchEnd';
 
+/*
+ * ── Batch buffering ──────────────────────────────────────────────────────────
+ *
+ * `transact_UNSTABLE` requires a **synchronous** callback, and some action
+ * handlers are async so we cannot buffer all ActionImpl objects and execute
+ * them inside a single `transact_UNSTABLE` call.
+ *
+ * Instead we:
+ *   1. Run handlers normally as they arrive, but with a recording `ActionContext`
+ *      that captures `set` / `reset` / `eventBus.publish` calls into arrays
+ *      instead of applying them.
+ *   2. On `BatchEnd`, replay all recorded Recoil operations inside a single
+ *      synchronous `transact_UNSTABLE` call, then run deferred callbacks.
+ *
+ * This gives us atomic Recoil updates (one React render) while still supporting
+ * async handlers.
+ */
+
 /**
- * A recorded `set` or `reset` call captured during a batch.
+ * A recorded Recoil operation captured during a batch.
  * Replayed inside `transact_UNSTABLE` when the batch ends.
+ *
+ * - `set`: direct value assignment, e.g. `ctx.set(atom, 42)`
+ * - `set-update`: updater function, e.g. `ctx.set(atom, prev => prev + 1)`.
+ *    The updater is stored as-is and resolved at replay time via the transaction's
+ *    `get`, which correctly chains multiple updaters on the same atom.
+ * - `reset`: atom reset to default value
  */
 type RecordedRecoilOp =
     | { type: 'set'; atom: RecoilState<unknown>; value: unknown }
+    | { type: 'set-update'; atom: RecoilState<unknown>; updater: (prev: unknown) => unknown }
     | { type: 'reset'; atom: RecoilState<unknown> };
 
 /**
@@ -56,40 +81,32 @@ interface BatchState {
 }
 
 /**
- * Recording `set` implementation for batching.
- * Uses `function` declaration to avoid TSX generic-arrow-function ambiguity.
+ * Create an `ActionContext` that records `set` / `reset` / `eventBus.publish`
+ * calls into `batch` instead of applying them immediately.
+ *
+ * The recording is intentionally simple: values and updater functions are stored
+ * as-is with no attempt to resolve or chain them here. Resolution happens at
+ * replay time inside `transact_UNSTABLE` (see `applyBatch`), where the
+ * transaction's `get` provides correct read-after-write semantics for chained
+ * updaters on the same atom.
  */
-function recordingSet(realCtx: ActionContext, batch: BatchState): ActionContext['set'] {
-    return function batchSet<T>(atom: RecoilState<T>, valOrUpdater: T | ((prev: T) => T)): void {
+function createBatchingContext(realCtx: ActionContext, batch: BatchState): ActionContext {
+    // `function` declaration (not arrow) to avoid TSX generic-arrow-function ambiguity with <T>
+    function batchSet<T>(atom: RecoilState<T>, valOrUpdater: T | ((prev: T) => T)): void {
         if (typeof valOrUpdater === 'function') {
-            // Updater form: evaluate against the latest batched value or snapshot
-            const updater = valOrUpdater as (prev: T) => T;
-            // Check if we already have a pending set for this atom
-            const existingIdx = batch.ops.findLastIndex(
-                (op) => op.type === 'set' && op.atom === (atom as RecoilState<unknown>)
-            );
-            if (existingIdx >= 0) {
-                const existing = batch.ops[existingIdx] as { type: 'set'; atom: RecoilState<unknown>; value: unknown };
-                existing.value = updater(existing.value as T);
-            } else {
-                // Read current value from snapshot for the updater
-                const currentValue = realCtx.snapshot.getLoadable(atom).getValue();
-                batch.ops.push({ type: 'set', atom: atom as RecoilState<unknown>, value: updater(currentValue) });
-            }
+            batch.ops.push({
+                type: 'set-update',
+                atom: atom as RecoilState<unknown>,
+                updater: valOrUpdater as (prev: unknown) => unknown,
+            });
         } else {
             batch.ops.push({ type: 'set', atom: atom as RecoilState<unknown>, value: valOrUpdater });
         }
-    };
-}
+    }
 
-/**
- * Create an `ActionContext` that records `set` / `reset` calls into `batch.ops`
- * instead of applying them immediately. All other fields are forwarded from `realCtx`.
- */
-function createBatchingContext(realCtx: ActionContext, batch: BatchState): ActionContext {
     return {
         ...realCtx,
-        set: recordingSet(realCtx, batch),
+        set: batchSet,
         reset: (atom: RecoilState<unknown>) => {
             batch.ops.push({ type: 'reset', atom });
         },
@@ -105,13 +122,20 @@ function createBatchingContext(realCtx: ActionContext, batch: BatchState): Actio
 
 /**
  * Apply all recorded operations atomically via `transact_UNSTABLE`, then run deferred callbacks.
+ *
+ * Inside the transaction, `get` reads the latest value *within the transaction*,
+ * so chained updaters on the same atom resolve correctly: the first updater sets
+ * the value, and the second updater's `get` sees the first's result.
  */
 function applyBatch(realCtx: ActionContext, batch: BatchState): void {
     if (batch.ops.length > 0) {
-        realCtx.transact_UNSTABLE(({ set, reset }) => {
+        realCtx.transact_UNSTABLE(({ set, reset, get }) => {
             for (const op of batch.ops) {
                 if (op.type === 'set') {
                     set(op.atom, op.value);
+                } else if (op.type === 'set-update') {
+                    const current = get(op.atom);
+                    set(op.atom, op.updater(current));
                 } else {
                     reset(op.atom);
                 }

--- a/packages/dara-core/tests/js/use-action.spec.tsx
+++ b/packages/dara-core/tests/js/use-action.spec.tsx
@@ -1293,4 +1293,442 @@ describe('useAction', () => {
             customAction
         );
     });
+
+    describe('batch framing', () => {
+        /**
+         * Helper to send a sequence of batch-framed action messages via the mock WS client.
+         * Wraps the actions in BatchStart/BatchEnd markers and terminates with null sentinel.
+         */
+        function sendBatchedActions(
+            wsClient: MockWebSocketClient,
+            executionId: string,
+            actions: Array<ActionImpl | null>
+        ): void {
+            for (const action of actions) {
+                wsClient.receiveMessage({
+                    message: { action, uid: executionId },
+                    type: 'message',
+                });
+            }
+        }
+
+        /** Shorthand for batch marker ActionImpl objects */
+        const BATCH_START_IMPL: ActionImpl = { __typename: 'ActionImpl', name: 'BatchStart' };
+        const BATCH_END_IMPL: ActionImpl = { __typename: 'ActionImpl', name: 'BatchEnd' };
+
+        it('should batch multiple UpdateVariable actions atomically', async () => {
+            const wsClient = new MockWebSocketClient('uid');
+
+            const varA: SingleVariable<string> = {
+                __typename: 'Variable',
+                default: 'a-default',
+                nested: [],
+                uid: 'var-a',
+            };
+
+            const varB: SingleVariable<string> = {
+                __typename: 'Variable',
+                default: 'b-default',
+                nested: [],
+                uid: 'var-b',
+            };
+
+            const annotated: AnnotatedAction = {
+                definition_uid: 'definition',
+                dynamic_kwargs: {},
+                loading: LOADING_VARIABLE,
+                uid: 'uid',
+            };
+
+            // Track render count to verify atomicity
+            let renderCount = 0;
+
+            const MockComponent = (props: {
+                action: Action;
+                varA: Variable<any>;
+                varB: Variable<any>;
+            }): JSX.Element => {
+                const [a] = useVariable(props.varA);
+                const [b] = useVariable(props.varB);
+                const trigger = useAction(props.action);
+                renderCount++;
+
+                return (
+                    <>
+                        <span data-testid="a">{a}</span>
+                        <span data-testid="b">{b}</span>
+                        {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+                        <button data-testid="trigger" onClick={() => trigger('input')} type="button">
+                            trigger
+                        </button>
+                    </>
+                );
+            };
+
+            let serverReceivedMessage: Record<string, any> | null = null;
+            server.use(
+                http.post('/api/core/action/:uid', async (info) => {
+                    serverReceivedMessage = (await info.request.json()) as any;
+                    return HttpResponse.json({ execution_id: 'exec-1' });
+                })
+            );
+
+            const { getByTestId } = render(
+                <Wrapper client={wsClient}>
+                    <MockComponent action={annotated} varA={varA} varB={varB} />
+                </Wrapper>
+            );
+
+            await waitFor(() => expect(getByTestId('a').innerHTML).toBe('a-default'));
+
+            // Reset render count after initial render
+            renderCount = 0;
+
+            // Trigger the action
+            act(() => {
+                fireEvent.click(getByTestId('trigger'));
+            });
+
+            await waitFor(() => expect(serverReceivedMessage).not.toBeNull());
+
+            const executionId = serverReceivedMessage!.execution_id;
+
+            // Send batched updates: BatchStart, two UpdateVariables, BatchEnd, null
+            act(() => {
+                sendBatchedActions(wsClient, executionId, [
+                    BATCH_START_IMPL,
+                    { __typename: 'ActionImpl', name: 'UpdateVariable', variable: varA, value: 'a-updated' } as any,
+                    { __typename: 'ActionImpl', name: 'UpdateVariable', variable: varB, value: 'b-updated' } as any,
+                    BATCH_END_IMPL,
+                    null as any,
+                ]);
+            });
+
+            // Both variables should be updated
+            await waitFor(() => {
+                expect(getByTestId('a').innerHTML).toBe('a-updated');
+                expect(getByTestId('b').innerHTML).toBe('b-updated');
+            });
+
+            // Should have rendered only once for the batch (not twice for each update)
+            // renderCount === 1 means both updates were applied atomically
+            expect(renderCount).toBe(1);
+        });
+
+        it('should handle flush splitting batches into separate atomic groups', async () => {
+            const wsClient = new MockWebSocketClient('uid');
+
+            const varA: SingleVariable<string> = {
+                __typename: 'Variable',
+                default: 'a-default',
+                nested: [],
+                uid: 'var-a-flush',
+            };
+
+            const varB: SingleVariable<string> = {
+                __typename: 'Variable',
+                default: 'b-default',
+                nested: [],
+                uid: 'var-b-flush',
+            };
+
+            const annotated: AnnotatedAction = {
+                definition_uid: 'definition',
+                dynamic_kwargs: {},
+                loading: LOADING_VARIABLE,
+                uid: 'uid-flush',
+            };
+
+            const MockComponent = (props: {
+                action: Action;
+                varA: Variable<any>;
+                varB: Variable<any>;
+            }): JSX.Element => {
+                const [a] = useVariable(props.varA);
+                const [b] = useVariable(props.varB);
+                const trigger = useAction(props.action);
+
+                return (
+                    <>
+                        <span data-testid="a">{a}</span>
+                        <span data-testid="b">{b}</span>
+                        {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+                        <button data-testid="trigger" onClick={() => trigger('input')} type="button">
+                            trigger
+                        </button>
+                    </>
+                );
+            };
+
+            let serverReceivedMessage: Record<string, any> | null = null;
+            server.use(
+                http.post('/api/core/action/:uid', async (info) => {
+                    serverReceivedMessage = (await info.request.json()) as any;
+                    return HttpResponse.json({ execution_id: 'exec-flush' });
+                })
+            );
+
+            const { getByTestId } = render(
+                <Wrapper client={wsClient}>
+                    <MockComponent action={annotated} varA={varA} varB={varB} />
+                </Wrapper>
+            );
+
+            await waitFor(() => expect(getByTestId('a').innerHTML).toBe('a-default'));
+
+            act(() => {
+                fireEvent.click(getByTestId('trigger'));
+            });
+
+            await waitFor(() => expect(serverReceivedMessage).not.toBeNull());
+
+            const executionId = serverReceivedMessage!.execution_id;
+
+            // First batch: update varA
+            act(() => {
+                sendBatchedActions(wsClient, executionId, [
+                    BATCH_START_IMPL,
+                    { __typename: 'ActionImpl', name: 'UpdateVariable', variable: varA, value: 'a-first' } as any,
+                    BATCH_END_IMPL,
+                ]);
+            });
+
+            // varA should be updated after the first batch
+            await waitFor(() => expect(getByTestId('a').innerHTML).toBe('a-first'));
+            // varB should still be at default
+            expect(getByTestId('b').innerHTML).toBe('b-default');
+
+            // Second batch: update varB
+            act(() => {
+                sendBatchedActions(wsClient, executionId, [
+                    BATCH_START_IMPL,
+                    { __typename: 'ActionImpl', name: 'UpdateVariable', variable: varB, value: 'b-second' } as any,
+                    BATCH_END_IMPL,
+                    null as any,
+                ]);
+            });
+
+            await waitFor(() => {
+                expect(getByTestId('a').innerHTML).toBe('a-first');
+                expect(getByTestId('b').innerHTML).toBe('b-second');
+            });
+        });
+
+        it('should handle empty batch without errors', async () => {
+            const wsClient = new MockWebSocketClient('uid');
+
+            const variable: SingleVariable<string> = {
+                __typename: 'Variable',
+                default: 'unchanged',
+                nested: [],
+                uid: 'var-empty',
+            };
+
+            const annotated: AnnotatedAction = {
+                definition_uid: 'definition',
+                dynamic_kwargs: {},
+                loading: LOADING_VARIABLE,
+                uid: 'uid-empty',
+            };
+
+            const MockComponent = (props: { action: Action; var: Variable<any> }): JSX.Element => {
+                const [a] = useVariable(props.var);
+                const trigger = useAction(props.action);
+
+                return (
+                    <>
+                        <span data-testid="result">{a}</span>
+                        {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+                        <button data-testid="trigger" onClick={() => trigger('input')} type="button">
+                            trigger
+                        </button>
+                    </>
+                );
+            };
+
+            let serverReceivedMessage: Record<string, any> | null = null;
+            server.use(
+                http.post('/api/core/action/:uid', async (info) => {
+                    serverReceivedMessage = (await info.request.json()) as any;
+                    return HttpResponse.json({ execution_id: 'exec-empty' });
+                })
+            );
+
+            const { getByTestId } = render(
+                <Wrapper client={wsClient}>
+                    <MockComponent action={annotated} var={variable} />
+                </Wrapper>
+            );
+
+            await waitFor(() => expect(getByTestId('result').innerHTML).toBe('unchanged'));
+
+            act(() => {
+                fireEvent.click(getByTestId('trigger'));
+            });
+
+            await waitFor(() => expect(serverReceivedMessage).not.toBeNull());
+
+            const executionId = serverReceivedMessage!.execution_id;
+
+            // Send empty batch: BatchStart, BatchEnd, null
+            act(() => {
+                sendBatchedActions(wsClient, executionId, [BATCH_START_IMPL, BATCH_END_IMPL, null as any]);
+            });
+
+            // Value should remain unchanged
+            await waitFor(() => expect(getByTestId('result').innerHTML).toBe('unchanged'));
+        });
+
+        it('should defer non-Recoil actions until BatchEnd', async () => {
+            const wsClient = new MockWebSocketClient('uid');
+
+            const annotated: AnnotatedAction = {
+                definition_uid: 'definition',
+                dynamic_kwargs: {},
+                loading: LOADING_VARIABLE,
+                uid: 'uid-defer',
+            };
+
+            const onUnhandledAction = vi.fn();
+
+            const { result } = renderHook(
+                () =>
+                    useAction(annotated, {
+                        onUnhandledAction,
+                    }),
+                { wrapper: ({ children }) => <Wrapper client={wsClient}>{children}</Wrapper> }
+            );
+
+            let serverReceivedMessage: Record<string, any> | null = null;
+            server.use(
+                http.post('/api/core/action/:uid', async (info) => {
+                    serverReceivedMessage = (await info.request.json()) as any;
+                    return HttpResponse.json({ execution_id: 'exec-defer' });
+                })
+            );
+
+            // Execute action
+            act(() => {
+                result.current('input');
+            });
+
+            await waitFor(() => expect(serverReceivedMessage).not.toBeNull());
+
+            const executionId = serverReceivedMessage!.execution_id;
+
+            // Send a custom action inside a batch
+            const customAction: ActionImpl = {
+                __typename: 'ActionImpl',
+                name: 'CustomAction',
+            };
+
+            act(() => {
+                // Send BatchStart and custom action but NOT BatchEnd yet
+                wsClient.receiveMessage({
+                    message: { action: BATCH_START_IMPL, uid: executionId },
+                    type: 'message',
+                });
+                wsClient.receiveMessage({
+                    message: { action: customAction, uid: executionId },
+                    type: 'message',
+                });
+            });
+
+            // The custom action handler should NOT have been called yet (buffered)
+            expect(onUnhandledAction).not.toHaveBeenCalled();
+
+            // Now send BatchEnd and null
+            act(() => {
+                wsClient.receiveMessage({
+                    message: { action: BATCH_END_IMPL, uid: executionId },
+                    type: 'message',
+                });
+                wsClient.receiveMessage({
+                    message: { action: null, uid: executionId },
+                    type: 'message',
+                });
+            });
+
+            // Now the handler should have been called
+            await waitFor(() => expect(onUnhandledAction).toHaveBeenCalledTimes(1));
+            expect(onUnhandledAction).toHaveBeenCalledWith(
+                expect.objectContaining({ input: 'input' }),
+                customAction
+            );
+        });
+
+        it('should support read-after-write within a batch via transaction snapshot', async () => {
+            const wsClient = new MockWebSocketClient('uid');
+
+            const variable: SingleVariable<boolean> = {
+                __typename: 'Variable',
+                default: true,
+                nested: [],
+                uid: 'var-toggle',
+            };
+
+            const annotated: AnnotatedAction = {
+                definition_uid: 'definition',
+                dynamic_kwargs: {},
+                loading: LOADING_VARIABLE,
+                uid: 'uid-toggle',
+            };
+
+            const MockComponent = (props: { action: Action; var: Variable<any> }): JSX.Element => {
+                const [a] = useVariable(props.var);
+                const trigger = useAction(props.action);
+
+                return (
+                    <>
+                        <span data-testid="result">{String(a)}</span>
+                        {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+                        <button data-testid="trigger" onClick={() => trigger('input')} type="button">
+                            trigger
+                        </button>
+                    </>
+                );
+            };
+
+            let serverReceivedMessage: Record<string, any> | null = null;
+            server.use(
+                http.post('/api/core/action/:uid', async (info) => {
+                    serverReceivedMessage = (await info.request.json()) as any;
+                    return HttpResponse.json({ execution_id: 'exec-toggle' });
+                })
+            );
+
+            const { getByTestId } = render(
+                <Wrapper client={wsClient}>
+                    <MockComponent action={annotated} var={variable} />
+                </Wrapper>
+            );
+
+            // Default is true
+            await waitFor(() => expect(getByTestId('result').innerHTML).toBe('true'));
+
+            act(() => {
+                fireEvent.click(getByTestId('trigger'));
+            });
+
+            await waitFor(() => expect(serverReceivedMessage).not.toBeNull());
+
+            const executionId = serverReceivedMessage!.execution_id;
+
+            // Batch: set to false, then toggle (should read false from transaction snapshot and produce true)
+            act(() => {
+                sendBatchedActions(wsClient, executionId, [
+                    BATCH_START_IMPL,
+                    // First: set variable to false
+                    { __typename: 'ActionImpl', name: 'UpdateVariable', variable, value: false } as any,
+                    // Second: toggle (reads current value via snapshot.getLoadable, should see false, toggle to true)
+                    { __typename: 'ActionImpl', name: 'UpdateVariable', variable, value: TOGGLE } as any,
+                    BATCH_END_IMPL,
+                    null as any,
+                ]);
+            });
+
+            // set(false) then toggle should produce true
+            await waitFor(() => expect(getByTestId('result').innerHTML).toBe('true'));
+        });
+    });
 });

--- a/packages/dara-core/tests/python/test_actions.py
+++ b/packages/dara-core/tests/python/test_actions.py
@@ -42,6 +42,7 @@ from tests.python.utils import (
     _call_action,
     create_app,
     get_action_results,
+    get_raw_action_messages,
 )
 
 pytestmark = pytest.mark.anyio
@@ -1156,3 +1157,181 @@ async def test_calling_action_with_nested_derived_variable_missing_path():
         assert len(actions) == 1
         assert actions[0]['name'] == 'UpdateVariable'
         assert actions[0]['value'] is None
+
+
+async def test_action_sends_batch_framing():
+    """
+    Test that an @action execution wraps its output in BatchStart/BatchEnd framing markers.
+    The raw message sequence should be: BatchStart, <actions...>, BatchEnd, None (sentinel).
+    """
+    builder = ConfigurationBuilder()
+    config = create_app(builder)
+
+    var1 = Variable(0)
+    var2 = Variable('')
+
+    @action
+    async def multi_update(ctx: action.Ctx):
+        await ctx.update(var1, 42)
+        await ctx.update(var2, 'hello')
+
+    action_instance = multi_update()
+
+    app = _start_application(config)
+
+    async with AsyncClient(app) as client, _async_ws_connect(client) as websocket:
+        init = await websocket.receive_json()
+        exec_uid = 'exec_batch'
+        res = await _call_action(
+            client,
+            action_instance,
+            {
+                'input': None,
+                'values': {},
+                'ws_channel': init.get('message', {}).get('channel'),
+                'execution_id': exec_uid,
+            },
+        )
+        assert res.status_code == 200
+
+        raw_messages = await get_raw_action_messages(websocket, exec_uid)
+
+        # Expected sequence: BatchStart, UpdateVariable, UpdateVariable, BatchEnd, None
+        assert len(raw_messages) == 5
+        assert raw_messages[0]['name'] == 'BatchStart'
+        assert raw_messages[1]['name'] == 'UpdateVariable'
+        assert raw_messages[1]['value'] == 42
+        assert raw_messages[2]['name'] == 'UpdateVariable'
+        assert raw_messages[2]['value'] == 'hello'
+        assert raw_messages[3]['name'] == 'BatchEnd'
+        assert raw_messages[4] is None
+
+
+async def test_action_batch_framing_filtered_by_default():
+    """
+    Test that get_action_results (used by most tests) filters out batch markers
+    so existing tests continue to work unchanged.
+    """
+    builder = ConfigurationBuilder()
+    config = create_app(builder)
+
+    var = Variable(0)
+
+    @action
+    async def single_update(ctx: action.Ctx):
+        await ctx.update(var, 99)
+
+    action_instance = single_update()
+
+    app = _start_application(config)
+
+    async with AsyncClient(app) as client, _async_ws_connect(client) as websocket:
+        init = await websocket.receive_json()
+        exec_uid = 'exec_filter'
+        res = await _call_action(
+            client,
+            action_instance,
+            {
+                'input': None,
+                'values': {},
+                'ws_channel': init.get('message', {}).get('channel'),
+                'execution_id': exec_uid,
+            },
+        )
+        assert res.status_code == 200
+
+        actions = await get_action_results(websocket, exec_uid)
+        # Batch markers should be filtered out, only the actual action remains
+        assert len(actions) == 1
+        assert actions[0]['name'] == 'UpdateVariable'
+        assert actions[0]['value'] == 99
+
+
+async def test_action_flush_splits_batches():
+    """
+    Test that ctx.flush() ends the current batch and starts a new one.
+    The raw message sequence should be: BatchStart, action, BatchEnd, BatchStart, action, BatchEnd, None.
+    """
+    builder = ConfigurationBuilder()
+    config = create_app(builder)
+
+    var1 = Variable(0)
+    var2 = Variable('')
+
+    @action
+    async def flush_action(ctx: action.Ctx):
+        await ctx.update(var1, 1)
+        await ctx.flush()
+        await ctx.update(var2, 'after_flush')
+
+    action_instance = flush_action()
+
+    app = _start_application(config)
+
+    async with AsyncClient(app) as client, _async_ws_connect(client) as websocket:
+        init = await websocket.receive_json()
+        exec_uid = 'exec_flush'
+        res = await _call_action(
+            client,
+            action_instance,
+            {
+                'input': None,
+                'values': {},
+                'ws_channel': init.get('message', {}).get('channel'),
+                'execution_id': exec_uid,
+            },
+        )
+        assert res.status_code == 200
+
+        raw_messages = await get_raw_action_messages(websocket, exec_uid)
+
+        # Expected sequence: BatchStart, UpdateVariable(1), BatchEnd, BatchStart, UpdateVariable('after_flush'), BatchEnd, None
+        assert len(raw_messages) == 7
+        assert raw_messages[0]['name'] == 'BatchStart'
+        assert raw_messages[1]['name'] == 'UpdateVariable'
+        assert raw_messages[1]['value'] == 1
+        assert raw_messages[2]['name'] == 'BatchEnd'
+        assert raw_messages[3]['name'] == 'BatchStart'
+        assert raw_messages[4]['name'] == 'UpdateVariable'
+        assert raw_messages[4]['value'] == 'after_flush'
+        assert raw_messages[5]['name'] == 'BatchEnd'
+        assert raw_messages[6] is None
+
+
+async def test_action_empty_batch():
+    """
+    Test that an action that does nothing still sends proper batch framing.
+    The raw message sequence should be: BatchStart, BatchEnd, None.
+    """
+    builder = ConfigurationBuilder()
+    config = create_app(builder)
+
+    @action
+    async def noop_action(ctx: action.Ctx):
+        pass
+
+    action_instance = noop_action()
+
+    app = _start_application(config)
+
+    async with AsyncClient(app) as client, _async_ws_connect(client) as websocket:
+        init = await websocket.receive_json()
+        exec_uid = 'exec_noop'
+        res = await _call_action(
+            client,
+            action_instance,
+            {
+                'input': None,
+                'values': {},
+                'ws_channel': init.get('message', {}).get('channel'),
+                'execution_id': exec_uid,
+            },
+        )
+        assert res.status_code == 200
+
+        raw_messages = await get_raw_action_messages(websocket, exec_uid)
+
+        assert len(raw_messages) == 3
+        assert raw_messages[0]['name'] == 'BatchStart'
+        assert raw_messages[1]['name'] == 'BatchEnd'
+        assert raw_messages[2] is None

--- a/packages/dara-core/tests/python/test_websocket.py
+++ b/packages/dara-core/tests/python/test_websocket.py
@@ -422,7 +422,12 @@ async def test_action_handler_error():
         await _call_action(
             client,
             action,
-            {'ws_channel': ws_channel, 'input': 'test', 'values': {'old': 'current', 'kwarg_0': 'val2'}, 'execution_id': exec_uid},
+            {
+                'ws_channel': ws_channel,
+                'input': 'test',
+                'values': {'old': 'current', 'kwarg_0': 'val2'},
+                'execution_id': exec_uid,
+            },
         )
 
         # Websocket should receive a Notify action about the error (batch markers are filtered)

--- a/packages/dara-core/tests/python/test_websocket.py
+++ b/packages/dara-core/tests/python/test_websocket.py
@@ -32,6 +32,7 @@ from tests.python.utils import (
     _call_action,
     _get_auth_headers,
     create_app,
+    get_action_results,
     get_ws_messages,
     wait_for,
 )
@@ -415,21 +416,20 @@ async def test_action_handler_error():
         init = await websocket.receive_json()
         ws_channel = init.get('message').get('channel')
 
+        exec_uid = 'exec_err'
+
         # The error will be send as a websocket message
         await _call_action(
             client,
             action,
-            {'ws_channel': ws_channel, 'input': 'test', 'values': {'old': 'current', 'kwarg_0': 'val2'}},
+            {'ws_channel': ws_channel, 'input': 'test', 'values': {'old': 'current', 'kwarg_0': 'val2'}, 'execution_id': exec_uid},
         )
 
-        # Websocket should receive a Notify action about the error
-        msg = await websocket.receive_json()
-
-        assert 'action' in msg.get('message')
-        action = msg.get('message').get('action')
-
-        assert action.get('name') == 'Notify'
-        assert action.get('status') == 'ERROR'
+        # Websocket should receive a Notify action about the error (batch markers are filtered)
+        actions = await get_action_results(websocket, exec_uid)
+        assert len(actions) == 1
+        assert actions[0].get('name') == 'Notify'
+        assert actions[0].get('status') == 'ERROR'
 
 
 async def test_action_task_error():

--- a/packages/dara-core/tests/python/utils.py
+++ b/packages/dara-core/tests/python/utils.py
@@ -518,9 +518,13 @@ async def get_ws_messages(ws: WebSocketSession, timeout: float = 3, count: int |
     return messages
 
 
+_BATCH_MARKER_NAMES = frozenset({'BatchStart', 'BatchEnd'})
+
+
 async def get_action_results(ws: WebSocketSession, execution_id: str, timeout: float = 3) -> list[dict]:
     """
     Wait for action results until timeout is passed.
+    Batch framing markers (BatchStart/BatchEnd) are filtered out by default.
     """
     actions = []
 
@@ -532,6 +536,9 @@ async def get_action_results(ws: WebSocketSession, execution_id: str, timeout: f
                 # Sentinel to end listening
                 if (action := msg['message']['action']) is None:
                     break
+                # Skip batch framing markers
+                elif action.get('name') in _BATCH_MARKER_NAMES:
+                    continue
                 else:
                     actions.append(action)
 
@@ -539,6 +546,29 @@ async def get_action_results(ws: WebSocketSession, execution_id: str, timeout: f
             break
 
     return actions
+
+
+async def get_raw_action_messages(ws: WebSocketSession, execution_id: str, timeout: float = 3) -> list[dict | None]:
+    """
+    Wait for action results until timeout is passed.
+    Returns all action messages including batch markers and the None sentinel.
+    """
+    messages = []
+
+    while True:
+        with anyio.move_on_after(timeout) as scope:
+            msg = await ws.receive_json()
+            if 'message' in msg and 'action' in msg['message'] and msg['message']['uid'] == execution_id:
+                action = msg['message']['action']
+                messages.append(action)
+                # Sentinel to end listening
+                if action is None:
+                    break
+
+        if scope.cancel_called:
+            break
+
+    return messages
 
 
 def create_app(configuration: ConfigurationBuilder, use_tasks=False):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,24 @@ importers:
         specifier: ^3.6.20
         version: 3.6.20
 
+  packages/demo-app/dist:
+    dependencies:
+      '@darajs/components':
+        specifier: 1.26.8
+        version: 1.26.8(@egjs/hammerjs@2.0.17)(@lezer/common@1.2.3)(@types/hoist-non-react-statics@3.3.5)(@types/node@18.19.64)(@types/react@18.2.60)(component-emitter@1.3.1)(keycharm@0.4.0)(react-is@18.3.1)(uuid@11.1.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      '@darajs/core':
+        specifier: 1.26.8
+        version: 1.26.8(@types/react@18.2.60)(react-is@18.3.1)
+      '@vitejs/plugin-react':
+        specifier: 4.6.0
+        version: 4.6.0(vite@7.0.8(@types/node@18.19.64)(yaml@2.8.3))
+      vite:
+        specifier: 7.0.8
+        version: 7.0.8(@types/node@18.19.64)(yaml@2.8.3)
+      vite-plugin-node-polyfills:
+        specifier: 0.24.0
+        version: 0.24.0(rollup@4.60.2)(vite@7.0.8(@types/node@18.19.64)(yaml@2.8.3))
+
   packages/eslint-config:
     dependencies:
       '@darajs/prettier-config':
@@ -2182,6 +2200,37 @@ packages:
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
 
+  '@darajs/components@1.26.8':
+    resolution: {integrity: sha512-Ki5h2YcV2BId1je2C8Wtq8gOrrimrY4aB4BL9DUoqlHvCnJS5glusiM0P0hkZxlH5pmxySWhDLyIJqokg8l3uQ==}
+
+  '@darajs/core@1.26.8':
+    resolution: {integrity: sha512-1ok87KJwmbQQncYG+gYkSOTl9U/ETOhWM+Bux6vWTEPCFCQ0TQSeEXCoA4hLEPXSky3y1BDAY5ASKvTEqYGszg==}
+    engines: {node: '>=20.19.0'}
+
+  '@darajs/styled-components@1.26.8':
+    resolution: {integrity: sha512-JBojeABseXBz62fySEOXo2dRy7JJOaEY7hHTSqD6W7nVj+H0cVuzl6Bz6m9ecb0qW4nh1SFHl10fYJ7qRd8BQg==}
+
+  '@darajs/ui-causal-graph-editor@1.26.8':
+    resolution: {integrity: sha512-HTZebBOBxT9CcHI+9MnnYYc+//QRLpbdStI88HCiRnde/WU5+oqGvIzNnWhW32rGC+3PkjQf7L/3ZyIXUGllZg==}
+
+  '@darajs/ui-components@1.26.8':
+    resolution: {integrity: sha512-LBzVqeUIv/j+bUyq6ujCD9oHzxaS8bQzSkgUSX2EpJoECWC6Q2g4KLwscXFgrL3t32iB6iUIGDI8kRRcIKedTA==}
+
+  '@darajs/ui-hierarchy-viewer@1.26.8':
+    resolution: {integrity: sha512-GD8fRvc2smg7Z+qZ0JwN+rd2Ur5kmlC3ZfpqRMRLWeH4ZaQqi5T9eQaMj+5m9hI0bsDgQz/v0/gNb8HukAsk4Q==}
+
+  '@darajs/ui-icons@1.26.8':
+    resolution: {integrity: sha512-fI1HeUqxezSk0WM5XnbsYUc+nl5YrZUQKD/3pS1vorJp5BgLoEmuhFlJeUUxTbVrhWGg6SI9jYRV/25aF2VYqw==}
+
+  '@darajs/ui-notifications@1.26.8':
+    resolution: {integrity: sha512-1sQHB1TpJ7aJC6YOGwir5YJcnQrzclOp378J+wKRzOLozqlbnnLy5zC7jNExo6TibXIBuH57ZwXeWiRIwi9aDA==}
+
+  '@darajs/ui-utils@1.26.8':
+    resolution: {integrity: sha512-NVpaXfsElMM6pQwAZcdTthr7nHE6BBNeNslxsLEDA1PIkhMSA6bA+HJSeFW5OUl43esUpQL9Oe9PEJ7etE4asg==}
+
+  '@darajs/ui-widgets@1.26.8':
+    resolution: {integrity: sha512-J4xe4np5cRjffJdt0DD6HvqGBoBWjt+FY9TyQDrsZnLmKCqWau9tdrnhpKbi7Z0VdStwHnZqlfH83CEmFEZIPQ==}
+
   '@egjs/hammerjs@2.0.17':
     resolution: {integrity: sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==}
     engines: {node: '>=0.8.0'}
@@ -3863,6 +3912,15 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.19':
     resolution: {integrity: sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==}
 
+  '@rollup/plugin-inject@5.0.5':
+    resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
     engines: {node: '>=14.0.0'}
@@ -4884,12 +4942,18 @@ packages:
     resolution: {integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==}
     engines: {node: '>=8'}
 
+  asn1.js@4.10.1:
+    resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
+
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
+
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -5049,6 +5113,12 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
+
+  bn.js@5.2.3:
+    resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
+
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
@@ -5062,6 +5132,32 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  brorand@1.1.0:
+    resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+
+  browser-resolve@2.0.0:
+    resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
+
+  browserify-aes@1.2.0:
+    resolution: {integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==}
+
+  browserify-cipher@1.0.1:
+    resolution: {integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==}
+
+  browserify-des@1.0.2:
+    resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
+
+  browserify-rsa@4.1.1:
+    resolution: {integrity: sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==}
+    engines: {node: '>= 0.10'}
+
+  browserify-sign@4.2.6:
+    resolution: {integrity: sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==}
+    engines: {node: '>= 0.10'}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.24.2:
     resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
@@ -5085,12 +5181,18 @@ packages:
     resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
     engines: {node: '>=0.10'}
 
+  buffer-xor@1.0.3:
+    resolution: {integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   buffers@0.1.1:
     resolution: {integrity: sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==}
     engines: {node: '>=0.2.0'}
+
+  builtin-status-codes@3.0.0:
+    resolution: {integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==}
 
   byte-size@8.1.1:
     resolution: {integrity: sha512-tUkzZWK0M/qdoLEqikxBWe4kumyuwjl3HO6zHTr4yEI23EojPtLYXdG1+AQY7MN0cGyNDvEaJ8wiYQm6P2bPxg==}
@@ -5217,6 +5319,10 @@ packages:
   ci-info@4.3.1:
     resolution: {integrity: sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==}
     engines: {node: '>=8'}
+
+  cipher-base@1.0.7:
+    resolution: {integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==}
+    engines: {node: '>= 0.10'}
 
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
@@ -5362,8 +5468,14 @@ packages:
   confusing-browser-globals@1.0.11:
     resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
 
+  console-browserify@1.2.0:
+    resolution: {integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==}
+
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+
+  constants-browserify@1.0.0:
+    resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
 
   conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
@@ -5446,10 +5558,22 @@ packages:
     resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
     engines: {node: '>= 10'}
 
+  create-ecdh@4.0.4:
+    resolution: {integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==}
+
+  create-hash@1.2.0:
+    resolution: {integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==}
+
+  create-hmac@1.1.7:
+    resolution: {integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==}
+
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -5457,6 +5581,10 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crypto-browserify@3.12.1:
+    resolution: {integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==}
+    engines: {node: '>= 0.10'}
 
   css-color-keywords@1.0.0:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
@@ -5799,6 +5927,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+
   detect-indent@5.0.0:
     resolution: {integrity: sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==}
     engines: {node: '>=4'}
@@ -5822,6 +5953,9 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  diffie-hellman@5.0.3:
+    resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -5842,6 +5976,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  domain-browser@4.22.0:
+    resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
+    engines: {node: '>=10'}
 
   domexception@4.0.0:
     resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
@@ -5891,6 +6029,9 @@ packages:
 
   electron-to-chromium@1.5.51:
     resolution: {integrity: sha512-kKeWV57KSS8jH4alKt/jKnvHPmJgBxXzGUSbMd4eQF+iOsVPl7bz2KUmu6eo80eMP8wVioTfTyTzdMgM15WXNg==}
+
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -6232,6 +6373,9 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  evp_bytestokey@1.0.3:
+    resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==}
 
   exceljs@4.4.0:
     resolution: {integrity: sha512-XctvKaEMaj1Ii9oDOqbW/6e1gXknSY4g/aLCDicOXqBE4M0nRWkUu0PTp++UPNzoFY12BNHMfs/VadKIS6llvg==}
@@ -6733,6 +6877,17 @@ packages:
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
+  hash-base@3.0.5:
+    resolution: {integrity: sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==}
+    engines: {node: '>= 0.10'}
+
+  hash-base@3.1.2:
+    resolution: {integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==}
+    engines: {node: '>= 0.8'}
+
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
@@ -6760,6 +6915,9 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  hmac-drbg@1.0.1:
+    resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -6810,6 +6968,9 @@ packages:
   http-signature@1.3.6:
     resolution: {integrity: sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==}
     engines: {node: '>=0.10'}
+
+  https-browserify@1.0.0:
+    resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -7087,6 +7248,10 @@ packages:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
 
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
@@ -7233,6 +7398,10 @@ packages:
 
   ismobilejs@1.1.1:
     resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
+
+  isomorphic-timers-promises@1.0.1:
+    resolution: {integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==}
+    engines: {node: '>=10'}
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -7811,6 +7980,9 @@ packages:
   mathml-tag-names@2.1.3:
     resolution: {integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==}
 
+  md5.js@1.3.5:
+    resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
+
   mdast-util-find-and-replace@3.0.1:
     resolution: {integrity: sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==}
 
@@ -7968,6 +8140,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  miller-rabin@4.0.1:
+    resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==}
+    hasBin: true
+
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -7983,6 +8159,12 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
+  minimalistic-crypto-utils@1.0.1:
+    resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -8114,6 +8296,10 @@ packages:
 
   node-releases@2.0.18:
     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
+
+  node-stdlib-browser@1.3.1:
+    resolution: {integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==}
+    engines: {node: '>=10'}
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -8272,6 +8458,9 @@ packages:
     resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}
     engines: {node: '>=10'}
 
+  os-browserify@0.3.0:
+    resolution: {integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==}
+
   ospath@1.2.2:
     resolution: {integrity: sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==}
 
@@ -8389,6 +8578,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-asn1@5.1.9:
+    resolution: {integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==}
+    engines: {node: '>= 0.10'}
+
   parse-conflict-json@4.0.0:
     resolution: {integrity: sha512-37CN2VtcuvKgHUs8+0b1uJeEsbGn61GRHz469C94P5xiOoqpDYJYwjg4RY9Vmz39WyZAVkR5++nbJwLMIgOCnQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -8418,6 +8611,9 @@ packages:
 
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -8471,6 +8667,10 @@ packages:
   pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
 
+  pbkdf2@3.1.6:
+    resolution: {integrity: sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==}
+    engines: {node: '>= 0.10'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -8522,6 +8722,10 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
+
+  pkg-dir@5.0.0:
+    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==}
+    engines: {node: '>=10'}
 
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
@@ -8618,6 +8822,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   proggy@3.0.0:
     resolution: {integrity: sha512-QE8RApCM3IaRRxVzxrjbgNMpQEX6Wu0p0KBeoSiSEw5/bsGwZHsshF4LCxH2jp/r6BU+bqA3LrMDEYNfJnpD8Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -8664,8 +8872,14 @@ packages:
   psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
 
+  public-encrypt@4.0.3:
+    resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
+
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
+
+  punycode@1.4.1:
+    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -8686,6 +8900,10 @@ packages:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
 
+  querystring-es3@0.2.1:
+    resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
+    engines: {node: '>=0.4.x'}
+
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
@@ -8703,6 +8921,12 @@ packages:
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  randomfill@1.0.4:
+    resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==}
 
   react-aria-components@1.9.0:
     resolution: {integrity: sha512-7cOYxvODDPn8PlWh7eM6/hcydM9sem9PJfL9XD90hIUGfX/f5wMu4lplpjFVzkoCPe4UcOrqC77k3vpRN+1eaw==}
@@ -8807,6 +9031,16 @@ packages:
 
   react-router@7.12.0:
     resolution: {integrity: sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react-router@7.9.6:
+    resolution: {integrity: sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -9065,6 +9299,10 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  ripemd160@2.0.3:
+    resolution: {integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==}
+    engines: {node: '>= 0.8'}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -9173,6 +9411,11 @@ packages:
 
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  sha.js@2.4.12:
+    resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
 
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -9346,8 +9589,14 @@ packages:
       prettier:
         optional: true
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
+
+  stream-http@3.2.0:
+    resolution: {integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -9559,6 +9808,10 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  timers-browserify@2.0.12:
+    resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
+    engines: {node: '>=0.6.0'}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -9601,6 +9854,10 @@ packages:
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
+
+  to-buffer@1.2.2:
+    resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
+    engines: {node: '>= 0.4'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -9703,6 +9960,9 @@ packages:
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  tty-browserify@0.0.1:
+    resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
 
   tuf-js@4.1.0:
     resolution: {integrity: sha512-50QV99kCKH5P/Vs4E2Gzp7BopNV+KzTXqWeaxrfu5IQJBOULRsTIS9seSsOVT8ZnGXzCyx55nYWAi4qJzpZKEQ==}
@@ -9912,6 +10172,10 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  url@0.11.4:
+    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
+    engines: {node: '>= 0.4'}
+
   use-async-resource@2.2.2:
     resolution: {integrity: sha512-BsQX4TkM2Iw+fGYefz+wISDxD8A3MUBL/l5QlN9euCBTbPJwM7myvV4E4BS4lduPYpskahbiFZqdibk6BQxZeQ==}
     peerDependencies:
@@ -9930,6 +10194,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -9996,6 +10263,51 @@ packages:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite-plugin-node-polyfills@0.24.0:
+    resolution: {integrity: sha512-GA9QKLH+vIM8NPaGA+o2t8PDfFUl32J8rUp1zQfMKVJQiNkOX4unE51tR6ppl6iKw5yOrDAdSH7r/UIFLCVhLw==}
+    peerDependencies:
+      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  vite@7.0.8:
+    resolution: {integrity: sha512-cJBdq0/u+8rgstg9t7UkBilf8ipLmeXJO30NxD5HAHOivnj10ocV8YtR/XBvd2wQpN3TmcaxNKaHX3tN7o5F5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -10069,6 +10381,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  vm-browserify@1.1.2:
+    resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
   vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
@@ -11601,6 +11916,257 @@ snapshots:
       debug: 3.2.7(supports-color@8.1.1)
       lodash.once: 4.1.1
     transitivePeerDependencies:
+      - supports-color
+
+  '@darajs/components@1.26.8(@egjs/hammerjs@2.0.17)(@lezer/common@1.2.3)(@types/hoist-non-react-statics@3.3.5)(@types/node@18.19.64)(@types/react@18.2.60)(component-emitter@1.3.1)(keycharm@0.4.0)(react-is@18.3.1)(uuid@11.1.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))':
+    dependencies:
+      '@bokeh/bokehjs': 3.1.1
+      '@codemirror/autocomplete': 6.18.2(@codemirror/language@6.10.3)(@codemirror/state@6.4.1)(@codemirror/view@6.34.1)(@lezer/common@1.2.3)
+      '@codemirror/commands': 6.7.1
+      '@codemirror/lang-json': 6.0.1
+      '@codemirror/lang-markdown': 6.3.0
+      '@codemirror/lang-python': 6.1.6(@codemirror/view@6.34.1)
+      '@codemirror/lang-sql': 6.8.0(@codemirror/view@6.34.1)
+      '@codemirror/language': 6.10.3
+      '@codemirror/lint': 6.8.2
+      '@codemirror/search': 6.5.7
+      '@codemirror/state': 6.4.1
+      '@codemirror/theme-one-dark': 6.1.2
+      '@codemirror/view': 6.34.1
+      '@darajs/core': 1.26.8(@types/react@18.2.60)(react-is@18.3.1)
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@darajs/ui-causal-graph-editor': 1.26.8(@egjs/hammerjs@2.0.17)(@types/hoist-non-react-statics@3.3.5)(@types/node@18.19.64)(@types/react@18.2.60)(component-emitter@1.3.1)(keycharm@0.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(uuid@11.1.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      '@darajs/ui-components': 1.26.8(@types/react@18.2.60)(react-is@18.3.1)
+      '@darajs/ui-hierarchy-viewer': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-icons': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-utils': 1.26.8
+      '@lezer/highlight': 1.2.1
+      '@lezer/json': 1.0.3
+      '@lezer/lr': 1.4.2
+      '@popperjs/core': 2.4.0
+      '@vscode/codicons': 0.0.36
+      date-fns: 2.30.0
+      immer: 10.1.1
+      lodash: 4.18.1
+      nanoid: 3.3.11
+      polished: 4.3.1
+      prism-react-renderer: 1.3.5(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-virtualized-auto-sizer: 1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recoil: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rehype-raw: 6.1.1
+      unist-util-visit: 5.0.0
+      vfile: 6.0.1
+      vscode-languageserver-types: 3.17.5
+    transitivePeerDependencies:
+      - '@egjs/hammerjs'
+      - '@lezer/common'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - component-emitter
+      - keycharm
+      - react-is
+      - react-native
+      - supports-color
+      - uuid
+      - vis-util
+
+  '@darajs/core@1.26.8(@types/react@18.2.60)(react-is@18.3.1)':
+    dependencies:
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@darajs/ui-components': 1.26.8(@types/react@18.2.60)(react-is@18.3.1)
+      '@darajs/ui-notifications': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-utils': 1.26.8
+      '@fortawesome/fontawesome-free': 6.4.2
+      '@microsoft/fetch-event-source': 2.0.1
+      '@recoiljs/refine': 0.1.1
+      '@tanstack/query-core': 4.40.0
+      '@tanstack/react-query': 4.40.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      date-fns: 2.30.0
+      exceljs: 4.4.0
+      fast-json-patch: 3.1.1
+      file-saver: 2.0.5
+      jwt-decode: 4.0.0
+      lodash: 4.18.1
+      nanoid: 3.3.11
+      nprogress: 0.2.0
+      p-queue: 9.1.0
+      polished: 4.3.1
+      query-string: 7.1.3
+      react: 18.3.1
+      react-collapse: 5.1.1(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-error-boundary: 4.1.2(react@18.3.1)
+      react-router: 7.9.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-virtualized-auto-sizer: 1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-window: 1.8.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recoil: 0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recoil-sync: 0.2.0(recoil@0.7.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      rxjs: 7.8.2
+      styled-components: 5.3.11(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      typescript: 5.8.2
+      use-async-resource: 2.2.2(react@18.3.1)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-is
+      - react-native
+      - supports-color
+
+  '@darajs/styled-components@1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)':
+    dependencies:
+      polished: 4.3.1
+      styled-components: 5.3.11(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - react-is
+
+  '@darajs/ui-causal-graph-editor@1.26.8(@egjs/hammerjs@2.0.17)(@types/hoist-non-react-statics@3.3.5)(@types/node@18.19.64)(@types/react@18.2.60)(component-emitter@1.3.1)(keycharm@0.4.0)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(uuid@11.1.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))':
+    dependencies:
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@darajs/ui-components': 1.26.8(@types/react@18.2.60)(react-is@18.3.1)
+      '@darajs/ui-icons': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-notifications': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-utils': 1.26.8
+      '@darajs/ui-widgets': 1.26.8(@types/react@18.2.60)(react-is@18.3.1)
+      comlink: 4.4.1
+      cytoscape: 3.30.3
+      cytoscape-fcose: 2.2.0(cytoscape@3.30.3)
+      d3: 6.2.0
+      d3-dag: 1.1.0
+      d3-scale: 3.2.1
+      eventemitter3: 5.0.1
+      fontfaceobserver: 2.3.0
+      graphology: 0.25.4(graphology-types@0.24.7)
+      graphology-dag: 0.2.0(graphology-types@0.24.7)
+      graphology-layout: 0.6.1(graphology-types@0.24.7)
+      graphology-layout-forceatlas2: 0.10.1(graphology-types@0.24.7)
+      graphology-layout-noverlap: 0.4.2(graphology-types@0.24.7)
+      graphology-types: 0.24.7
+      immer: 10.1.1
+      lodash: 4.18.1
+      nanoid: 3.3.11
+      polished: 4.3.1
+      react: 18.3.1
+      react-dnd: 14.0.5(@types/hoist-non-react-statics@3.3.5)(@types/node@18.19.64)(@types/react@18.2.60)(react@18.3.1)
+      react-dnd-html5-backend: 14.1.0
+      svg-path-parser: 1.1.0
+      use-immer: 0.9.0(immer@10.1.1)(react@18.3.1)
+      vis-data: 7.1.9(uuid@11.1.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+      vis-network: 9.1.9(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)(keycharm@0.4.0)(uuid@11.1.0)(vis-data@7.1.9(uuid@11.1.0)(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1)))(vis-util@5.0.7(@egjs/hammerjs@2.0.17)(component-emitter@1.3.1))
+    transitivePeerDependencies:
+      - '@egjs/hammerjs'
+      - '@types/hoist-non-react-statics'
+      - '@types/node'
+      - '@types/react'
+      - component-emitter
+      - keycharm
+      - react-dom
+      - react-is
+      - supports-color
+      - uuid
+      - vis-util
+
+  '@darajs/ui-components@1.26.8(@types/react@18.2.60)(react-is@18.3.1)':
+    dependencies:
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@darajs/ui-icons': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-utils': 1.26.8
+      '@floating-ui/react': 0.26.27(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fortawesome/fontawesome-svg-core': 6.4.2
+      '@fortawesome/free-regular-svg-icons': 6.4.2
+      '@fortawesome/free-solid-svg-icons': 6.4.2
+      '@fortawesome/react-fontawesome': 0.2.2(@fortawesome/fontawesome-svg-core@6.4.2)(react@18.3.1)
+      '@headlessui-float/react': 0.15.0(@headlessui/react@1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@headlessui/react': 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      d3-array: 3.2.4
+      date-fns: 2.30.0
+      downshift: 7.6.2(react@18.3.1)
+      lodash: 4.18.1
+      memoize-one: 6.0.0
+      nanoid: 3.3.11
+      polished: 3.6.4
+      prism-react-renderer: 1.3.5(react@18.3.1)
+      react: 18.3.1
+      react-aria-components: 1.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-collapse: 5.1.1(react@18.3.1)
+      react-datepicker: 4.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-dropzone: 11.0.1(react@18.3.1)
+      react-markdown: 9.0.1(@types/react@18.2.60)(react@18.3.1)
+      react-table: 7.7.0(react@18.3.1)
+      react-table-sticky: 1.1.3
+      react-virtualized-auto-sizer: 1.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-window: 1.8.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      remark-gfm: 4.0.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-is
+      - supports-color
+
+  '@darajs/ui-hierarchy-viewer@1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)':
+    dependencies:
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@darajs/ui-utils': 1.26.8
+      d3: 6.2.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - react-dom
+      - react-is
+
+  '@darajs/ui-icons@1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)':
+    dependencies:
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@fortawesome/fontawesome-svg-core': 6.4.2
+      '@fortawesome/free-brands-svg-icons': 6.4.2
+      '@fortawesome/free-regular-svg-icons': 6.4.2
+      '@fortawesome/free-solid-svg-icons': 6.4.2
+      '@fortawesome/react-fontawesome': 0.2.2(@fortawesome/fontawesome-svg-core@6.4.2)(react@18.3.1)
+      '@mdi/js': 5.9.55
+      '@mdi/react': 1.4.0
+      react: 18.3.1
+    transitivePeerDependencies:
+      - react-dom
+      - react-is
+
+  '@darajs/ui-notifications@1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)':
+    dependencies:
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@darajs/ui-icons': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-utils': 1.26.8
+      lodash: 4.18.1
+      polished: 4.3.1
+      react: 18.3.1
+      rxjs: 7.8.2
+    transitivePeerDependencies:
+      - react-dom
+      - react-is
+
+  '@darajs/ui-utils@1.26.8':
+    dependencies:
+      d3-scale: 3.2.1
+      lodash: 4.18.1
+      nanoid: 3.3.11
+      react: 18.3.1
+      rxjs: 7.8.2
+      tinykeys: 3.0.0(patch_hash=6855931e9590b29110de8402432514ff7aa294934a067557e96dc7eb46f365e3)
+
+  '@darajs/ui-widgets@1.26.8(@types/react@18.2.60)(react-is@18.3.1)':
+    dependencies:
+      '@darajs/styled-components': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)
+      '@darajs/ui-components': 1.26.8(@types/react@18.2.60)(react-is@18.3.1)
+      '@darajs/ui-icons': 1.26.8(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)
+      '@darajs/ui-utils': 1.26.8
+      lodash: 4.18.1
+      nanoid: 3.3.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-is
       - supports-color
 
   '@egjs/hammerjs@2.0.17':
@@ -13777,6 +14343,14 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.19': {}
 
+  '@rollup/plugin-inject@5.0.5(rollup@4.60.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.2.0(rollup@4.60.2)
+      estree-walker: 2.0.2
+      magic-string: 0.30.17
+    optionalDependencies:
+      rollup: 4.60.2
+
   '@rollup/pluginutils@5.2.0(rollup@4.60.2)':
     dependencies:
       '@types/estree': 1.0.8
@@ -14585,6 +15159,18 @@ snapshots:
   '@unrs/rspack-resolver-binding-win32-x64-msvc@1.1.2':
     optional: true
 
+  '@vitejs/plugin-react@4.6.0(vite@7.0.8(@types/node@18.19.64)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.19
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.0.8(@types/node@18.19.64)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-react@4.6.0(vite@7.3.2(@types/node@18.19.64)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.28.0
@@ -14898,11 +15484,25 @@ snapshots:
 
   arrify@2.0.1: {}
 
+  asn1.js@4.10.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   asn1@0.2.6:
     dependencies:
       safer-buffer: 2.1.2
 
   assert-plus@1.0.0: {}
+
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.8
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
 
   assertion-error@2.0.1: {}
 
@@ -15124,6 +15724,10 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  bn.js@4.12.3: {}
+
+  bn.js@5.2.3: {}
+
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -15140,6 +15744,56 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  brorand@1.1.0: {}
+
+  browser-resolve@2.0.0:
+    dependencies:
+      resolve: 1.22.8
+
+  browserify-aes@1.2.0:
+    dependencies:
+      buffer-xor: 1.0.3
+      cipher-base: 1.0.7
+      create-hash: 1.2.0
+      evp_bytestokey: 1.0.3
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  browserify-cipher@1.0.1:
+    dependencies:
+      browserify-aes: 1.2.0
+      browserify-des: 1.0.2
+      evp_bytestokey: 1.0.3
+
+  browserify-des@1.0.2:
+    dependencies:
+      cipher-base: 1.0.7
+      des.js: 1.1.0
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  browserify-rsa@4.1.1:
+    dependencies:
+      bn.js: 5.2.3
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+
+  browserify-sign@4.2.6:
+    dependencies:
+      bn.js: 5.2.3
+      browserify-rsa: 4.1.1
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      elliptic: 6.6.1
+      inherits: 2.0.4
+      parse-asn1: 5.1.9
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.24.2:
     dependencies:
@@ -15162,12 +15816,16 @@ snapshots:
 
   buffer-indexof-polyfill@1.0.2: {}
 
+  buffer-xor@1.0.3: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
   buffers@0.1.1: {}
+
+  builtin-status-codes@3.0.0: {}
 
   byte-size@8.1.1: {}
 
@@ -15302,6 +15960,12 @@ snapshots:
 
   ci-info@4.3.1: {}
 
+  cipher-base@1.0.7:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
   cjs-module-lexer@1.4.1: {}
 
   classnames@2.5.1: {}
@@ -15429,7 +16093,11 @@ snapshots:
 
   confusing-browser-globals@1.0.11: {}
 
+  console-browserify@1.2.0: {}
+
   console-control-strings@1.1.0: {}
+
+  constants-browserify@1.0.0: {}
 
   conventional-changelog-angular@7.0.0:
     dependencies:
@@ -15535,6 +16203,28 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.2
 
+  create-ecdh@4.0.4:
+    dependencies:
+      bn.js: 4.12.3
+      elliptic: 6.6.1
+
+  create-hash@1.2.0:
+    dependencies:
+      cipher-base: 1.0.7
+      inherits: 2.0.4
+      md5.js: 1.3.5
+      ripemd160: 2.0.3
+      sha.js: 2.4.12
+
+  create-hmac@1.1.7:
+    dependencies:
+      cipher-base: 1.0.7
+      create-hash: 1.2.0
+      inherits: 2.0.4
+      ripemd160: 2.0.3
+      safe-buffer: 5.2.1
+      sha.js: 2.4.12
+
   create-jest@29.7.0(@types/node@18.19.64):
     dependencies:
       '@jest/types': 29.6.3
@@ -15550,6 +16240,8 @@ snapshots:
       - supports-color
       - ts-node
 
+  create-require@1.1.1: {}
+
   crelt@1.0.6: {}
 
   cross-spawn@7.0.6:
@@ -15557,6 +16249,21 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crypto-browserify@3.12.1:
+    dependencies:
+      browserify-cipher: 1.0.1
+      browserify-sign: 4.2.6
+      create-ecdh: 4.0.4
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      diffie-hellman: 5.0.3
+      hash-base: 3.0.5
+      inherits: 2.0.4
+      pbkdf2: 3.1.6
+      public-encrypt: 4.0.3
+      randombytes: 2.1.0
+      randomfill: 1.0.4
 
   css-color-keywords@1.0.0: {}
 
@@ -15976,6 +16683,11 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  des.js@1.1.0:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   detect-indent@5.0.0: {}
 
   detect-newline@3.1.0: {}
@@ -15989,6 +16701,12 @@ snapshots:
   diff-sequences@27.5.1: {}
 
   diff-sequences@29.6.3: {}
+
+  diffie-hellman@5.0.3:
+    dependencies:
+      bn.js: 4.12.3
+      miller-rabin: 4.0.1
+      randombytes: 2.1.0
 
   dir-glob@3.0.1:
     dependencies:
@@ -16011,6 +16729,8 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  domain-browser@4.22.0: {}
 
   domexception@4.0.0:
     dependencies:
@@ -16061,6 +16781,16 @@ snapshots:
       jake: 10.9.2
 
   electron-to-chromium@1.5.51: {}
+
+  elliptic@6.6.1:
+    dependencies:
+      bn.js: 4.12.3
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
 
   emittery@0.13.1: {}
 
@@ -16630,6 +17360,11 @@ snapshots:
 
   events@3.3.0: {}
 
+  evp_bytestokey@1.0.3:
+    dependencies:
+      md5.js: 1.3.5
+      safe-buffer: 5.2.1
+
   exceljs@4.4.0:
     dependencies:
       archiver: 5.3.2
@@ -17193,6 +17928,23 @@ snapshots:
 
   has-unicode@2.0.1: {}
 
+  hash-base@3.0.5:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
+  hash-base@3.1.2:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
+
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
@@ -17268,6 +18020,12 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  hmac-drbg@1.0.1:
+    dependencies:
+      hash.js: 1.1.7
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -17320,6 +18078,8 @@ snapshots:
       assert-plus: 1.0.0
       jsprim: 2.0.2
       sshpk: 1.18.0
+
+  https-browserify@1.0.0: {}
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -17590,6 +18350,11 @@ snapshots:
 
   is-map@2.0.3: {}
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+
   is-negative-zero@2.0.3: {}
 
   is-node-process@1.2.0: {}
@@ -17707,6 +18472,8 @@ snapshots:
   isexe@4.0.0: {}
 
   ismobilejs@1.1.1: {}
+
+  isomorphic-timers-promises@1.0.1: {}
 
   isstream@0.1.2: {}
 
@@ -18599,6 +19366,12 @@ snapshots:
 
   mathml-tag-names@2.1.3: {}
 
+  md5.js@1.3.5:
+    dependencies:
+      hash-base: 3.0.5
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+
   mdast-util-find-and-replace@3.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -18987,6 +19760,11 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  miller-rabin@4.0.1:
+    dependencies:
+      bn.js: 4.12.3
+      brorand: 1.1.0
+
   mime-db@1.52.0: {}
 
   mime-types@2.1.35:
@@ -18996,6 +19774,10 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   min-indent@1.0.1: {}
+
+  minimalistic-assert@1.0.1: {}
+
+  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -19172,6 +19954,36 @@ snapshots:
   node-machine-id@1.1.12: {}
 
   node-releases@2.0.18: {}
+
+  node-stdlib-browser@1.3.1:
+    dependencies:
+      assert: 2.1.0
+      browser-resolve: 2.0.0
+      browserify-zlib: 0.2.0
+      buffer: 5.7.1
+      console-browserify: 1.2.0
+      constants-browserify: 1.0.0
+      create-require: 1.1.1
+      crypto-browserify: 3.12.1
+      domain-browser: 4.22.0
+      events: 3.3.0
+      https-browserify: 1.0.0
+      isomorphic-timers-promises: 1.0.1
+      os-browserify: 0.3.0
+      path-browserify: 1.0.1
+      pkg-dir: 5.0.0
+      process: 0.11.10
+      punycode: 1.4.1
+      querystring-es3: 0.2.1
+      readable-stream: 3.6.2
+      stream-browserify: 3.0.0
+      stream-http: 3.2.0
+      string_decoder: 1.3.0
+      timers-browserify: 2.0.12
+      tty-browserify: 0.0.1
+      url: 0.11.4
+      util: 0.12.5
+      vm-browserify: 1.1.2
 
   nopt@8.1.0:
     dependencies:
@@ -19413,6 +20225,8 @@ snapshots:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
 
+  os-browserify@0.3.0: {}
+
   ospath@1.2.2: {}
 
   outvariant@1.4.3: {}
@@ -19549,6 +20363,14 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-asn1@5.1.9:
+    dependencies:
+      asn1.js: 4.10.1
+      browserify-aes: 1.2.0
+      evp_bytestokey: 1.0.3
+      pbkdf2: 3.1.6
+      safe-buffer: 5.2.1
+
   parse-conflict-json@4.0.0:
     dependencies:
       json-parse-even-better-errors: 4.0.0
@@ -19594,6 +20416,8 @@ snapshots:
     dependencies:
       entities: 4.5.0
 
+  path-browserify@1.0.1: {}
+
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
@@ -19631,6 +20455,15 @@ snapshots:
   pause-stream@0.0.11:
     dependencies:
       through: 2.3.8
+
+  pbkdf2@3.1.6:
+    dependencies:
+      create-hash: 1.2.0
+      create-hmac: 1.1.7
+      ripemd160: 2.0.3
+      safe-buffer: 5.2.1
+      sha.js: 2.4.12
+      to-buffer: 1.2.2
 
   pend@1.2.0: {}
 
@@ -19674,6 +20507,10 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  pkg-dir@5.0.0:
+    dependencies:
+      find-up: 5.0.0
 
   plimit-lit@1.6.1:
     dependencies:
@@ -19763,6 +20600,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  process@0.11.10: {}
+
   proggy@3.0.0: {}
 
   promise-all-reject-late@1.0.1: {}
@@ -19803,10 +20642,21 @@ snapshots:
 
   psl@1.9.0: {}
 
+  public-encrypt@4.0.3:
+    dependencies:
+      bn.js: 4.12.3
+      browserify-rsa: 4.1.1
+      create-hash: 1.2.0
+      parse-asn1: 5.1.9
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
+
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
+
+  punycode@1.4.1: {}
 
   punycode@2.3.1: {}
 
@@ -19825,6 +20675,8 @@ snapshots:
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
 
+  querystring-es3@0.2.1: {}
+
   querystringify@2.2.0: {}
 
   queue-lit@1.5.2: {}
@@ -19834,6 +20686,15 @@ snapshots:
   quick-lru@4.0.1: {}
 
   quick-lru@5.1.1: {}
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  randomfill@1.0.4:
+    dependencies:
+      randombytes: 2.1.0
+      safe-buffer: 5.2.1
 
   react-aria-components@1.9.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -20025,6 +20886,14 @@ snapshots:
   react-refresh@0.17.0: {}
 
   react-router@7.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.0.2
+      react: 18.3.1
+      set-cookie-parser: 2.7.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-router@7.9.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       cookie: 1.0.2
       react: 18.3.1
@@ -20358,6 +21227,11 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
+  ripemd160@2.0.3:
+    dependencies:
+      hash-base: 3.1.2
+      inherits: 2.0.4
+
   rollup@4.60.2:
     dependencies:
       '@types/estree': 1.0.8
@@ -20506,6 +21380,12 @@ snapshots:
       es-object-atoms: 1.1.1
 
   setimmediate@1.0.5: {}
+
+  sha.js@2.4.12:
+    dependencies:
+      inherits: 2.0.4
+      safe-buffer: 5.2.1
+      to-buffer: 1.2.2
 
   shallowequal@1.1.0: {}
 
@@ -20715,9 +21595,21 @@ snapshots:
       - utf-8-validate
       - vite
 
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   stream-combiner@0.0.4:
     dependencies:
       duplexer: 0.1.2
+
+  stream-http@3.2.0:
+    dependencies:
+      builtin-status-codes: 3.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      xtend: 4.0.2
 
   strict-event-emitter@0.5.1: {}
 
@@ -21060,6 +21952,10 @@ snapshots:
 
   through@2.3.8: {}
 
+  timers-browserify@2.0.12:
+    dependencies:
+      setimmediate: 1.0.5
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -21092,6 +21988,12 @@ snapshots:
   tmp@0.2.6: {}
 
   tmpl@1.0.5: {}
+
+  to-buffer@1.2.2:
+    dependencies:
+      isarray: 2.0.5
+      safe-buffer: 5.2.1
+      typed-array-buffer: 1.0.3
 
   to-fast-properties@2.0.0: {}
 
@@ -21201,6 +22103,8 @@ snapshots:
     dependencies:
       tslib: 1.14.1
       typescript: 5.8.2
+
+  tty-browserify@0.0.1: {}
 
   tuf-js@4.1.0:
     dependencies:
@@ -21452,6 +22356,11 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  url@0.11.4:
+    dependencies:
+      punycode: 1.4.1
+      qs: 6.15.2
+
   use-async-resource@2.2.2(react@18.3.1):
     dependencies:
       object-hash: 2.2.0
@@ -21467,6 +22376,14 @@ snapshots:
       react: 18.3.1
 
   util-deprecate@1.0.2: {}
+
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.1.1
+      is-generator-function: 1.1.0
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.19
 
   uuid@11.1.0: {}
 
@@ -21559,6 +22476,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-plugin-node-polyfills@0.24.0(rollup@4.60.2)(vite@7.0.8(@types/node@18.19.64)(yaml@2.8.3)):
+    dependencies:
+      '@rollup/plugin-inject': 5.0.5(rollup@4.60.2)
+      node-stdlib-browser: 1.3.1
+      vite: 7.0.8(@types/node@18.19.64)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - rollup
+
+  vite@7.0.8(@types/node@18.19.64)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.25.8
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.12
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 18.19.64
+      fsevents: 2.3.3
+      yaml: 2.8.3
+
   vite@7.3.2(@types/node@18.19.64)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
@@ -21620,6 +22558,8 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vm-browserify@1.1.2: {}
 
   vscode-languageserver-types@3.17.5: {}
 


### PR DESCRIPTION
## Motivation and Context

When an `@action` handler calls `ctx.update()` multiple times, each call sends a separate WebSocket message to the client. Each message triggers an independent React re-render cycle. For actions that update N variables, this means N full re-render passes before the UI settles. With large component trees this can add up to seconds of wasted client-side work, and DerivedVariables that depend on multiple updated variables resolve prematurely with partially-updated state, causing wasted server round-trips.

This PR implements implicit batching so that all actions from a single `@action` execution are collected and applied as one atomic React render on the client. The mental model is simple: everything is delivered at the end of the action, unless you call `ctx.flush()`.

## Implementation Description

**Server side:**

- Added `BatchStart` / `BatchEnd` `ActionImpl` marker subclasses that serialize as regular action messages (`__typename: 'ActionImpl'`, `name: 'BatchStart'` / `'BatchEnd'`).
- `_stream_action` now sends a `BatchStart` before running the handler and a `BatchEnd` after (just before the existing `None` sentinel). This wraps every action execution in an implicit batch with zero code changes required by app developers. A `batch` parameter (default `True`) controls whether framing markers are emitted.
- Added `ctx.flush()` on `ActionCtx` as an escape hatch: it sends `BatchEnd` + `BatchStart` to end the current batch early and start a new one, for actions that need progressive UI feedback (e.g. showing a loading spinner before slow work).
- `execute_action_sync` (used for route `on_load` actions) passes `batch=False` since its results are accumulated and sent in one HTTP response, making client-side batch framing unnecessary.

**Client side:**

* The `executeAction` function in `use-action.tsx` now recognises batch framing markers. Between `BatchStart` and `BatchEnd`, ActionImpl objects are **buffered** without executing their handlers. Nothing runs until `BatchEnd`.
* On `BatchEnd`, all buffered handlers are executed sequentially with a batching `ActionContext`. Handlers' `set` / `reset` calls are applied to a transaction snapshot (via Recoil's `snapshot.map`) rather than to the live store. Handlers read from this transaction snapshot, so reads within the batch see writes from earlier handlers -- including correct defaults after `reset` (since `MutableSnapshot.reset` knows atom defaults natively). `eventBus.publish` calls are deferred.
* After all handlers have run, final values of touched atoms are read from the transaction snapshot and committed atomically via a single `transact_UNSTABLE` call. This avoids `gotoSnapshot` which would replace the entire store state and could clobber concurrent modifications (e.g. server variable pushes, stream updates). Deferred callbacks (event bus publishes) run after the commit.
* All action types are batched uniformly -- there is no distinction between "state-mutating" and "side-effect" actions. This keeps the mental model simple ("everything is batched") and ensures custom `ActionImpl` subclasses are also covered.

**Why implicit batching is safe:** `ctx.update()` is fire-and-forget with no client acknowledgement, DerivedVariable values are resolved before the action runs (not during), and the server has no access to client-side Recoil state. No existing action can depend on intermediate client-side reactions to its own prior updates.

## Any new dependencies Introduced

No

## How Has This Been Tested?

- 4 new backend integration tests covering batch framing, marker filtering, `ctx.flush()` splitting, and empty batches
- All 728 existing Python tests pass (including updated `test_websocket.py::test_action_handler_error`)
- TypeScript lint and type-check pass (`pnpm lerna run lint --scope=@darajs/core`)

## PR Checklist

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.