### PR TITLE
Feat: DO-11819 - add HTTP request metrics middleware

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## 1.28.7
+
+- Extended metrics to include HTTP request stats
+
 ## 1.28.6
 
 - Added implicit batching for `@action` handlers: all actions within a single action execution are now collected and applied atomically, so dependent `DerivedVariable` chains only recompute once against the final consistent state.

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -267,6 +267,12 @@ def _start_application(config: Configuration):
     if os.environ.get('DARA_TEST_FLAG', None) is None:
         app.add_middleware(LoggingMiddleware, logger=http_logger)
 
+    # Setup Prometheus HTTP request metrics middleware
+    if os.environ.get('DARA_DISABLE_METRICS') != 'TRUE' and os.environ.get('DARA_TEST_FLAG', None) is None:
+        from dara.core.metrics.http import PrometheusMiddleware
+
+        app.add_middleware(PrometheusMiddleware)
+
     # Add custom middlewares
     for middleware in config.middlewares:
         app.user_middleware.insert(0, middleware)

--- a/packages/dara-core/dara/core/metrics/__init__.py
+++ b/packages/dara-core/dara/core/metrics/__init__.py
@@ -16,7 +16,14 @@ limitations under the License.
 """
 
 from dara.core.metrics.cache import CACHE_METRICS_TRACKER
+from dara.core.metrics.http import HTTP_REQUEST_DURATION_SECONDS, HTTP_REQUESTS_TOTAL
 from dara.core.metrics.runtime import RUNTIME_METRICS_TRACKER
 from dara.core.metrics.utils import total_size
 
-__all__ = ['CACHE_METRICS_TRACKER', 'RUNTIME_METRICS_TRACKER', 'total_size']
+__all__ = [
+    'CACHE_METRICS_TRACKER',
+    'HTTP_REQUEST_DURATION_SECONDS',
+    'HTTP_REQUESTS_TOTAL',
+    'RUNTIME_METRICS_TRACKER',
+    'total_size',
+]

--- a/packages/dara-core/dara/core/metrics/http.py
+++ b/packages/dara-core/dara/core/metrics/http.py
@@ -18,7 +18,7 @@ limitations under the License.
 import time
 
 from prometheus_client import Counter, Histogram
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -43,7 +43,7 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
     label to avoid unbounded cardinality from dynamic path segments.
     """
 
-    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.monotonic()
         response = await call_next(request)
         duration = time.monotonic() - start

--- a/packages/dara-core/dara/core/metrics/http.py
+++ b/packages/dara-core/dara/core/metrics/http.py
@@ -1,0 +1,67 @@
+"""
+Copyright 2023 Impulse Innovations Limited
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+
+from prometheus_client import Counter, Histogram
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+HTTP_REQUESTS_TOTAL = Counter(
+    'http_requests_total',
+    'Total HTTP requests',
+    labelnames=['method', 'status', 'path'],
+)
+
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    'http_request_duration_seconds',
+    'HTTP request duration in seconds',
+    labelnames=['method', 'status', 'path'],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, float('inf')),
+)
+
+
+class PrometheusMiddleware(BaseHTTPMiddleware):
+    """Middleware that records HTTP request count and duration as Prometheus metrics.
+
+    Uses the matched Starlette route pattern (e.g. ``/api/components/{uid}``) for the ``path``
+    label to avoid unbounded cardinality from dynamic path segments.
+    """
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        start = time.monotonic()
+        response = await call_next(request)
+        duration = time.monotonic() - start
+
+        # Use the matched route pattern to keep label cardinality bounded
+        route = request.scope.get('route')
+        path = route.path if route is not None and hasattr(route, 'path') else request.url.path
+
+        HTTP_REQUESTS_TOTAL.labels(
+            method=request.method,
+            status=str(response.status_code),
+            path=path,
+        ).inc()
+
+        HTTP_REQUEST_DURATION_SECONDS.labels(
+            method=request.method,
+            status=str(response.status_code),
+            path=path,
+        ).observe(duration)
+
+        return response


### PR DESCRIPTION
## Motivation and Context

Dara already exposes Prometheus metrics on port 10000 (task runtimes, DV runtimes, cache size), but has no HTTP request-level metrics. Adding `http_requests_total` and `http_request_duration_seconds` enables the observability service to surface request rate, error rate, and latency for deployed Dara apps.

## Implementation Description

- **New `metrics/http.py`** — defines `http_requests_total` (Counter) and `http_request_duration_seconds` (Histogram) with labels `method`, `status`, `path`. A `PrometheusMiddleware` (Starlette `BaseHTTPMiddleware`) wraps every request and records both metrics. Uses the matched route pattern (e.g. `/api/components/{uid}`) for the `path` label to avoid unbounded cardinality.

- **Middleware registration in `main.py`** — gated by the same conditions as the existing metrics server (`DARA_DISABLE_METRICS != TRUE` and `DARA_TEST_FLAG` not set), so tests are unaffected.

- **Exports added to `metrics/__init__.py`** — `HTTP_REQUESTS_TOTAL` and `HTTP_REQUEST_DURATION_SECONDS` are available for downstream code if needed.

No changes to the existing `/status` endpoint, metrics server startup, or `prometheus_client` dependency — all already in place.

> [!NOTE]
> Not sure if we need a changelog update for this sort of change

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- Targeted test suite passes (70 passed). The middleware is not registered during tests (`DARA_TEST_FLAG` guard), so existing tests are unaffected.
- Import verification: `from dara.core.metrics.http import PrometheusMiddleware` succeeds.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

N/A — backend-only change. Metrics are visible via `curl http://localhost:10000/metrics`.
