### PR TITLE
Refactor: DO-12260 enable TypeScript strict mode

### DIFF
--- a/packages/dara-components/js/smart/ui-code-editor/code-editor.tsx
+++ b/packages/dara-components/js/smart/ui-code-editor/code-editor.tsx
@@ -256,7 +256,7 @@ const UiCodeEditor: FunctionComponent<CodeEditorProps> = ({
     const enableGoToDef = React.useMemo(() => onGoToDefinition !== undefined, [onGoToDefinition]);
     const goToDef = useLatestCallback(onGoToDefinition ?? noop);
 
-    useOnClickOutside(ref.current!, () => {
+    useOnClickOutside(ref.current, () => {
         closeArgumentsHintsTooltip(viewRef.current!);
     });
 

--- a/packages/dara-core/dara/core/js_tooling/statics/tsconfig.json
+++ b/packages/dara-core/dara/core/js_tooling/statics/tsconfig.json
@@ -12,7 +12,7 @@
         "preserveSymlinks": true,
         "skipLibCheck": true,
         "sourceMap": true,
-        "strict": false,
+        "strict": true,
         "target": "es2015",
     }
 }

--- a/packages/styled-components/tsconfig.json
+++ b/packages/styled-components/tsconfig.json
@@ -12,7 +12,7 @@
         "rootDir": "./src/",
         "skipLibCheck": true,
         "sourceMap": true,
-        "strict": false,
+        "strict": true,
         "target": "es2015",
     }
 }

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -146,7 +146,7 @@ export interface CausalGraphEditorProps extends Settings {
     /** Any extra sections to display in the side panel on edge click */
     edgeExtrasContent?: React.ReactElement;
     /** The backend data */
-    graphData: CausalGraph;
+    graphData?: CausalGraph;
     /** Graph layout to use */
     graphLayout: GraphLayout;
     /** Optional initial constraints to show in edge encoder mode */
@@ -156,9 +156,9 @@ export interface CausalGraphEditorProps extends Settings {
     /** Array of node names that cannot be removed */
     nonRemovableNodes?: Array<string>;
     /** Event handler for clicking on an edge */
-    onClickEdge?: (edge: CausalGraphEdge | null) => void | Promise<void>;
+    onClickEdge?: (edge: CausalGraphEdge) => void | Promise<void>;
     /** Event handler for clicking on a node */
-    onClickNode?: (node: CausalGraphNode | null) => void | Promise<void>;
+    onClickNode?: (node: CausalGraphNode) => void | Promise<void>;
     /** Handler called when constraints are update in edge encoder mode */
     onEdgeConstraintsUpdate?: (constraints: EdgeConstraint[]) => void | Promise<void>;
     /** onUpdate handler for live updating the edited graph */
@@ -191,7 +191,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     const canvasParentRef = React.useRef<HTMLDivElement>(null);
 
     const { state, api, layout } = useCausalGraphEditor(
-        props.graphData,
+        props.graphData as CausalGraph,
         props.editorMode,
         props.graphLayout,
         props.availableInputs
@@ -220,7 +220,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         onSetFocus,
     } = useRenderEngine({
         constraints: props.initialConstraints,
-        editable: props.editable ?? false,
+        editable: props.editable as boolean,
         editorMode: state.editorMode,
         errorHandler: handleError,
         graph: state.graph,
@@ -258,7 +258,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
     // track node highlighted by search separately
     // this is used instead of selection when there is no concept of selection, i.e. not editable or allowSelectionWhenNotEditable
-    const [highlightedNode, setHighlightedNode] = useState<string | null>(null);
+    const [highlightedNode, setHighlightedNode] = useState<string | null>();
 
     useUpdateEffect(() => {
         // Update visual selection when a node is highlighted
@@ -278,7 +278,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
                 serializedNode = serializeGraphNode(state.graph.getNodeAttributes(selectedNode));
             }
 
-            props.onClickNode(serializedNode);
+            props.onClickNode(serializedNode as CausalGraphNode);
         }
     }, [selectedNode]);
 
@@ -300,13 +300,13 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
                 );
             }
 
-            props.onClickEdge(serializedEdge);
+            props.onClickEdge(serializedEdge as CausalGraphEdge);
         }
     }, [selectedEdge]);
 
     // constraints
     const { constraints, addConstraint, updateConstraint, removeConstraint, reverseConstraint } =
-        useEdgeConstraintEncoder(props.initialConstraints ?? [], props.onEdgeConstraintsUpdate);
+        useEdgeConstraintEncoder(props.initialConstraints as EdgeConstraint[], props.onEdgeConstraintsUpdate);
 
     const selectedConstraint = useMemo(() => {
         if (state.editorMode === EditorMode.EDGE_ENCODER && selectedEdge) {
@@ -322,14 +322,11 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     // deletion
 
     function onRemoveNode(): void {
-        if (!selectedNode) {
-            return;
-        }
         if (layoutHasGroup) {
             const layoutGroup = (layout as GraphLayoutWithGrouping).group!;
             const groupsObject = getGroupToNodesMap(state.graph.nodes(), layoutGroup, state.graph);
             const nodesToGroups = getNodeToGroupMap(state.graph.nodes(), layoutGroup, state.graph);
-            const group = nodesToGroups[selectedNode];
+            const group = nodesToGroups[selectedNode!];
             if (groupsObject[group]?.length === 1) {
                 props.onNotify?.({
                     key: 'delete-group',
@@ -340,27 +337,22 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
                 return;
             }
         }
-        api.removeNode(selectedNode);
+        api.removeNode(selectedNode!);
         setSelectedNode(null);
     }
 
     function onRemoveConstraint(): void {
         // Remove constraint that's selected
-        if (selectedConstraint) {
-            removeConstraint(selectedConstraint.id);
-        }
+        removeConstraint(selectedConstraint!.id);
     }
 
     function onConfirmRemoveEdge(): void {
-        if (!selectedEdge) {
-            return;
-        }
         // In encoder mode, remove related constraint
         if (state.editorMode === EditorMode.EDGE_ENCODER) {
             onRemoveConstraint();
         }
 
-        api.removeEdge(selectedEdge);
+        api.removeEdge(selectedEdge!);
         setSelectedEdge(null);
     }
 
@@ -373,19 +365,16 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     );
 
     function onRemoveEdge(): void {
-        if (!selectedEdge) {
-            return;
-        }
-        const edgeAttributes = state.graph.getEdgeAttributes(...selectedEdge);
+        const edgeAttributes = state.graph.getEdgeAttributes(...selectedEdge!);
 
         if (edgeAttributes['meta.rendering_properties.forced'] === true) {
-            askToRemoveEdge(selectedEdge);
+            askToRemoveEdge(selectedEdge!);
         } else {
             onConfirmRemoveEdge();
         }
     }
 
-    let onDelete: (() => void) | undefined;
+    let onDelete: (() => void) | null = null;
 
     if (selectedEdge) {
         onDelete = onRemoveEdge;
@@ -442,17 +431,14 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     }
 
     function onReverseEdge(): void {
-        if (!selectedEdge) {
-            return;
-        }
-        const [source, target] = selectedEdge;
+        const [source, target] = selectedEdge!;
 
         // Skip if a cycle would be created in default mode
         if (props.editorMode === EditorMode.DEFAULT) {
             // This creates a clone of the graph without the reversed edge so we can properly check if the reverse would create a cycle
             const graphCopy = state.graph.copy();
             graphCopy.dropEdge(source, target);
-            if (willCreateCycle(graphCopy, selectedEdge)) {
+            if (willCreateCycle(graphCopy, selectedEdge!)) {
                 props.onNotify?.({
                     key: 'reverse-edge-cycle',
                     message: 'Could not reverse the edge as it would create a cycle',
@@ -464,7 +450,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         }
 
         // Reverse the edge
-        api.reverseEdge(selectedEdge);
+        api.reverseEdge(selectedEdge!);
 
         // Update selection to the new edge
         setSelectedEdge([target, source]);
@@ -473,16 +459,11 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     function onReverseConstraint(): void {
         setSelectedEdge(null);
 
-        if (selectedConstraint) {
-            reverseConstraint(selectedConstraint);
-        }
+        reverseConstraint(selectedConstraint!);
     }
 
     function confirmDirection(reverse: boolean): void {
-        if (!selectedEdge) {
-            return;
-        }
-        api.updateEdgeType(selectedEdge, EdgeType.DIRECTED_EDGE);
+        api.updateEdgeType(selectedEdge!, EdgeType.DIRECTED_EDGE);
 
         if (reverse) {
             if (state.editorMode === EditorMode.EDGE_ENCODER) {
@@ -524,7 +505,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         setTooltipContent(
             getTooltipContent(
                 nodeId,
-                nodeAttributes['meta.rendering_properties.tooltip'] ?? '',
+                nodeAttributes['meta.rendering_properties.tooltip'] as string,
                 theme,
                 nodeAttributes['meta.rendering_properties.label'],
                 props.tooltipSize
@@ -533,7 +514,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     });
 
     useEngineEvent('nodeMouseout', () => {
-        setTooltipContent(undefined);
+        setTooltipContent(null);
     });
 
     useEngineEvent('edgeMouseover', (event, edgeKey) => {
@@ -550,9 +531,9 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
         const edgeTooltipContent = getTooltipContent(
             `${sourceLabel} ${tooltipArrow} ${targetLabel}`,
-            edgeAttributes['meta.rendering_properties.tooltip'] ?? '',
+            edgeAttributes['meta.rendering_properties.tooltip'] as string,
             theme,
-            undefined,
+            null as unknown as string,
             props.tooltipSize
         );
 
@@ -664,7 +645,9 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     const { currentSearchNode, onNextSearchResult, onPrevSearchResult, onSearchBarChange, searchResults } = useSearch({
         graph: state.graph,
         // when selection is possible use selectedNode, otherwise use highlightedNode
-        setSelectedNode: props.editable || props.allowSelectionWhenNotEditable ? setSelectedNode : setHighlightedNode,
+        setSelectedNode: (props.editable || props.allowSelectionWhenNotEditable ?
+            setSelectedNode
+        :   setHighlightedNode) as React.Dispatch<React.SetStateAction<string | null>>,
     });
     useEffect(() => {
         onSearchResults(searchResults);
@@ -704,7 +687,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
     // dragging
     const { dragMode, setDragMode } = useDragMode(
-        props.editable ?? false,
+        props.editable as boolean,
         !props.disableEdgeAdd,
         layout.supportsDrag,
         onSetDragMode
@@ -735,7 +718,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     }
 
     // if the graph is not editable and there are no nodes, there's nothing to display so show a message
-    if (!props.editable && Object.keys(props.graphData?.nodes).length === 0) {
+    if (!props.editable && Object.keys(props.graphData?.nodes as object).length === 0) {
         return (
             <Wrapper style={props.style} id={props.id}>
                 <Center style={{ height: 300 }}>The CausalGraph structure is empty.</Center>
@@ -843,8 +826,8 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
                                     editable: props.editable,
                                     graphState: state,
                                     onUpdateConstraint: updateConstraint,
-                                    selectedEdge: selectedEdge ?? undefined,
-                                    selectedNode: selectedNode ?? undefined,
+                                    selectedEdge,
+                                    selectedNode,
                                     verboseDescriptions: props.verboseDescriptions,
                                 }}
                             >
@@ -878,10 +861,10 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
                         )}
                         <GraphParent ref={canvasParentRef} $isLayoutComputing={isLayoutComputing} />
                         <Tooltip
-                            appendTo={canvasParentRef.current ?? undefined}
+                            appendTo={canvasParentRef.current as HTMLElement}
                             content={tooltipContent}
                             followCursor
-                            getReferenceClientRect={tooltipRef.current ?? undefined}
+                            getReferenceClientRect={tooltipRef.current as () => DOMRect}
                             visible={!isInPanel && !!tooltipContent}
                         />
                         <ConfirmationModal title="Confirm Removal" {...removeEdgeProps} />

--- a/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/causal-graph-editor.tsx
@@ -146,7 +146,7 @@ export interface CausalGraphEditorProps extends Settings {
     /** Any extra sections to display in the side panel on edge click */
     edgeExtrasContent?: React.ReactElement;
     /** The backend data */
-    graphData?: CausalGraph;
+    graphData: CausalGraph;
     /** Graph layout to use */
     graphLayout: GraphLayout;
     /** Optional initial constraints to show in edge encoder mode */
@@ -156,9 +156,9 @@ export interface CausalGraphEditorProps extends Settings {
     /** Array of node names that cannot be removed */
     nonRemovableNodes?: Array<string>;
     /** Event handler for clicking on an edge */
-    onClickEdge?: (edge: CausalGraphEdge) => void | Promise<void>;
+    onClickEdge?: (edge: CausalGraphEdge | null) => void | Promise<void>;
     /** Event handler for clicking on a node */
-    onClickNode?: (node: CausalGraphNode) => void | Promise<void>;
+    onClickNode?: (node: CausalGraphNode | null) => void | Promise<void>;
     /** Handler called when constraints are update in edge encoder mode */
     onEdgeConstraintsUpdate?: (constraints: EdgeConstraint[]) => void | Promise<void>;
     /** onUpdate handler for live updating the edited graph */
@@ -197,7 +197,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         props.availableInputs
     );
 
-    const [error, setError] = useState(null);
+    const [error, setError] = useState<NotificationPayload | null>(null);
     const handleError = (e: NotificationPayload): void => {
         setError(e);
     };
@@ -220,7 +220,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         onSetFocus,
     } = useRenderEngine({
         constraints: props.initialConstraints,
-        editable: props.editable,
+        editable: props.editable ?? false,
         editorMode: state.editorMode,
         errorHandler: handleError,
         graph: state.graph,
@@ -253,12 +253,12 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     useOnClickOutside(paneRef.current, () => onPaneFocus(false));
 
     // track selection
-    const [selectedEdge, setSelectedEdge] = useState<[string, string]>(null);
-    const [selectedNode, setSelectedNode] = useState<string>(null);
+    const [selectedEdge, setSelectedEdge] = useState<[string, string] | null>(null);
+    const [selectedNode, setSelectedNode] = useState<string | null>(null);
 
     // track node highlighted by search separately
     // this is used instead of selection when there is no concept of selection, i.e. not editable or allowSelectionWhenNotEditable
-    const [highlightedNode, setHighlightedNode] = useState<string>();
+    const [highlightedNode, setHighlightedNode] = useState<string | null>(null);
 
     useUpdateEffect(() => {
         // Update visual selection when a node is highlighted
@@ -272,7 +272,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         }
 
         if (props.onClickNode) {
-            let serializedNode: CausalGraphNode = null;
+            let serializedNode: CausalGraphNode | null = null;
 
             if (selectedNode) {
                 serializedNode = serializeGraphNode(state.graph.getNodeAttributes(selectedNode));
@@ -289,7 +289,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         }
 
         if (props.onClickEdge) {
-            let serializedEdge: CausalGraphEdge = null;
+            let serializedEdge: CausalGraphEdge | null = null;
 
             if (selectedEdge) {
                 const [source, target] = selectedEdge;
@@ -306,7 +306,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
     // constraints
     const { constraints, addConstraint, updateConstraint, removeConstraint, reverseConstraint } =
-        useEdgeConstraintEncoder(props.initialConstraints, props.onEdgeConstraintsUpdate);
+        useEdgeConstraintEncoder(props.initialConstraints ?? [], props.onEdgeConstraintsUpdate);
 
     const selectedConstraint = useMemo(() => {
         if (state.editorMode === EditorMode.EDGE_ENCODER && selectedEdge) {
@@ -322,8 +322,11 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     // deletion
 
     function onRemoveNode(): void {
+        if (!selectedNode) {
+            return;
+        }
         if (layoutHasGroup) {
-            const layoutGroup = (layout as GraphLayoutWithGrouping).group;
+            const layoutGroup = (layout as GraphLayoutWithGrouping).group!;
             const groupsObject = getGroupToNodesMap(state.graph.nodes(), layoutGroup, state.graph);
             const nodesToGroups = getNodeToGroupMap(state.graph.nodes(), layoutGroup, state.graph);
             const group = nodesToGroups[selectedNode];
@@ -343,10 +346,15 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
     function onRemoveConstraint(): void {
         // Remove constraint that's selected
-        removeConstraint(selectedConstraint.id);
+        if (selectedConstraint) {
+            removeConstraint(selectedConstraint.id);
+        }
     }
 
     function onConfirmRemoveEdge(): void {
+        if (!selectedEdge) {
+            return;
+        }
         // In encoder mode, remove related constraint
         if (state.editorMode === EditorMode.EDGE_ENCODER) {
             onRemoveConstraint();
@@ -365,6 +373,9 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     );
 
     function onRemoveEdge(): void {
+        if (!selectedEdge) {
+            return;
+        }
         const edgeAttributes = state.graph.getEdgeAttributes(...selectedEdge);
 
         if (edgeAttributes['meta.rendering_properties.forced'] === true) {
@@ -374,7 +385,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         }
     }
 
-    let onDelete: () => void = null;
+    let onDelete: (() => void) | undefined;
 
     if (selectedEdge) {
         onDelete = onRemoveEdge;
@@ -389,7 +400,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
     function onAddEdge(edge: [string, string]): void {
         if (layoutHasGroup) {
-            const layoutGroup = (layout as GraphLayoutWithGrouping).group;
+            const layoutGroup = (layout as GraphLayoutWithGrouping).group!;
             const groupsObject = getGroupToNodesMap(state.graph.nodes(), layoutGroup, state.graph);
             const groups = Object.keys(groupsObject);
 
@@ -431,6 +442,9 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     }
 
     function onReverseEdge(): void {
+        if (!selectedEdge) {
+            return;
+        }
         const [source, target] = selectedEdge;
 
         // Skip if a cycle would be created in default mode
@@ -459,10 +473,15 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     function onReverseConstraint(): void {
         setSelectedEdge(null);
 
-        reverseConstraint(selectedConstraint);
+        if (selectedConstraint) {
+            reverseConstraint(selectedConstraint);
+        }
     }
 
     function confirmDirection(reverse: boolean): void {
+        if (!selectedEdge) {
+            return;
+        }
         api.updateEdgeType(selectedEdge, EdgeType.DIRECTED_EDGE);
 
         if (reverse) {
@@ -474,7 +493,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         }
     }
 
-    const tooltipRef = React.useRef<() => DOMRect>(null);
+    const tooltipRef = React.useRef<(() => DOMRect) | null>(null);
     const { tooltipContent, setTooltipContent } = useGraphTooltip(paneRef, tooltipRef);
 
     // keep track of when a drag action is happening
@@ -505,7 +524,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
         setTooltipContent(
             getTooltipContent(
                 nodeId,
-                nodeAttributes['meta.rendering_properties.tooltip'],
+                nodeAttributes['meta.rendering_properties.tooltip'] ?? '',
                 theme,
                 nodeAttributes['meta.rendering_properties.label'],
                 props.tooltipSize
@@ -514,7 +533,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
     });
 
     useEngineEvent('nodeMouseout', () => {
-        setTooltipContent(null);
+        setTooltipContent(undefined);
     });
 
     useEngineEvent('edgeMouseover', (event, edgeKey) => {
@@ -531,9 +550,9 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
         const edgeTooltipContent = getTooltipContent(
             `${sourceLabel} ${tooltipArrow} ${targetLabel}`,
-            edgeAttributes['meta.rendering_properties.tooltip'],
+            edgeAttributes['meta.rendering_properties.tooltip'] ?? '',
             theme,
-            null,
+            undefined,
             props.tooltipSize
         );
 
@@ -685,7 +704,7 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
 
     // dragging
     const { dragMode, setDragMode } = useDragMode(
-        props.editable,
+        props.editable ?? false,
         !props.disableEdgeAdd,
         layout.supportsDrag,
         onSetDragMode
@@ -824,8 +843,8 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
                                     editable: props.editable,
                                     graphState: state,
                                     onUpdateConstraint: updateConstraint,
-                                    selectedEdge,
-                                    selectedNode,
+                                    selectedEdge: selectedEdge ?? undefined,
+                                    selectedNode: selectedNode ?? undefined,
                                     verboseDescriptions: props.verboseDescriptions,
                                 }}
                             >
@@ -859,10 +878,10 @@ function CausalGraphEditorComponent({ requireFocusToZoom = true, ...props }: Cau
                         )}
                         <GraphParent ref={canvasParentRef} $isLayoutComputing={isLayoutComputing} />
                         <Tooltip
-                            appendTo={canvasParentRef.current}
+                            appendTo={canvasParentRef.current ?? undefined}
                             content={tooltipContent}
                             followCursor
-                            getReferenceClientRect={tooltipRef.current}
+                            getReferenceClientRect={tooltipRef.current ?? undefined}
                             visible={!isInPanel && !!tooltipContent}
                         />
                         <ConfirmationModal title="Confirm Removal" {...removeEdgeProps} />

--- a/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-edges.ts
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-edges.ts
@@ -37,27 +37,21 @@ const useIterateEdges = (
 ): UseIterateEdges => {
     const nextEdge = (): void => {
         const edges = Array.from(state.graph.edgeEntries());
-        if (!selectedEdge) {
-            return;
-        }
 
-        const [source, target] = selectedEdge;
+        const [source, target] = selectedEdge!;
 
         const selectedEdgeIndex = edges.findIndex((entry) => entry.source === source && entry.target === target);
 
         const newEdgeIndex = (selectedEdgeIndex + 1) % edges.length;
         const newEdgeEntry = edges[newEdgeIndex];
 
-        return setSelectedEdge(newEdgeEntry ? [newEdgeEntry.source, newEdgeEntry.target] : null);
+        return setSelectedEdge([newEdgeEntry.source, newEdgeEntry.target]);
     };
 
     const prevEdge = (): void => {
         const edges = Array.from(state.graph.edgeEntries());
-        if (!selectedEdge) {
-            return;
-        }
 
-        const [source, target] = selectedEdge;
+        const [source, target] = selectedEdge!;
 
         const selectedEdgeIndex = edges.findIndex((entry) => entry.source === source && entry.target === target);
 
@@ -68,7 +62,7 @@ const useIterateEdges = (
 
         const newEdgeEntry = edges[newEdgeIndex];
 
-        return setSelectedEdge(newEdgeEntry ? [newEdgeEntry.source, newEdgeEntry.target] : null);
+        return setSelectedEdge([newEdgeEntry.source, newEdgeEntry.target]);
     };
 
     return {

--- a/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-edges.ts
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-edges.ts
@@ -31,12 +31,15 @@ type UseIterateEdges = {
  * @param state graph viewer state
  */
 const useIterateEdges = (
-    selectedEdge: [string, string],
-    setSelectedEdge: Dispatch<SetStateAction<[string, string]>>,
+    selectedEdge: [string, string] | null,
+    setSelectedEdge: Dispatch<SetStateAction<[string, string] | null>>,
     state: GraphState
 ): UseIterateEdges => {
     const nextEdge = (): void => {
         const edges = Array.from(state.graph.edgeEntries());
+        if (!selectedEdge) {
+            return;
+        }
 
         const [source, target] = selectedEdge;
 
@@ -45,11 +48,14 @@ const useIterateEdges = (
         const newEdgeIndex = (selectedEdgeIndex + 1) % edges.length;
         const newEdgeEntry = edges[newEdgeIndex];
 
-        return setSelectedEdge([newEdgeEntry.source, newEdgeEntry.target]);
+        return setSelectedEdge(newEdgeEntry ? [newEdgeEntry.source, newEdgeEntry.target] : null);
     };
 
     const prevEdge = (): void => {
         const edges = Array.from(state.graph.edgeEntries());
+        if (!selectedEdge) {
+            return;
+        }
 
         const [source, target] = selectedEdge;
 
@@ -62,7 +68,7 @@ const useIterateEdges = (
 
         const newEdgeEntry = edges[newEdgeIndex];
 
-        return setSelectedEdge([newEdgeEntry.source, newEdgeEntry.target]);
+        return setSelectedEdge(newEdgeEntry ? [newEdgeEntry.source, newEdgeEntry.target] : null);
     };
 
     return {

--- a/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-nodes.ts
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-nodes.ts
@@ -31,8 +31,8 @@ type UseIterateNodes = {
  * @param state graph viewer state
  */
 const useIterateNodes = (
-    selectedNode: string,
-    setSelectedNode: React.Dispatch<React.SetStateAction<string>>,
+    selectedNode: string | null,
+    setSelectedNode: React.Dispatch<React.SetStateAction<string | null>>,
     state: GraphState
 ): UseIterateNodes => {
     const nextNode = (): void => {
@@ -41,7 +41,7 @@ const useIterateNodes = (
         const selectedNodeIndex = nodes.findIndex((n) => n === selectedNode);
         const newNodeIndex = (selectedNodeIndex + 1) % nodes.length;
 
-        setSelectedNode(nodes[newNodeIndex]);
+        setSelectedNode(nodes[newNodeIndex] ?? null);
     };
 
     const prevNode = (): void => {
@@ -55,7 +55,7 @@ const useIterateNodes = (
             newNodeIndex += nodes.length;
         }
 
-        setSelectedNode(nodes[newNodeIndex]);
+        setSelectedNode(nodes[newNodeIndex] ?? null);
     };
 
     return {

--- a/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-nodes.ts
+++ b/packages/ui-causal-graph-editor/src/graph-viewer/utils/use-iterate-nodes.ts
@@ -41,7 +41,7 @@ const useIterateNodes = (
         const selectedNodeIndex = nodes.findIndex((n) => n === selectedNode);
         const newNodeIndex = (selectedNodeIndex + 1) % nodes.length;
 
-        setSelectedNode(nodes[newNodeIndex] ?? null);
+        setSelectedNode(nodes[newNodeIndex]);
     };
 
     const prevNode = (): void => {
@@ -55,7 +55,7 @@ const useIterateNodes = (
             newNodeIndex += nodes.length;
         }
 
-        setSelectedNode(nodes[newNodeIndex] ?? null);
+        setSelectedNode(nodes[newNodeIndex]);
     };
 
     return {

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-divider.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-divider.tsx
@@ -135,7 +135,7 @@ interface LayerDividerProps {
 function LayerDivider({ onClick, position = 'bottom', viewOnly }: LayerDividerProps): JSX.Element {
     return (
         <LayerDividerWrapper $position={position}>
-            <LayerAddArea $viewOnly={Boolean(viewOnly)} data-testid="divider-button" onClick={onClick} />
+            <LayerAddArea $viewOnly={viewOnly as boolean} data-testid="divider-button" onClick={onClick} />
 
             <DividerButton>
                 <Plus />

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-divider.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-divider.tsx
@@ -135,7 +135,7 @@ interface LayerDividerProps {
 function LayerDivider({ onClick, position = 'bottom', viewOnly }: LayerDividerProps): JSX.Element {
     return (
         <LayerDividerWrapper $position={position}>
-            <LayerAddArea $viewOnly={viewOnly} data-testid="divider-button" onClick={onClick} />
+            <LayerAddArea $viewOnly={Boolean(viewOnly)} data-testid="divider-button" onClick={onClick} />
 
             <DividerButton>
                 <Plus />

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-label-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-label-editor.tsx
@@ -97,9 +97,9 @@ const LabelEditorWrapper = styled.div`
  */
 function LayerLabelEditor(props: LayerLabelEditorProps): JSX.Element {
     const [editEnabled, setEditEnabled] = useState(false);
-    const [label, setLabel] = useState(null);
+    const [label, setLabel] = useState<string | null>(null);
 
-    const ref = useRef(null);
+    const ref = useRef<HTMLDivElement>(null);
     useOnClickOutside(ref.current, () => setEditEnabled(false));
 
     const debouncedUpdateLabel = useMemo(() => debounce(props.onChange, 300), [props.onChange]);
@@ -129,7 +129,7 @@ function LayerLabelEditor(props: LayerLabelEditorProps): JSX.Element {
                     value={labelToDisplay}
                 />
             :   <LabelStaticDisplay
-                    $viewOnly={props.viewOnly}
+                    $viewOnly={Boolean(props.viewOnly)}
                     onClick={() => onEnableEditing()}
                     onKeyDown={(k) => k.key === 'Enter' && onEnableEditing()}
                     role="button"

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-label-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/layer-label-editor.tsx
@@ -129,7 +129,7 @@ function LayerLabelEditor(props: LayerLabelEditorProps): JSX.Element {
                     value={labelToDisplay}
                 />
             :   <LabelStaticDisplay
-                    $viewOnly={Boolean(props.viewOnly)}
+                    $viewOnly={props.viewOnly as boolean}
                     onClick={() => onEnableEditing()}
                     onKeyDown={(k) => k.key === 'Enter' && onEnableEditing()}
                     role="button"

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node-hierarchy-builder.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node-hierarchy-builder.tsx
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/* eslint-disable no-return-assign */
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import { nanoid } from 'nanoid';
@@ -119,9 +121,8 @@ function NodeHierarchyBuilder<T extends string | Node>(props: NodeHierarchyBuild
                 nodes: layer.nodes.map((node) => {
                     return {
                         ...node,
-                        selected: Boolean(
-                            matchesQuery(node.name, query) || (node.meta?.label && matchesQuery(node.meta.label, query))
-                        ),
+                        selected: (matchesQuery(node.name, query) ||
+                            (node.meta?.label && matchesQuery(node.meta.label, query))) as boolean,
                     };
                 }),
             };
@@ -270,12 +271,11 @@ function NodeHierarchyBuilder<T extends string | Node>(props: NodeHierarchyBuild
                                     onDeleteLayer={() => onDeleteLayer(idx)}
                                     onDrop={(item) => onDropNode(item, idx)}
                                     onUpdateLabel={onUpdateLabel}
-                                    // eslint-disable-next-line no-return-assign
-                                    ref={(el) => {
-                                        if (el) {
-                                            layersRef.current[idx] = el;
-                                        }
-                                    }}
+                                    ref={
+                                        ((el) =>
+                                            (layersRef.current[idx] =
+                                                el as HTMLDivElement)) as React.RefCallback<HTMLDivElement>
+                                    }
                                     viewOnly={props.viewOnly}
                                     wrapNodeText={props.wrapNodeText}
                                 />

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node-hierarchy-builder.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node-hierarchy-builder.tsx
@@ -119,9 +119,9 @@ function NodeHierarchyBuilder<T extends string | Node>(props: NodeHierarchyBuild
                 nodes: layer.nodes.map((node) => {
                     return {
                         ...node,
-                        selected:
-                            matchesQuery(node.name, query) ||
-                            (node.meta?.label && matchesQuery(node.meta.label, query)),
+                        selected: Boolean(
+                            matchesQuery(node.name, query) || (node.meta?.label && matchesQuery(node.meta.label, query))
+                        ),
                     };
                 }),
             };
@@ -271,7 +271,11 @@ function NodeHierarchyBuilder<T extends string | Node>(props: NodeHierarchyBuild
                                     onDrop={(item) => onDropNode(item, idx)}
                                     onUpdateLabel={onUpdateLabel}
                                     // eslint-disable-next-line no-return-assign
-                                    ref={(el) => (layersRef.current[idx] = el)}
+                                    ref={(el) => {
+                                        if (el) {
+                                            layersRef.current[idx] = el;
+                                        }
+                                    }}
                                     viewOnly={props.viewOnly}
                                     wrapNodeText={props.wrapNodeText}
                                 />

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node.tsx
@@ -110,7 +110,7 @@ function Node(props: NodeProps): JSX.Element {
 
     return (
         <Tooltip
-            content={getTooltipContent(props.node?.name, props.node?.meta?.tooltip, theme, props.node?.meta?.label)}
+            content={getTooltipContent(props.node.name, props.node.meta?.tooltip ?? '', theme, props.node.meta?.label)}
         >
             <NodeCircle
                 $isDragging={isDragging}

--- a/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node.tsx
+++ b/packages/ui-causal-graph-editor/src/node-hierarchy-builder/node.tsx
@@ -110,7 +110,12 @@ function Node(props: NodeProps): JSX.Element {
 
     return (
         <Tooltip
-            content={getTooltipContent(props.node.name, props.node.meta?.tooltip ?? '', theme, props.node.meta?.label)}
+            content={getTooltipContent(
+                props.node?.name,
+                props.node?.meta?.tooltip as string,
+                theme,
+                props.node?.meta?.label
+            )}
         >
             <NodeCircle
                 $isDragging={isDragging}

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/add-node-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/add-node-button.tsx
@@ -32,7 +32,7 @@ interface EditControlsProps extends ComponentProps<typeof FloatingButton> {
 
 function EditControls(props: EditControlsProps): JSX.Element {
     const { disableLatentNodeAdd, editorMode, editable } = useSettings();
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
     const { onAddNode, ...rest } = props;
 
     return (

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/center-graph-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/center-graph-button.tsx
@@ -28,7 +28,7 @@ interface CenterGraphButtonProps {
 }
 
 function CenterGraphButton(props: CenterGraphButtonProps): JSX.Element {
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
     const theme = useTheme();
 
     return (

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/collapse-all-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/collapse-all-button.tsx
@@ -28,7 +28,7 @@ interface CollapseGroupButtonProps {
 }
 
 function CollapseGroupButton(props: CollapseGroupButtonProps): JSX.Element {
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
 
     return (
         <Tooltip content="Collapse All" placement="bottom">

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/collapse-expand-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/collapse-expand-button.tsx
@@ -29,7 +29,7 @@ interface CollapseExpandGroupButtonProps extends ComponentProps<typeof FloatingB
 }
 
 function CollapseExpandGroupButton(props: CollapseExpandGroupButtonProps): JSX.Element {
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
     const buttonText = props.showExpandAll ? 'Collapse All' : 'Expand All';
     const { onCollapseAll, onExpandAll, showExpandAll, ...rest } = props;
 

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/drag-mode-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/drag-mode-button.tsx
@@ -29,9 +29,9 @@ import { FloatingButton } from '../floating-elements';
 
 interface DragModeButtonProps {
     /** Current drag mode */
-    dragMode: DragMode;
+    dragMode: DragMode | null;
     /** Handler to update drag mode */
-    setDragMode: Dispatch<SetStateAction<DragMode>>;
+    setDragMode: Dispatch<SetStateAction<DragMode | null>>;
 }
 
 function DragModeButton(props: DragModeButtonProps): JSX.Element {

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/drag-mode-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/drag-mode-button.tsx
@@ -36,7 +36,7 @@ interface DragModeButtonProps {
 
 function DragModeButton(props: DragModeButtonProps): JSX.Element {
     const { editable, disableEdgeAdd, allowNodeDrag } = useSettings();
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
     const theme = useTheme();
 
     const isMoveNode = props.dragMode === 'move_node';

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/recalculate-layout-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/recalculate-layout-button.tsx
@@ -29,7 +29,7 @@ interface RecalculateLayoutButtonProps {
 }
 
 function RecalculateLayoutButton(props: RecalculateLayoutButtonProps): JSX.Element {
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
 
     return (
         <Tooltip content="Recalculate Layout" placement="bottom">

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/save-image-button.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/buttons/save-image-button.tsx
@@ -30,7 +30,7 @@ interface SaveImageButtonProps {
 
 function SaveImageButton(props: SaveImageButtonProps): JSX.Element {
     const [hovered, setHovered] = useState(false);
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
     const theme = useTheme();
 
     return (

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-data.tsx
@@ -51,9 +51,9 @@ export type GraphLegendDefinition =
       };
 
 export function getLegendData(
-    defaultLegends: Record<EditorMode, GraphLegendDefinition[]>,
+    defaultLegends: Record<EditorMode, GraphLegendDefinition[]> | undefined,
     editorMode: EditorMode,
-    additionalLegend: GraphLegendDefinition[]
+    additionalLegend?: GraphLegendDefinition[]
 ): GraphLegendDefinition[] {
     const modeData = defaultLegends?.[editorMode] ?? [];
 

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend-list.tsx
@@ -123,18 +123,18 @@ function HalfCircle(props: SvgProps): JSX.Element {
     );
 }
 
-type CenterSymbolType = Extract<GraphLegendDefinition, { type: 'edge' }>['center_symbol'];
+type CenterSymbolType = Exclude<Extract<GraphLegendDefinition, { type: 'edge' }>['center_symbol'], undefined>;
 
-const CenterSymbols: Record<CenterSymbolType, (props: SvgProps) => JSX.Element> = {
+const CenterSymbols: Record<CenterSymbolType, ((props: SvgProps) => JSX.Element) | null> = {
     bidirected: Bidirected,
     cross: Cross,
     none: null,
     question: QuestionMark,
 };
 
-type ArrowsType = Extract<GraphLegendDefinition, { type: 'edge' }>['arrow_type'];
+type ArrowsType = Exclude<Extract<GraphLegendDefinition, { type: 'edge' }>['arrow_type'], undefined>;
 
-const Arrows: Record<ArrowsType, (props: SvgProps) => JSX.Element> = {
+const Arrows: Record<ArrowsType, ((props: SvgProps) => JSX.Element) | null> = {
     empty: EmptyCircle,
     filled: FullArrow,
     none: null,

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend.tsx
@@ -64,7 +64,7 @@ export interface LegendProps {
 
 function Legend(props: LegendProps): JSX.Element | null {
     const [showLegend, setShowLegend] = useState(false);
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
 
     const panelRef = useRef<HTMLDivElement>(null);
     useOnClickOutside(panelRef.current, () => setShowLegend(false));

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/legend/legend.tsx
@@ -62,7 +62,7 @@ export interface LegendProps {
     listItems: LegendListProps['listItems'];
 }
 
-function Legend(props: LegendProps): JSX.Element {
+function Legend(props: LegendProps): JSX.Element | null {
     const [showLegend, setShowLegend] = useState(false);
     const { disablePointerEvents } = useContext(PointerContext);
 

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
@@ -43,7 +43,7 @@ interface EditorOverlayProps {
     /** Whether to hide the frame and show just the graph */
     hideFrame?: boolean;
     /** Function to delete currently selected content */
-    onDelete: () => void | Promise<void>;
+    onDelete?: () => void | Promise<void>;
     /** Function to select the next edge/node */
     onNext: () => void | Promise<void>;
     /** Function to select the previous edge/node */
@@ -71,7 +71,7 @@ interface EditorOverlayProps {
  * This overlay goes on top of a graph and provides actions in each corner
  * This overlay also includes a dissmissable info panel
  */
-function EditorOverlay(props: EditorOverlayProps): JSX.Element {
+function EditorOverlay(props: EditorOverlayProps): JSX.Element | null {
     const { editable, allowSelectionWhenNotEditable } = useSettings();
     const { onPanelEnter, onPanelExit } = useContext(PointerContext);
 
@@ -81,25 +81,33 @@ function EditorOverlay(props: EditorOverlayProps): JSX.Element {
 
     const controlPadding = '10px';
 
-    const showPanel = editable || allowSelectionWhenNotEditable;
+    const showPanel = Boolean(editable || allowSelectionWhenNotEditable);
 
     return (
         <>
             <TopDiv padding={controlPadding}>
                 {/*  We only apply the show flag to content, as we want the indicator to always appear */}
                 <TopLeftDiv onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
-                    <TopLeftDivContent $show={props.showFrameButtons}>{props.topLeft}</TopLeftDivContent>
+                    <TopLeftDivContent $show={Boolean(props.showFrameButtons)}>{props.topLeft}</TopLeftDivContent>
                     {props.loadingIndicator}
                 </TopLeftDiv>
-                <TopCenterDiv $show={props.showFrameButtons} onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
+                <TopCenterDiv
+                    $show={Boolean(props.showFrameButtons)}
+                    onMouseEnter={onPanelEnter}
+                    onMouseLeave={onPanelExit}
+                >
                     {props.topCenter}
                 </TopCenterDiv>
-                <TopRightDiv $show={props.showFrameButtons} onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
+                <TopRightDiv
+                    $show={Boolean(props.showFrameButtons)}
+                    onMouseEnter={onPanelEnter}
+                    onMouseLeave={onPanelExit}
+                >
                     {props.topRight}
                 </TopRightDiv>
             </TopDiv>
 
-            <BottomDiv $show={props.showFrameButtons} padding={controlPadding}>
+            <BottomDiv $show={Boolean(props.showFrameButtons)} padding={controlPadding}>
                 <BottomLeftDiv onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
                     {props.bottomLeft}
                 </BottomLeftDiv>
@@ -116,7 +124,7 @@ function EditorOverlay(props: EditorOverlayProps): JSX.Element {
                     onMouseLeave={onPanelExit}
                     onNext={props.onNext}
                     onPrev={props.onPrev}
-                    title={props.title}
+                    title={props.title ?? ''}
                 >
                     {props.children ?? null}
                 </PanelContent>

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/overlay.tsx
@@ -43,7 +43,7 @@ interface EditorOverlayProps {
     /** Whether to hide the frame and show just the graph */
     hideFrame?: boolean;
     /** Function to delete currently selected content */
-    onDelete?: () => void | Promise<void>;
+    onDelete: (() => void | Promise<void>) | null;
     /** Function to select the next edge/node */
     onNext: () => void | Promise<void>;
     /** Function to select the previous edge/node */
@@ -73,7 +73,7 @@ interface EditorOverlayProps {
  */
 function EditorOverlay(props: EditorOverlayProps): JSX.Element | null {
     const { editable, allowSelectionWhenNotEditable } = useSettings();
-    const { onPanelEnter, onPanelExit } = useContext(PointerContext);
+    const { onPanelEnter, onPanelExit } = useContext(PointerContext)!;
 
     if (props.hideFrame) {
         return null;
@@ -81,25 +81,25 @@ function EditorOverlay(props: EditorOverlayProps): JSX.Element | null {
 
     const controlPadding = '10px';
 
-    const showPanel = Boolean(editable || allowSelectionWhenNotEditable);
+    const showPanel = editable || allowSelectionWhenNotEditable;
 
     return (
         <>
             <TopDiv padding={controlPadding}>
                 {/*  We only apply the show flag to content, as we want the indicator to always appear */}
                 <TopLeftDiv onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
-                    <TopLeftDivContent $show={Boolean(props.showFrameButtons)}>{props.topLeft}</TopLeftDivContent>
+                    <TopLeftDivContent $show={props.showFrameButtons as boolean}>{props.topLeft}</TopLeftDivContent>
                     {props.loadingIndicator}
                 </TopLeftDiv>
                 <TopCenterDiv
-                    $show={Boolean(props.showFrameButtons)}
+                    $show={props.showFrameButtons as boolean}
                     onMouseEnter={onPanelEnter}
                     onMouseLeave={onPanelExit}
                 >
                     {props.topCenter}
                 </TopCenterDiv>
                 <TopRightDiv
-                    $show={Boolean(props.showFrameButtons)}
+                    $show={props.showFrameButtons as boolean}
                     onMouseEnter={onPanelEnter}
                     onMouseLeave={onPanelExit}
                 >
@@ -107,7 +107,7 @@ function EditorOverlay(props: EditorOverlayProps): JSX.Element | null {
                 </TopRightDiv>
             </TopDiv>
 
-            <BottomDiv $show={Boolean(props.showFrameButtons)} padding={controlPadding}>
+            <BottomDiv $show={props.showFrameButtons as boolean} padding={controlPadding}>
                 <BottomLeftDiv onMouseEnter={onPanelEnter} onMouseLeave={onPanelExit}>
                     {props.bottomLeft}
                 </BottomLeftDiv>
@@ -119,12 +119,12 @@ function EditorOverlay(props: EditorOverlayProps): JSX.Element | null {
             {showPanel && props.validContentSelected && (
                 <PanelContent
                     disabled={props.disabled}
-                    onDelete={props.onDelete}
+                    onDelete={props.onDelete as () => void | Promise<void>}
                     onMouseEnter={onPanelEnter}
                     onMouseLeave={onPanelExit}
                     onNext={props.onNext}
                     onPrev={props.onPrev}
-                    title={props.title ?? ''}
+                    title={props.title as string}
                 >
                     {props.children ?? null}
                 </PanelContent>

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-editor.tsx
@@ -24,7 +24,7 @@ import EncoderEditor from './encoder-editor';
 import PagEditor from './pag-editor';
 import ResolverEditor from './resolver-editor';
 
-const EditorComponentMap: Record<EditorMode, (props: EdgeEditorProps) => JSX.Element> = {
+const EditorComponentMap: Record<EditorMode, ((props: EdgeEditorProps) => JSX.Element) | null> = {
     [EditorMode.DEFAULT]: null,
     [EditorMode.EDGE_ENCODER]: EncoderEditor,
     [EditorMode.RESOLVER]: ResolverEditor,
@@ -38,7 +38,7 @@ const EditorComponentMap: Record<EditorMode, (props: EdgeEditorProps) => JSX.Ele
 function EdgeEditor(props: EdgeEditorProps): JSX.Element {
     const { editorMode } = useSettings();
 
-    const EditorComponent = EditorComponentMap[editorMode];
+    const EditorComponent = editorMode ? EditorComponentMap[editorMode] : null;
 
     return <ColumnWrapper>{EditorComponent && <EditorComponent {...props} />}</ColumnWrapper>;
 }

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-editor.tsx
@@ -38,7 +38,7 @@ const EditorComponentMap: Record<EditorMode, ((props: EdgeEditorProps) => JSX.El
 function EdgeEditor(props: EdgeEditorProps): JSX.Element {
     const { editorMode } = useSettings();
 
-    const EditorComponent = editorMode ? EditorComponentMap[editorMode] : null;
+    const EditorComponent = EditorComponentMap[editorMode!];
 
     return <ColumnWrapper>{EditorComponent && <EditorComponent {...props} />}</ColumnWrapper>;
 }

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-info-content.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-info-content.tsx
@@ -20,6 +20,7 @@ import { useSettings } from '@shared/settings-context';
 import type { GraphApi } from '@shared/use-causal-graph-editor';
 
 import type { EdgeConstraintItem, GraphState } from '@types';
+import { EditorMode } from '@types';
 
 import { ColumnWrapper } from '../styled';
 import EdgeEditor from './edge-editor';
@@ -67,11 +68,11 @@ function EdgeInfoContent(props: EdgeInfoContentProps): JSX.Element {
                 {(editable || edgeAttributes['meta.rendering_properties.description']) && (
                     <DescriptionEditor api={props.api} edge={edgeAttributes} selectedEdge={props.selectedEdge} />
                 )}
-                {editable && (
+                {editable && (props.state.editorMode !== EditorMode.EDGE_ENCODER || props.selectedConstraint) && (
                     <EdgeEditor
                         api={props.api}
                         edge={edgeAttributes}
-                        edgeConstraint={props.selectedConstraint}
+                        edgeConstraint={props.selectedConstraint!}
                         onUpdateConstraint={props.onUpdateConstraint}
                         source={source}
                         state={props.state}

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-info-content.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/edge-info-content.tsx
@@ -20,7 +20,6 @@ import { useSettings } from '@shared/settings-context';
 import type { GraphApi } from '@shared/use-causal-graph-editor';
 
 import type { EdgeConstraintItem, GraphState } from '@types';
-import { EditorMode } from '@types';
 
 import { ColumnWrapper } from '../styled';
 import EdgeEditor from './edge-editor';
@@ -68,11 +67,11 @@ function EdgeInfoContent(props: EdgeInfoContentProps): JSX.Element {
                 {(editable || edgeAttributes['meta.rendering_properties.description']) && (
                     <DescriptionEditor api={props.api} edge={edgeAttributes} selectedEdge={props.selectedEdge} />
                 )}
-                {editable && (props.state.editorMode !== EditorMode.EDGE_ENCODER || props.selectedConstraint) && (
+                {editable && (
                     <EdgeEditor
                         api={props.api}
                         edge={edgeAttributes}
-                        edgeConstraint={props.selectedConstraint!}
+                        edgeConstraint={props.selectedConstraint as EdgeConstraintItem}
                         onUpdateConstraint={props.onUpdateConstraint}
                         source={source}
                         state={props.state}

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
@@ -99,10 +99,16 @@ export interface ConstraintEditorProps {
  * It should be displayed inside the EditorFrame's sidebar to allow the user to
  * specify a constraint type & type of relationship.
  */
-function ConstraintEditor(props: ConstraintEditorProps): JSX.Element {
+function ConstraintEditor(props: ConstraintEditorProps): JSX.Element | null {
+    if (!props.edgeConstraint) {
+        return null;
+    }
+
+    const { edgeConstraint } = props;
+
     function updateConstraintType(constraintType: EdgeConstraintItem['type']): void {
         props.onUpdate({
-            id: props.edgeConstraint.id,
+            id: edgeConstraint.id,
             source: props.source,
             target: props.target,
             type: constraintType,
@@ -113,9 +119,9 @@ function ConstraintEditor(props: ConstraintEditorProps): JSX.Element {
         <ColumnWrapper>
             <SectionTitle>Connection</SectionTitle>
             <ButtonBar
-                initialValue={constraintItems.find((i) => i.value === props.edgeConstraint.type) as Item}
+                initialValue={constraintItems.find((i) => i.value === edgeConstraint.type) as Item}
                 items={constraintItems as any}
-                key={props.edgeConstraint.id}
+                key={edgeConstraint.id}
                 onSelect={(e) => updateConstraintType(e.value)}
                 styling="secondary"
             />

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/edge/sections/constraint-editor.tsx
@@ -99,16 +99,10 @@ export interface ConstraintEditorProps {
  * It should be displayed inside the EditorFrame's sidebar to allow the user to
  * specify a constraint type & type of relationship.
  */
-function ConstraintEditor(props: ConstraintEditorProps): JSX.Element | null {
-    if (!props.edgeConstraint) {
-        return null;
-    }
-
-    const { edgeConstraint } = props;
-
+function ConstraintEditor(props: ConstraintEditorProps): JSX.Element {
     function updateConstraintType(constraintType: EdgeConstraintItem['type']): void {
         props.onUpdate({
-            id: edgeConstraint.id,
+            id: props.edgeConstraint!.id,
             source: props.source,
             target: props.target,
             type: constraintType,
@@ -119,9 +113,9 @@ function ConstraintEditor(props: ConstraintEditorProps): JSX.Element | null {
         <ColumnWrapper>
             <SectionTitle>Connection</SectionTitle>
             <ButtonBar
-                initialValue={constraintItems.find((i) => i.value === edgeConstraint.type) as Item}
+                initialValue={constraintItems.find((i) => i.value === props.edgeConstraint!.type) as Item}
                 items={constraintItems as any}
-                key={edgeConstraint.id}
+                key={props.edgeConstraint!.id}
                 onSelect={(e) => updateConstraintType(e.value)}
                 styling="secondary"
             />

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/node/label-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/node/label-editor.tsx
@@ -104,7 +104,7 @@ function LabelEditor(props: LabelEditorProps): JSX.Element {
     }
 
     return (
-        <LabelEditorWrapper $editable={editable}>
+        <LabelEditorWrapper $editable={Boolean(editable)}>
             {editable && editEnabled ?
                 <StyledInput onChange={onLabelChange} value={label} />
             :   <span

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/node/label-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/node/label-editor.tsx
@@ -104,7 +104,7 @@ function LabelEditor(props: LabelEditorProps): JSX.Element {
     }
 
     return (
-        <LabelEditorWrapper $editable={Boolean(editable)}>
+        <LabelEditorWrapper $editable={editable as boolean}>
             {editable && editEnabled ?
                 <StyledInput onChange={onLabelChange} value={label} />
             :   <span

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/panel-content.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/panel-content/panel-content.tsx
@@ -37,7 +37,7 @@ interface PanelContentProps {
 }
 
 function PanelContent(props: PanelContentProps): JSX.Element {
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
 
     return (
         <PanelDiv

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/search-bar.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/search-bar.tsx
@@ -121,7 +121,7 @@ function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
     }
 
     const debouncedOnChange = debounce((val: string, e?: SyntheticEvent<HTMLInputElement, Event>) => {
-        props.onChange(val, e);
+        props.onChange?.(val, e);
     }, inputDebounceValue);
 
     useUpdateEffect(() => {
@@ -137,20 +137,20 @@ function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
 
     function onEnter(): void {
         if (props.totalNumberOfResults) {
-            props.onNext();
+            props.onNext?.();
         }
     }
 
     function onOpenSearch(): void {
         setShowSearchBar(true);
-        searchInputRef.current.focus();
+        searchInputRef.current?.focus();
     }
 
     function onClose(): void {
         setSearchInput('');
         setShowSearchBar(false);
         setShowResultCount(false);
-        props.onClose();
+        props.onClose?.();
     }
 
     function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
@@ -158,10 +158,10 @@ function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
             onClose();
         }
         if (e.key === 'ArrowDown') {
-            props.onNext();
+            props.onNext?.();
         }
         if (e.key === 'ArrowUp') {
-            props.onPrev();
+            props.onPrev?.();
         }
     }
 
@@ -171,7 +171,7 @@ function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
         resultsText = `${props.selectedResult}/${props.totalNumberOfResults}`;
     }
 
-    let results: JSX.Element = null;
+    let results: JSX.Element | null = null;
 
     if (showResultCount) {
         results = (

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/search-bar.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/search-bar.tsx
@@ -103,7 +103,7 @@ const SearchInput = styled(Input)`
 const inputDebounceValue = 200;
 
 function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
-    const { disablePointerEvents } = useContext(PointerContext);
+    const { disablePointerEvents } = useContext(PointerContext)!;
     const searchInputRef = useRef<HTMLInputElement>(null);
 
     const [showResultCount, setShowResultCount] = useState(false);
@@ -121,7 +121,7 @@ function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
     }
 
     const debouncedOnChange = debounce((val: string, e?: SyntheticEvent<HTMLInputElement, Event>) => {
-        props.onChange?.(val, e);
+        props.onChange!(val, e);
     }, inputDebounceValue);
 
     useUpdateEffect(() => {
@@ -137,20 +137,20 @@ function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
 
     function onEnter(): void {
         if (props.totalNumberOfResults) {
-            props.onNext?.();
+            props.onNext!();
         }
     }
 
     function onOpenSearch(): void {
         setShowSearchBar(true);
-        searchInputRef.current?.focus();
+        searchInputRef.current!.focus();
     }
 
     function onClose(): void {
         setSearchInput('');
         setShowSearchBar(false);
         setShowResultCount(false);
-        props.onClose?.();
+        props.onClose!();
     }
 
     function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
@@ -158,10 +158,10 @@ function FloatingSearchBar(props: FloatingSearchBarProps): JSX.Element {
             onClose();
         }
         if (e.key === 'ArrowDown') {
-            props.onNext?.();
+            props.onNext!();
         }
         if (e.key === 'ArrowUp') {
-            props.onPrev?.();
+            props.onPrev!();
         }
     }
 

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/use-search.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/use-search.tsx
@@ -63,7 +63,7 @@ function useSearch({ graph, setSelectedNode }: UseSearchInput): UseSearchOutput 
 
                     return idIncludesValue || hasLabelWhichIncludesValue ? id : undefined;
                 })
-                .filter((node): node is string => node !== undefined);
+                .filter(Boolean) as string[];
 
             setSearchResults(filteredNodes);
 
@@ -79,7 +79,7 @@ function useSearch({ graph, setSelectedNode }: UseSearchInput): UseSearchOutput 
         const totalNumberOfResults = searchResults.length;
         const newIndex = (currentSearchNode + 1) % totalNumberOfResults;
         setCurrentSearchNode(newIndex);
-        setSelectedNode(searchResults[newIndex] ?? null);
+        setSelectedNode(searchResults[newIndex]);
     }
     function onPrevSearchResult(): void {
         const totalNumberOfResults = searchResults.length;
@@ -88,7 +88,7 @@ function useSearch({ graph, setSelectedNode }: UseSearchInput): UseSearchOutput 
             newIndex += totalNumberOfResults;
         }
         setCurrentSearchNode(newIndex);
-        setSelectedNode(searchResults[newIndex] ?? null);
+        setSelectedNode(searchResults[newIndex]);
     }
 
     useEffect(() => {

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/use-search.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/search-bar/use-search.tsx
@@ -21,7 +21,7 @@ import type { SimulationGraph } from '../../../types';
 
 interface UseSearchInput {
     graph: SimulationGraph;
-    setSelectedNode: (value: SetStateAction<string>) => void;
+    setSelectedNode: (value: SetStateAction<string | null>) => void;
 }
 
 interface UseSearchOutput {
@@ -36,7 +36,7 @@ function useSearch({ graph, setSelectedNode }: UseSearchInput): UseSearchOutput 
     const [searchResults, setSearchResults] = useState<string[]>([]);
     const [currentSearchNode, setCurrentSearchNode] = useState(0);
 
-    const [searchValue, setSearchValue] = useState('');
+    const [searchValue, setSearchValue] = useState<string | undefined>('');
 
     const updateSearchResults =
         (setActiveNode = true) =>
@@ -63,7 +63,7 @@ function useSearch({ graph, setSelectedNode }: UseSearchInput): UseSearchOutput 
 
                     return idIncludesValue || hasLabelWhichIncludesValue ? id : undefined;
                 })
-                .filter(Boolean);
+                .filter((node): node is string => node !== undefined);
 
             setSearchResults(filteredNodes);
 
@@ -79,7 +79,7 @@ function useSearch({ graph, setSelectedNode }: UseSearchInput): UseSearchOutput 
         const totalNumberOfResults = searchResults.length;
         const newIndex = (currentSearchNode + 1) % totalNumberOfResults;
         setCurrentSearchNode(newIndex);
-        setSelectedNode(searchResults[newIndex]);
+        setSelectedNode(searchResults[newIndex] ?? null);
     }
     function onPrevSearchResult(): void {
         const totalNumberOfResults = searchResults.length;
@@ -88,7 +88,7 @@ function useSearch({ graph, setSelectedNode }: UseSearchInput): UseSearchOutput 
             newIndex += totalNumberOfResults;
         }
         setCurrentSearchNode(newIndex);
-        setSelectedNode(searchResults[newIndex]);
+        setSelectedNode(searchResults[newIndex] ?? null);
     }
 
     useEffect(() => {

--- a/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/editor-overlay/zoom-prompt.tsx
@@ -73,7 +73,7 @@ const blurredText = 'To zoom in/out with scroll, click the viewer area.';
 const focusedText = 'To disable zoom in/out with scroll, click out of the viewer area.';
 
 export default function ZoomPrompt(props: ZoomPromptProps): React.ReactElement {
-    const { disablePointerEvents, onPanelEnter, onPanelExit } = React.useContext(PointerContext);
+    const { disablePointerEvents, onPanelEnter, onPanelExit } = React.useContext(PointerContext)!;
 
     const [showTooltip, setShowTooltip] = React.useState(false);
 

--- a/packages/ui-causal-graph-editor/src/shared/graph-context.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-context.tsx
@@ -42,6 +42,6 @@ interface GraphContext {
 /**
  * Context for handling interactions between the side panel and graph canvas
  */
-const graphCtx = createContext<GraphContext>(null);
+const graphCtx = createContext<GraphContext>(null!);
 
 export default graphCtx;

--- a/packages/ui-causal-graph-editor/src/shared/graph-context.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-context.tsx
@@ -32,9 +32,9 @@ interface GraphContext {
     /** Handler to update a given constraint */
     onUpdateConstraint: (constraint: EdgeConstraintItem) => void | Promise<void>;
     /** Currently selected edge */
-    selectedEdge?: [string, string];
+    selectedEdge?: [string, string] | null;
     /** Currently selected node */
-    selectedNode?: string;
+    selectedNode?: string | null;
     /** Defines whether verbose description should show */
     verboseDescriptions?: boolean;
 }
@@ -42,6 +42,6 @@ interface GraphContext {
 /**
  * Context for handling interactions between the side panel and graph canvas
  */
-const graphCtx = createContext<GraphContext>(null!);
+const graphCtx = createContext<GraphContext | null>(null);
 
 export default graphCtx;

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/common.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/common.tsx
@@ -81,7 +81,7 @@ export abstract class GraphLayout<TLayoutParams extends BaseLayoutParams = BaseL
     /**
      * Worker function that can be be called to compute a layout
      */
-    worker: LayoutWorker;
+    worker!: LayoutWorker;
 
     constructor(builder: GraphLayoutBuilder<unknown>) {
         this.nodeSize = builder._nodeSize;
@@ -137,10 +137,10 @@ export abstract class GraphLayout<TLayoutParams extends BaseLayoutParams = BaseL
 }
 
 export interface GraphLayoutWithTiers extends GraphLayout {
-    orientation: DirectionType;
-    tiers: GraphTiers;
+    orientation?: DirectionType;
+    tiers?: GraphTiers;
 }
 
 export interface GraphLayoutWithGrouping extends GraphLayout {
-    group: string;
+    group?: string;
 }

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/custom-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/custom-layout.tsx
@@ -40,8 +40,8 @@ export default class CustomLayout extends GraphLayout {
         // TODO: in the future this could call a callback passed into the layout to compute a custom layout
         const layout = graph.reduceNodes((acc, node, attrs) => {
             acc[node] = {
-                x: attrs['meta.rendering_properties.x'],
-                y: attrs['meta.rendering_properties.y'],
+                x: attrs['meta.rendering_properties.x'] ?? attrs.x ?? 0,
+                y: attrs['meta.rendering_properties.y'] ?? attrs.y ?? 0,
             };
 
             return acc;

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/custom-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/custom-layout.tsx
@@ -40,8 +40,8 @@ export default class CustomLayout extends GraphLayout {
         // TODO: in the future this could call a callback passed into the layout to compute a custom layout
         const layout = graph.reduceNodes((acc, node, attrs) => {
             acc[node] = {
-                x: attrs['meta.rendering_properties.x'] ?? attrs.x ?? 0,
-                y: attrs['meta.rendering_properties.y'] ?? attrs.y ?? 0,
+                x: attrs['meta.rendering_properties.x']!,
+                y: attrs['meta.rendering_properties.y']!,
             };
 
             return acc;

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
@@ -60,9 +60,9 @@ class FcoseLayoutBuilder
 
     orientation?: DirectionType = 'horizontal';
 
-    tiers: GraphTiers;
+    tiers?: GraphTiers;
 
-    group: string;
+    group?: string;
 
     /**
      * Set edge elasticity
@@ -193,9 +193,9 @@ export default class FcoseLayout extends GraphLayout<FcoseLayoutParams> {
 
     public orientation: DirectionType;
 
-    public tiers: GraphTiers;
+    public tiers?: GraphTiers;
 
-    public group: string;
+    public group?: string;
 
     constructor(builder: FcoseLayoutBuilder) {
         super(builder);
@@ -209,7 +209,7 @@ export default class FcoseLayout extends GraphLayout<FcoseLayoutParams> {
         this.nodeRepulsion = builder._nodeRepulsion;
         this.nodeSeparation = builder._nodeSeparation;
         this.tierSeparation = builder._tierSeparation;
-        this.orientation = builder.orientation;
+        this.orientation = builder.orientation ?? 'horizontal';
         this.tiers = builder.tiers;
         this.group = builder.group;
     }

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/fcose-layout.tsx
@@ -209,7 +209,7 @@ export default class FcoseLayout extends GraphLayout<FcoseLayoutParams> {
         this.nodeRepulsion = builder._nodeRepulsion;
         this.nodeSeparation = builder._nodeSeparation;
         this.tierSeparation = builder._tierSeparation;
-        this.orientation = builder.orientation ?? 'horizontal';
+        this.orientation = builder.orientation!;
         this.tiers = builder.tiers;
         this.group = builder.group;
     }

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/marketing-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/marketing-layout.tsx
@@ -27,7 +27,7 @@ class MarketingLayoutBuilder extends GraphLayoutBuilder<MarketingLayout> impleme
 
     orientation: DirectionType = 'horizontal';
 
-    tiers: GraphTiers;
+    tiers?: GraphTiers;
 
     /**
      * Sets the target location and returns the builder
@@ -59,7 +59,7 @@ export interface MarketingLayoutParams extends BaseLayoutParams {
     targetLocation: TargetLocation;
     tierSeparation: number;
     orientation: DirectionType;
-    tiers: GraphTiers;
+    tiers?: GraphTiers;
 }
 
 /**
@@ -75,7 +75,7 @@ export default class MarketingLayout extends GraphLayout<MarketingLayoutParams> 
 
     public orientation: DirectionType;
 
-    public tiers: GraphTiers;
+    public tiers?: GraphTiers;
 
     constructor(builder: MarketingLayoutBuilder) {
         super(builder);

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/planar-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/planar-layout.tsx
@@ -105,7 +105,7 @@ export default class PlanarLayout extends GraphLayout<PlanarLayoutParams> implem
                 graph,
                 forceUpdate
             );
-            forceUpdate?.(recomputedLayout, recomputedPoints);
+            forceUpdate!(recomputedLayout, recomputedPoints);
         };
 
         return {

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/planar-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/planar-layout.tsx
@@ -24,7 +24,7 @@ import { GraphLayout, GraphLayoutBuilder } from './common';
 class PlanarLayoutBuilder extends GraphLayoutBuilder<PlanarLayout> {
     _orientation: DirectionType = 'horizontal';
 
-    _tiers: GraphTiers;
+    _tiers?: GraphTiers;
 
     _layeringAlgorithm: PlanarLayeringAlgorithm = PlanarLayeringAlgorithm.SIMPLEX;
 
@@ -66,7 +66,7 @@ class PlanarLayoutBuilder extends GraphLayoutBuilder<PlanarLayout> {
 
 export interface PlanarLayoutParams extends BaseLayoutParams {
     orientation: DirectionType;
-    tiers: GraphTiers;
+    tiers?: GraphTiers;
     layeringAlgorithm: PlanarLayeringAlgorithm;
 }
 
@@ -77,7 +77,7 @@ export interface PlanarLayoutParams extends BaseLayoutParams {
 export default class PlanarLayout extends GraphLayout<PlanarLayoutParams> implements TieredGraphLayoutBuilder {
     public orientation: DirectionType = 'horizontal';
 
-    public tiers: GraphTiers;
+    public tiers?: GraphTiers;
 
     public layeringAlgorithm: PlanarLayeringAlgorithm = PlanarLayeringAlgorithm.SIMPLEX;
 
@@ -95,7 +95,7 @@ export default class PlanarLayout extends GraphLayout<PlanarLayoutParams> implem
 
     async applyLayout(
         graph: SimulationGraph,
-        forceUpdate?: (layout: LayoutMapping<XYPosition>, edgePoints: LayoutMapping<XYPosition[]>) => void
+        forceUpdate?: (layout: LayoutMapping<XYPosition>, edgePoints?: LayoutMapping<XYPosition[]>) => void
     ): Promise<LayoutComputationResult> {
         const { layout, edgePoints } = await this.worker.applyLayout(this, graph, forceUpdate);
 
@@ -105,7 +105,7 @@ export default class PlanarLayout extends GraphLayout<PlanarLayoutParams> implem
                 graph,
                 forceUpdate
             );
-            forceUpdate(recomputedLayout, recomputedPoints);
+            forceUpdate?.(recomputedLayout, recomputedPoints);
         };
 
         return {

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/spring-layout.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/spring-layout.tsx
@@ -44,9 +44,9 @@ class SpringLayoutBuilder
 
     orientation: DirectionType = 'horizontal';
 
-    tiers: GraphTiers;
+    tiers?: GraphTiers;
 
-    group: string;
+    group?: string;
 
     /**
      * Set the multiplier for collision force
@@ -122,8 +122,8 @@ export interface SpringLayoutParams extends BaseLayoutParams {
     tierSeparation: number;
     groupRepelStrength: number;
     orientation: DirectionType;
-    tiers: GraphTiers;
-    group: string;
+    tiers?: GraphTiers;
+    group?: string;
 }
 
 /**
@@ -145,9 +145,9 @@ export default class SpringLayout extends GraphLayout<SpringLayoutParams> {
 
     public orientation: DirectionType;
 
-    public tiers: GraphTiers;
+    public tiers?: GraphTiers;
 
-    public group: string;
+    public group?: string;
 
     constructor(builder: SpringLayoutBuilder) {
         super(builder);

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/client.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/client.ts
@@ -54,7 +54,7 @@ export class LayoutWorker extends EventEmitter<LayoutEvents> {
 
     async invokeCallback<CbName extends keyof LayoutComputationCallbacks>(
         cbName: CbName,
-        ...args: Parameters<LayoutComputationCallbacks[CbName]>
+        ...args: Parameters<NonNullable<LayoutComputationCallbacks[CbName]>>
     ): Promise<void> {
         // @ts-expect-error The type might not be quite correct
         return this.remoteApi.invokeCallback(cbName, ...args);

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/fcose.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/fcose.ts
@@ -28,9 +28,7 @@ function assignParents(elements: cytoscape.ElementDefinition[], relationships: R
 
     // Populate the lookup table
     elements.forEach((element) => {
-        if (element.data.id) {
-            elementLookup[element.data.id] = element;
-        }
+        elementLookup[element.data.id!] = element;
     });
 
     // Iterate over each parent in the relationships object
@@ -183,13 +181,13 @@ export default function compute(
         }
 
         const hasPositions = graph.getNodeAttribute(graph.nodes()[0], 'x');
-        const size = graph.getAttribute('size') ?? layoutParams.nodeSize;
+        const size = graph.getAttribute('size')!;
         const tiersPlacement =
             layoutParams.tiers ?
                 getTieredLayoutProperties(
                     graph,
                     layoutParams.tiers,
-                    layoutParams.orientation ?? 'horizontal',
+                    layoutParams.orientation!,
                     layoutParams.tierSeparation
                 )
             :   { alignmentConstraint: undefined, relativePlacementConstraint: undefined };
@@ -198,7 +196,7 @@ export default function compute(
             ...graph.mapNodes<ElementDefinition>((id, attrs) => ({
                 data: { ...attrs, height: size, width: size },
                 group: 'nodes',
-                position: { x: attrs.x ?? 0, y: attrs.y ?? 0 },
+                position: { x: attrs.x!, y: attrs.y! },
             })),
             ...graph.mapEdges<ElementDefinition>((id, attrs, source, target) => ({
                 data: { ...attrs, source, target },

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/fcose.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/fcose.ts
@@ -28,7 +28,9 @@ function assignParents(elements: cytoscape.ElementDefinition[], relationships: R
 
     // Populate the lookup table
     elements.forEach((element) => {
-        elementLookup[element.data.id] = element;
+        if (element.data.id) {
+            elementLookup[element.data.id] = element;
+        }
     });
 
     // Iterate over each parent in the relationships object
@@ -146,7 +148,7 @@ export function getTieredLayoutProperties(
     tierSeparation: number
 ): TiersProperties {
     let tiersArray = getTiersArray(tiers, graph);
-    let nodesOrder: Record<string, string>;
+    let nodesOrder: Record<string, string> | undefined;
     const nodes = graph.nodes();
 
     if (!Array.isArray(tiers)) {
@@ -181,13 +183,13 @@ export default function compute(
         }
 
         const hasPositions = graph.getNodeAttribute(graph.nodes()[0], 'x');
-        const size = graph.getAttribute('size');
+        const size = graph.getAttribute('size') ?? layoutParams.nodeSize;
         const tiersPlacement =
             layoutParams.tiers ?
                 getTieredLayoutProperties(
                     graph,
                     layoutParams.tiers,
-                    layoutParams.orientation,
+                    layoutParams.orientation ?? 'horizontal',
                     layoutParams.tierSeparation
                 )
             :   { alignmentConstraint: undefined, relativePlacementConstraint: undefined };
@@ -196,7 +198,7 @@ export default function compute(
             ...graph.mapNodes<ElementDefinition>((id, attrs) => ({
                 data: { ...attrs, height: size, width: size },
                 group: 'nodes',
-                position: { x: attrs.x, y: attrs.y },
+                position: { x: attrs.x ?? 0, y: attrs.y ?? 0 },
             })),
             ...graph.mapEdges<ElementDefinition>((id, attrs, source, target) => ({
                 data: { ...attrs, source, target },

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/marketing.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/marketing.ts
@@ -1,7 +1,6 @@
 import * as d3 from 'd3';
-import type { SimulationLinkDatum } from 'd3';
 
-import type { SimulationGraph, SimulationNodeWithCategory } from '../../../types';
+import type { D3SimulationEdge, SimulationGraph, SimulationNodeWithCategory } from '../../../types';
 import { getD3Data, nodesToLayout } from '../../parsers';
 import type { LayoutComputationResult } from '../common';
 import type { MarketingLayoutParams } from '../marketing-layout';
@@ -12,13 +11,13 @@ export default function compute(layoutParams: MarketingLayoutParams, graph: Simu
 
     // Add some code in here to move the root of the graph up when there are no secondary nodes.
     const simulation = d3
-        .forceSimulation(nodes)
+        .forceSimulation<SimulationNodeWithCategory, D3SimulationEdge>(nodes)
         .alphaMin(0.001)
         // The link force pulls linked nodes together so they try to be a given distance apart
         .force(
             'link',
             d3
-                .forceLink<SimulationNodeWithCategory, SimulationLinkDatum<SimulationNodeWithCategory>>(edges)
+                .forceLink<SimulationNodeWithCategory, D3SimulationEdge>(edges)
                 .id((d) => d.id)
                 .distance(() => layoutParams.nodeSize * 3)
                 .strength(layoutParams.targetLocation === 'center' ? 0.7 : 0.1)

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/planar.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/planar.ts
@@ -52,7 +52,7 @@ function dagGraphParser(graph: SimulationGraph, tiers?: GraphTiers): MutGraph<Da
         if (tiers) {
             const nodeData = nodeTiersMap.get(id);
             // in the case of e.g. a new node group etc may be undefined
-            nodeType = nodeData?.group;
+            nodeType = nodeData?.group ?? 'latent';
             nodeOrder = nodeData?.order;
             nodeRank = nodeData?.rank;
         }
@@ -102,7 +102,7 @@ function customDecross(layers: SugiNode<{ ord?: number }, unknown>[][]): void {
             vals.set(node, val);
         });
 
-        layer.sort((a, b) => vals.get(a) - vals.get(b));
+        layer.sort((a, b) => (vals.get(a) ?? 0) - (vals.get(b) ?? 0));
     });
 }
 
@@ -131,11 +131,11 @@ export default function compute(
 
     try {
         function groupAccessor(node: GraphNode<DagNodeData, any>): string {
-            return node.data.group;
+            return node.data.group ?? 'latent';
         }
 
         function rankAccessor(node: GraphNode<DagNodeData, any>): number {
-            return node.data.rank;
+            return node.data.rank ?? 0;
         }
 
         newDagLayout = sugiyama()

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/planar.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/planar.ts
@@ -45,21 +45,21 @@ function dagGraphParser(graph: SimulationGraph, tiers?: GraphTiers): MutGraph<Da
 
     const nodes: DagNodeData[] = graph.mapNodes((id: string, attributes: SimulationNode) => {
         const parentIds = graph.inboundNeighbors(id);
-        let nodeType = 'latent';
+        let nodeType: string | undefined = 'latent';
         let nodeOrder;
         let nodeRank;
 
         if (tiers) {
             const nodeData = nodeTiersMap.get(id);
             // in the case of e.g. a new node group etc may be undefined
-            nodeType = nodeData?.group ?? 'latent';
+            nodeType = nodeData?.group;
             nodeOrder = nodeData?.order;
             nodeRank = nodeData?.rank;
         }
 
         return {
             ...attributes,
-            group: nodeType,
+            group: nodeType as string,
             ord: nodeOrder,
             parentIds,
             rank: nodeRank,
@@ -102,7 +102,7 @@ function customDecross(layers: SugiNode<{ ord?: number }, unknown>[][]): void {
             vals.set(node, val);
         });
 
-        layer.sort((a, b) => (vals.get(a) ?? 0) - (vals.get(b) ?? 0));
+        layer.sort((a, b) => vals.get(a)! - vals.get(b)!);
     });
 }
 
@@ -131,11 +131,11 @@ export default function compute(
 
     try {
         function groupAccessor(node: GraphNode<DagNodeData, any>): string {
-            return node.data.group ?? 'latent';
+            return node.data.group!;
         }
 
         function rankAccessor(node: GraphNode<DagNodeData, any>): number {
-            return node.data.rank ?? 0;
+            return node.data.rank!;
         }
 
         newDagLayout = sugiyama()

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/spring.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/spring.ts
@@ -56,12 +56,10 @@ function applyOrderNodesForce(
                         if (targetedNode) {
                             if (orientation === 'horizontal') {
                                 // Apply a nudge towards the target y position
-                                targetedNode.vy =
-                                    (targetedNode.vy ?? 0) + (targetPosition - (targetedNode.y ?? 0)) * alpha;
+                                targetedNode.vy! += (targetPosition - targetedNode.y!) * alpha;
                             } else {
                                 // Apply a nudge towards the target x position
-                                targetedNode.vx =
-                                    (targetedNode.vx ?? 0) + (targetPosition - (targetedNode.x ?? 0)) * alpha;
+                                targetedNode.vx! += (targetPosition - targetedNode.x!) * alpha;
                             }
                         }
                     });
@@ -110,10 +108,10 @@ export function applyTierForces(
                     if (targetedNode) {
                         if (orientation === 'horizontal') {
                             // Directly set the x position
-                            targetedNode.x = targetPosition + ((targetedNode.x ?? 0) - targetPosition) * alpha;
+                            targetedNode.x = targetPosition + (targetedNode.x! - targetPosition) * alpha;
                         } else {
                             // Directly set the y position
-                            targetedNode.y = targetPosition + ((targetedNode.y ?? 0) - targetPosition) * alpha;
+                            targetedNode.y = targetPosition + (targetedNode.y! - targetPosition) * alpha;
                         }
                     }
                 });
@@ -157,9 +155,9 @@ function createEdgesWithinAllGroups(
 
     Object.keys(groupsToNodes).forEach((groupName) => {
         const nodeStringsList = groupsToNodes[groupName];
-        const nodeList = nodeStringsList
-            .map((nodeString) => nodes.find((node) => node.id === nodeString))
-            .filter((node): node is SimulationNodeWithCategory => node !== undefined);
+        const nodeList = nodeStringsList.map((nodeString) =>
+            nodes.find((node) => node.id === nodeString)
+        ) as SimulationNodeWithCategory[];
         const groupEdges = createGroupEdges(nodeList);
         edges.push(...groupEdges);
     });
@@ -209,8 +207,8 @@ export default function compute(
                     const groupBSize = groupsToNodes[groupB].length;
 
                     // Distance calculation
-                    const dx = (nodeA.x ?? 0) - (nodeB.x ?? 0);
-                    const dy = (nodeA.y ?? 0) - (nodeB.y ?? 0);
+                    const dx = nodeA.x! - nodeB.x!;
+                    const dy = nodeA.y! - nodeB.y!;
                     const distance = Math.sqrt(dx * dx + dy * dy);
 
                     if (distance > 3000) {
@@ -226,16 +224,16 @@ export default function compute(
                         continue; // Skip weak forces
                     }
 
-                    nodeA.vx = (nodeA.vx ?? 0) + (nodeA.x ?? 0) * strength;
-                    nodeA.vy = (nodeA.vy ?? 0) + (nodeA.y ?? 0) * strength;
-                    nodeB.vx = (nodeB.vx ?? 0) - (nodeB.x ?? 0) * strength;
-                    nodeB.vy = (nodeB.vy ?? 0) - (nodeB.y ?? 0) * strength;
+                    nodeA.vx! += nodeA.x! * strength;
+                    nodeA.vy! += nodeA.y! * strength;
+                    nodeB.vx! -= nodeB.x! * strength;
+                    nodeB.vy! -= nodeB.y! * strength;
                 }
             }
         }
 
         // We create fake edges between nodes in the same group so that they stay together
-        const groupEdges = createEdgesWithinAllGroups(group, graph, nodes);
+        const groupEdges = createEdgesWithinAllGroups(layoutParams.group!, graph, nodes);
 
         simulation = d3
             .forceSimulation<SimulationNodeWithCategory, D3SimulationEdge>(nodes)

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/spring.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/spring.ts
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import type { Simulation, SimulationLinkDatum } from 'd3';
+import type { Simulation } from 'd3';
 import { DirectedGraph } from 'graphology';
 import type { LayoutMapping, XYPosition } from 'graphology-layout/utils';
 import debounce from 'lodash/debounce';
@@ -31,7 +31,7 @@ import type { SpringLayoutParams } from '../spring-layout';
  * @param nodesMap a map of node name to node object
  */
 function applyOrderNodesForce(
-    simulation: d3.Simulation<SimulationNode, D3SimulationEdge>,
+    simulation: d3.Simulation<SimulationNodeWithCategory, D3SimulationEdge>,
     tiers: GraphTiers,
     graph: SimulationGraph,
     orientation: DirectionType,
@@ -56,10 +56,12 @@ function applyOrderNodesForce(
                         if (targetedNode) {
                             if (orientation === 'horizontal') {
                                 // Apply a nudge towards the target y position
-                                targetedNode.vy += (targetPosition - targetedNode.y) * alpha;
+                                targetedNode.vy =
+                                    (targetedNode.vy ?? 0) + (targetPosition - (targetedNode.y ?? 0)) * alpha;
                             } else {
                                 // Apply a nudge towards the target x position
-                                targetedNode.vx += (targetPosition - targetedNode.x) * alpha;
+                                targetedNode.vx =
+                                    (targetedNode.vx ?? 0) + (targetPosition - (targetedNode.x ?? 0)) * alpha;
                             }
                         }
                     });
@@ -85,7 +87,7 @@ function applyOrderNodesForce(
  * @param orientation the orientation of the layout
  */
 export function applyTierForces(
-    simulation: d3.Simulation<SimulationNode, D3SimulationEdge>,
+    simulation: d3.Simulation<SimulationNodeWithCategory, D3SimulationEdge>,
     graph: SimulationGraph,
     nodes: SimulationNodeWithCategory[],
     tiers: GraphTiers,
@@ -108,10 +110,10 @@ export function applyTierForces(
                     if (targetedNode) {
                         if (orientation === 'horizontal') {
                             // Directly set the x position
-                            targetedNode.x = targetPosition + (targetedNode.x - targetPosition) * alpha;
+                            targetedNode.x = targetPosition + ((targetedNode.x ?? 0) - targetPosition) * alpha;
                         } else {
                             // Directly set the y position
-                            targetedNode.y = targetPosition + (targetedNode.y - targetPosition) * alpha;
+                            targetedNode.y = targetPosition + ((targetedNode.y ?? 0) - targetPosition) * alpha;
                         }
                     }
                 });
@@ -155,7 +157,9 @@ function createEdgesWithinAllGroups(
 
     Object.keys(groupsToNodes).forEach((groupName) => {
         const nodeStringsList = groupsToNodes[groupName];
-        const nodeList = nodeStringsList.map((nodeString) => nodes.find((node) => node.id === nodeString));
+        const nodeList = nodeStringsList
+            .map((nodeString) => nodes.find((node) => node.id === nodeString))
+            .filter((node): node is SimulationNodeWithCategory => node !== undefined);
         const groupEdges = createGroupEdges(nodeList);
         edges.push(...groupEdges);
     });
@@ -166,7 +170,7 @@ function createEdgesWithinAllGroups(
 /**
  * Latest computed simulation for the current graph.
  */
-let simulation: Simulation<SimulationNode, D3SimulationEdge>;
+let simulation: Simulation<SimulationNodeWithCategory, D3SimulationEdge>;
 
 export default function compute(
     layoutParams: SpringLayoutParams,
@@ -205,8 +209,8 @@ export default function compute(
                     const groupBSize = groupsToNodes[groupB].length;
 
                     // Distance calculation
-                    const dx = nodeA.x - nodeB.x;
-                    const dy = nodeA.y - nodeB.y;
+                    const dx = (nodeA.x ?? 0) - (nodeB.x ?? 0);
+                    const dy = (nodeA.y ?? 0) - (nodeB.y ?? 0);
                     const distance = Math.sqrt(dx * dx + dy * dy);
 
                     if (distance > 3000) {
@@ -222,26 +226,26 @@ export default function compute(
                         continue; // Skip weak forces
                     }
 
-                    nodeA.vx += nodeA.x * strength;
-                    nodeA.vy += nodeA.y * strength;
-                    nodeB.vx -= nodeB.x * strength;
-                    nodeB.vy -= nodeB.y * strength;
+                    nodeA.vx = (nodeA.vx ?? 0) + (nodeA.x ?? 0) * strength;
+                    nodeA.vy = (nodeA.vy ?? 0) + (nodeA.y ?? 0) * strength;
+                    nodeB.vx = (nodeB.vx ?? 0) - (nodeB.x ?? 0) * strength;
+                    nodeB.vy = (nodeB.vy ?? 0) - (nodeB.y ?? 0) * strength;
                 }
             }
         }
 
         // We create fake edges between nodes in the same group so that they stay together
-        const groupEdges = createEdgesWithinAllGroups(layoutParams.group, graph, nodes);
+        const groupEdges = createEdgesWithinAllGroups(group, graph, nodes);
 
         simulation = d3
-            .forceSimulation(nodes)
+            .forceSimulation<SimulationNodeWithCategory, D3SimulationEdge>(nodes)
             // Apply the force that repels groups from each other
             .force('clusterRepel', clusterRepelForce)
             // Apply the force that keeps nodes within a group together
             .force(
                 'groupLinks',
                 d3
-                    .forceLink<SimulationNode, D3SimulationEdge>(groupEdges)
+                    .forceLink<SimulationNodeWithCategory, D3SimulationEdge>(groupEdges)
                     .id((d) => d.id)
                     .distance(() => layoutParams.nodeSize * layoutParams.linkForce)
             )
@@ -252,12 +256,12 @@ export default function compute(
             .stop(); // don't start just yet
     } else {
         simulation = d3
-            .forceSimulation(nodes)
+            .forceSimulation<SimulationNodeWithCategory, D3SimulationEdge>(nodes)
             // The link force pulls linked nodes together so they try to be a given distance apart
             .force(
                 'links',
                 d3
-                    .forceLink<SimulationNode, SimulationLinkDatum<SimulationNode>>(edges)
+                    .forceLink<SimulationNodeWithCategory, D3SimulationEdge>(edges)
                     .id((d) => d.id)
                     .distance(() => layoutParams.nodeSize * layoutParams.linkForce)
             )
@@ -306,7 +310,7 @@ export default function compute(
             .force(
                 'links',
                 d3
-                    .forceLink<SimulationNode, SimulationLinkDatum<SimulationNode>>(edges)
+                    .forceLink<SimulationNodeWithCategory, D3SimulationEdge>(edges)
                     .id((d) => d.id)
                     .distance(() => layoutParams.nodeSize * layoutParams.linkForce)
             )

--- a/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/worker.ts
+++ b/packages/ui-causal-graph-editor/src/shared/graph-layout/worker/worker.ts
@@ -26,14 +26,14 @@ interface LayoutImpl {
     ): Promise<LayoutComputationResult> | LayoutComputationResult;
 }
 
-const IMPL_MAP: Record<string, LayoutImpl> = {
+const IMPL_MAP = {
     PlanarLayout: computePlanarLayout,
     FcoseLayout: computeFcoseLayout,
     ForceAtlasLayout: computeForceAtlasLayout,
     CircularLayout: computeCircularLayout,
     MarketingLayout: computeMarketingLayout,
     SpringLayout: computeSpringLayout,
-};
+} as const;
 
 /**
  * Callbacks returned by the layout computation to be invoked by requests
@@ -56,7 +56,7 @@ export async function applyLayout<TParams extends BaseLayoutParams>(
     const graph = new DirectedGraph<SimulationNode, SimulationEdge, SimulationAttributes>();
     graph.import(serializedGraph);
 
-    const impl = IMPL_MAP[layoutParams.layoutName];
+    const impl = (IMPL_MAP as unknown as Record<string, LayoutImpl>)[layoutParams.layoutName];
 
     if (!impl) {
         throw new Error(`Unknown layout: ${layoutParams.layoutName}`);
@@ -90,7 +90,7 @@ export async function applyLayout<TParams extends BaseLayoutParams>(
  */
 export async function invokeCallback<CbName extends keyof LayoutComputationCallbacks>(
     cbName: CbName,
-    ...args: Parameters<LayoutComputationCallbacks[CbName]>
+    ...args: Parameters<NonNullable<LayoutComputationCallbacks[CbName]>>
 ): Promise<void> {
     const cb = LAYOUT_CALLBACKS[cbName];
 

--- a/packages/ui-causal-graph-editor/src/shared/parsers.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/parsers.tsx
@@ -70,8 +70,8 @@ export function getD3Data(graph: SimulationGraph): [edges: D3SimulationEdge[], n
 export function nodesToLayout(nodes: SimulationNode[]): LayoutMapping<XYPosition> {
     return nodes.reduce((acc, node) => {
         acc[node.id] = {
-            x: node.x,
-            y: node.y,
+            x: node.x ?? 0,
+            y: node.y ?? 0,
         };
 
         return acc;
@@ -179,7 +179,7 @@ export function parseGraphEdge(edgeData: CausalGraphEdge): SimulationEdge {
 }
 
 type Entries<T> = {
-    [K in keyof T]: [K, T[K]];
+    [K in keyof T]-?: [K, T[K]];
 }[keyof T][];
 
 /**
@@ -217,7 +217,7 @@ export function updateNodesForTimeSeries(graph: SimulationGraph): void {
         if (group.length > 1) {
             group.forEach((nodeId) => {
                 const attributes = graph.getNodeAttributes(nodeId);
-                attributes.extras.time_series_variable = variableName;
+                (attributes.extras ??= {}).time_series_variable = variableName;
                 graph.updateNode(nodeId, () => attributes);
             });
         }
@@ -306,7 +306,7 @@ export function causalGraphParser(
     try {
         const existingGraphAttributes = resultGraph.getAttributes();
         const { extras } = existingGraphAttributes;
-        if (Object.keys(extras).length === 0) {
+        if (Object.keys(extras ?? {}).length === 0) {
             resultGraph.updateAttribute('extras', () => getExtraGraphFields(data));
         }
     } catch {

--- a/packages/ui-causal-graph-editor/src/shared/parsers.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/parsers.tsx
@@ -70,8 +70,8 @@ export function getD3Data(graph: SimulationGraph): [edges: D3SimulationEdge[], n
 export function nodesToLayout(nodes: SimulationNode[]): LayoutMapping<XYPosition> {
     return nodes.reduce((acc, node) => {
         acc[node.id] = {
-            x: node.x ?? 0,
-            y: node.y ?? 0,
+            x: node.x!,
+            y: node.y!,
         };
 
         return acc;
@@ -217,7 +217,7 @@ export function updateNodesForTimeSeries(graph: SimulationGraph): void {
         if (group.length > 1) {
             group.forEach((nodeId) => {
                 const attributes = graph.getNodeAttributes(nodeId);
-                (attributes.extras ??= {}).time_series_variable = variableName;
+                attributes.extras!.time_series_variable = variableName;
                 graph.updateNode(nodeId, () => attributes);
             });
         }
@@ -306,7 +306,7 @@ export function causalGraphParser(
     try {
         const existingGraphAttributes = resultGraph.getAttributes();
         const { extras } = existingGraphAttributes;
-        if (Object.keys(extras ?? {}).length === 0) {
+        if (Object.keys(extras!).length === 0) {
             resultGraph.updateAttribute('extras', () => getExtraGraphFields(data));
         }
     } catch {

--- a/packages/ui-causal-graph-editor/src/shared/pointer-context.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/pointer-context.tsx
@@ -34,6 +34,6 @@ interface PointerContext {
 /**
  * Context for handling interactions between the editor overlay and the editor canvas
  */
-const pointerCtx = createContext<PointerContext>(null);
+const pointerCtx = createContext<PointerContext>(null!);
 
 export default pointerCtx;

--- a/packages/ui-causal-graph-editor/src/shared/pointer-context.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/pointer-context.tsx
@@ -34,6 +34,6 @@ interface PointerContext {
 /**
  * Context for handling interactions between the editor overlay and the editor canvas
  */
-const pointerCtx = createContext<PointerContext>(null!);
+const pointerCtx = createContext<PointerContext | null>(null);
 
 export default pointerCtx;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/background.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/background.tsx
@@ -47,7 +47,7 @@ export class Background extends EventEmitter<'click'> {
      * @param viewport viewport to listen to
      */
     private setupListeners(viewport: pixi_viewport.Viewport): void {
-        let bgClickLocation: PIXI.PointData = null;
+        let bgClickLocation: PIXI.PointData | null = null;
         viewport.on('mousedown', (ev) => {
             if (ev.target === viewport) {
                 bgClickLocation = ev.client.clone();

--- a/packages/ui-causal-graph-editor/src/shared/rendering/edge/curve.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/edge/curve.tsx
@@ -70,7 +70,7 @@ export function getCurvePoints(points: PIXI.PointData[], tension = 0.5, numOfSeg
             const t1y = (_pts[i + 1].y - _pts[i - 1].y) * tension;
             const t2y = (_pts[i + 2].y - _pts[i].y) * tension;
 
-            const { c1, c2, c3, c4 } = segmentCache.get(t);
+            const { c1, c2, c3, c4 } = segmentCache.get(t)!;
 
             const x = c1 * _pts[i].x + c2 * _pts[i + 1].x + c3 * t1x + c4 * t2x;
             const y = c1 * _pts[i].y + c2 * _pts[i + 1].y + c3 * t1y + c4 * t2y;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/edge/definitions.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/edge/definitions.tsx
@@ -22,7 +22,7 @@ export interface PixiEdgeStyle {
     /** Whether edge is accepted by domain expert */
     accepted?: boolean;
     /** Optional color override */
-    color?: string;
+    color: string;
     /** Constraint attached to the edge, used in EdgeEncoder mode */
     constraint?: EdgeConstraint;
     /** Current editor mode */

--- a/packages/ui-causal-graph-editor/src/shared/rendering/edge/definitions.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/edge/definitions.tsx
@@ -22,7 +22,7 @@ export interface PixiEdgeStyle {
     /** Whether edge is accepted by domain expert */
     accepted?: boolean;
     /** Optional color override */
-    color: string;
+    color?: string;
     /** Constraint attached to the edge, used in EdgeEncoder mode */
     constraint?: EdgeConstraint;
     /** Current editor mode */
@@ -36,7 +36,7 @@ export interface PixiEdgeStyle {
     /** Current edge state */
     state: EdgeState;
     /** Strength definition to be used if provided */
-    strength?: EdgeStrengthDefinition;
+    strength?: EdgeStrengthDefinition | null;
     /** The number of collapsed edges at either end of the edge */
     collapsedEdgesCount?: number;
     /** Current theme object */

--- a/packages/ui-causal-graph-editor/src/shared/rendering/edge/edge-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/edge/edge-object.tsx
@@ -190,7 +190,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
 
         // Get/create edge line texture
         const edgeLineTexture = textureCache.get(
-            createKey(EDGE_LINE_SPRITE, dash ?? 0, gapScale),
+            createKey(EDGE_LINE_SPRITE, dash as number, gapScale),
             () => {
                 const gfx = new PIXI.Graphics();
 
@@ -222,7 +222,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
             edgeLineSprite.height = edgeGfx.height;
         }
 
-        [edgeLineSprite.tint] = colorToPixi(edgeStyle.color);
+        [edgeLineSprite.tint] = colorToPixi(edgeStyle.color!);
 
         // Add opacity in default state
         if (edgeStyle.state.hover || edgeStyle.state.selected) {
@@ -270,7 +270,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         // Top
         const edgeTopSymbol = edgeSymbolsGfx.getChildByName(EDGE_TOP_SYMBOL) as PIXI.Sprite;
 
-        const [tint] = colorToPixi(edgeStyle.color);
+        const [tint] = colorToPixi(edgeStyle.color!);
         const [bgTint] = colorToPixi(edgeStyle.theme.colors.blue1);
         const topSymbolTexture = textureCache.get(
             createKey(
@@ -279,7 +279,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
                 edgeStyle.type,
                 tint,
                 bgTint,
-                edgeStyle.constraint?.type ?? ''
+                edgeStyle.constraint?.type as string
             ),
             () => createSideSymbol(edgeStyle, 'top', tint, bgTint),
             1
@@ -293,11 +293,11 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         const edgeCenterSymbol = edgeSymbolsGfx.getChildByName(EDGE_CENTER_SYMBOL) as PIXI.Sprite;
 
         const centerSymbolTexture = textureCache.get(
-            createKey(EDGE_CENTER_SYMBOL, edgeStyle.editorMode, edgeStyle.type, edgeStyle.constraint?.type ?? ''),
+            createKey(EDGE_CENTER_SYMBOL, edgeStyle.editorMode, edgeStyle.type, edgeStyle.constraint?.type as string),
             () => createCenterSymbol(edgeStyle)
         );
         edgeCenterSymbol.texture = centerSymbolTexture;
-        [edgeCenterSymbol.tint] = colorToPixi(edgeStyle.color);
+        [edgeCenterSymbol.tint] = colorToPixi(edgeStyle.color!);
         edgeCenterSymbol.alpha = 1;
 
         // Question mark should be un-rotated (always vertical)
@@ -315,7 +315,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
                 edgeStyle.type,
                 tint,
                 bgTint,
-                edgeStyle.constraint?.type ?? ''
+                edgeStyle.constraint?.type as string
             ),
             () => createSideSymbol(edgeStyle, 'bottom', tint, bgTint),
             1
@@ -328,18 +328,18 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         const edgeStrengthSymbol = edgeSymbolsGfx.getChildByName(EDGE_STRENGTH_SYMBOL) as PIXI.Sprite;
 
         const strengthSymbolTexture = textureCache.get(
-            createKey(EDGE_STRENGTH_SYMBOL, edgeStyle.strength?.dots ?? 0),
-            () => createStrengthSymbol(edgeStyle.strength?.dots ?? 0)
+            createKey(EDGE_STRENGTH_SYMBOL, edgeStyle.strength?.dots as number),
+            () => createStrengthSymbol(edgeStyle.strength?.dots as number)
         );
         edgeStrengthSymbol.texture = strengthSymbolTexture;
         edgeStrengthSymbol.position.y = edgeTopSymbol.position.y - 5; // leave gap from arrow
-        [edgeStrengthSymbol.tint] = colorToPixi(edgeStyle.color);
+        [edgeStrengthSymbol.tint] = colorToPixi(edgeStyle.color!);
         edgeStrengthSymbol.alpha = 1;
 
         // Number symbols
         const edgeNumberSymbol = edgeSymbolsGfx.getChildByName(EDGE_NUMBER_SYMBOL) as PIXI.Sprite;
         const numberSymbolTexture = textureCache.get(
-            createKey(EDGE_NUMBER_SYMBOL, edgeStyle.collapsedEdgesCount ?? 0),
+            createKey(EDGE_NUMBER_SYMBOL, edgeStyle.collapsedEdgesCount as number),
             () => {
                 if (edgeStyle.collapsedEdgesCount === undefined) {
                     return new PIXI.Graphics();
@@ -348,7 +348,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
                 const textStyle = new PIXI.TextStyle({
                     fontFamily: 'Manrope',
                     fontSize: 18,
-                    fill: colorToPixi(edgeStyle.color),
+                    fill: colorToPixi(edgeStyle.color!),
                 });
                 const text = new PIXI.Text({ text: edgeStyle.collapsedEdgesCount, style: textStyle });
                 return text;
@@ -365,7 +365,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
             ) ?
                 -Math.PI / 2
             :   Math.PI / 2;
-        [edgeStrengthSymbol.tint] = colorToPixi(edgeStyle.color);
+        [edgeStrengthSymbol.tint] = colorToPixi(edgeStyle.color!);
         edgeNumberSymbol.alpha = 1;
 
         // If selection is active but the edge itself is not selected, adjust opacity

--- a/packages/ui-causal-graph-editor/src/shared/rendering/edge/edge-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/edge/edge-object.tsx
@@ -163,7 +163,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         }
 
         // Handle dash styles in resolver modes
-        let dash: number = null;
+        let dash: number | null = null;
         let gapScale = 1;
 
         if (EditorMode.RESOLVER === edgeStyle.editorMode) {
@@ -190,7 +190,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
 
         // Get/create edge line texture
         const edgeLineTexture = textureCache.get(
-            createKey(EDGE_LINE_SPRITE, dash, gapScale),
+            createKey(EDGE_LINE_SPRITE, dash ?? 0, gapScale),
             () => {
                 const gfx = new PIXI.Graphics();
 
@@ -273,7 +273,14 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         const [tint] = colorToPixi(edgeStyle.color);
         const [bgTint] = colorToPixi(edgeStyle.theme.colors.blue1);
         const topSymbolTexture = textureCache.get(
-            createKey(EDGE_TOP_SYMBOL, edgeStyle.editorMode, edgeStyle.type, tint, bgTint, edgeStyle.constraint?.type),
+            createKey(
+                EDGE_TOP_SYMBOL,
+                edgeStyle.editorMode,
+                edgeStyle.type,
+                tint,
+                bgTint,
+                edgeStyle.constraint?.type ?? ''
+            ),
             () => createSideSymbol(edgeStyle, 'top', tint, bgTint),
             1
         );
@@ -286,7 +293,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         const edgeCenterSymbol = edgeSymbolsGfx.getChildByName(EDGE_CENTER_SYMBOL) as PIXI.Sprite;
 
         const centerSymbolTexture = textureCache.get(
-            createKey(EDGE_CENTER_SYMBOL, edgeStyle.editorMode, edgeStyle.type, edgeStyle.constraint?.type),
+            createKey(EDGE_CENTER_SYMBOL, edgeStyle.editorMode, edgeStyle.type, edgeStyle.constraint?.type ?? ''),
             () => createCenterSymbol(edgeStyle)
         );
         edgeCenterSymbol.texture = centerSymbolTexture;
@@ -308,7 +315,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
                 edgeStyle.type,
                 tint,
                 bgTint,
-                edgeStyle.constraint?.type
+                edgeStyle.constraint?.type ?? ''
             ),
             () => createSideSymbol(edgeStyle, 'bottom', tint, bgTint),
             1
@@ -320,8 +327,9 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         // Strength symbols
         const edgeStrengthSymbol = edgeSymbolsGfx.getChildByName(EDGE_STRENGTH_SYMBOL) as PIXI.Sprite;
 
-        const strengthSymbolTexture = textureCache.get(createKey(EDGE_STRENGTH_SYMBOL, edgeStyle.strength?.dots), () =>
-            createStrengthSymbol(edgeStyle.strength?.dots)
+        const strengthSymbolTexture = textureCache.get(
+            createKey(EDGE_STRENGTH_SYMBOL, edgeStyle.strength?.dots ?? 0),
+            () => createStrengthSymbol(edgeStyle.strength?.dots ?? 0)
         );
         edgeStrengthSymbol.texture = strengthSymbolTexture;
         edgeStrengthSymbol.position.y = edgeTopSymbol.position.y - 5; // leave gap from arrow
@@ -331,7 +339,7 @@ export class EdgeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         // Number symbols
         const edgeNumberSymbol = edgeSymbolsGfx.getChildByName(EDGE_NUMBER_SYMBOL) as PIXI.Sprite;
         const numberSymbolTexture = textureCache.get(
-            createKey(EDGE_NUMBER_SYMBOL, edgeStyle.collapsedEdgesCount),
+            createKey(EDGE_NUMBER_SYMBOL, edgeStyle.collapsedEdgesCount ?? 0),
             () => {
                 if (edgeStyle.collapsedEdgesCount === undefined) {
                     return new PIXI.Graphics();

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -98,16 +98,16 @@ export const ENGINE_EVENTS: Array<keyof EngineEvents> = [
 
 export class Engine extends EventEmitter<EngineEvents> {
     /** App instance */
-    private app: PIXI.Application;
+    private app!: PIXI.Application;
 
     /** Background object */
-    private background: Background;
+    private background!: Background;
 
     /** Available edge constraints */
     private constraints: EdgeConstraint[];
 
     /** Parent container where canvas is rendered in */
-    private container: HTMLElement;
+    private container!: HTMLElement;
 
     /** Running layout worker instance */
     private layoutWorker: LayoutWorker;
@@ -116,16 +116,16 @@ export class Engine extends EventEmitter<EngineEvents> {
     public debouncedUpdateLayout = debounce(this.updateLayout, 150, { trailing: true });
 
     /** Current drag mode */
-    private dragMode: DragMode = null;
+    private dragMode: DragMode | null = null;
 
     /** Container storing edge graphics */
-    private edgeLayer: PIXI.Container;
+    private edgeLayer!: PIXI.Container;
 
     /** Edge ID -> EdgeObject cache */
     private edgeMap = new Map<string | symbol, EdgeObject>();
 
     /** Container storing edge symbol graphics */
-    private edgeSymbolsLayer: PIXI.Container;
+    private edgeSymbolsLayer!: PIXI.Container;
 
     /** Whether the graph is editable */
     private editable: boolean;
@@ -146,7 +146,7 @@ export class Engine extends EventEmitter<EngineEvents> {
     private isMovingNode = false;
 
     /** Graph layout instance */
-    private layout?: GraphLayout;
+    private layout: GraphLayout;
 
     /** Which edge the user is holding down mouse button on */
     private mousedownEdgeKey: string | null = null;
@@ -155,31 +155,31 @@ export class Engine extends EventEmitter<EngineEvents> {
     private mousedownNodeKey: string | null = null;
 
     /** Container storing node label graphics */
-    private nodeLabelLayer: PIXI.Container;
+    private nodeLabelLayer!: PIXI.Container;
 
     /** Container storing node graphics */
-    private nodeLayer: PIXI.Container;
+    private nodeLayer!: PIXI.Container;
 
     /** Node ID -> NodeObject cache */
     private nodeMap = new Map<string, NodeObject>();
 
     /** Center position of the node user pressed mousedown on, stored while user is holding down mouse1 */
-    private nodeMousedownCenterPosition: PIXI.Point = null;
+    private nodeMousedownCenterPosition: PIXI.Point | null = null;
 
     /** Last mousedown event position stored while user is holding down mouse1 */
-    private nodeMousedownPosition: PIXI.Point = null;
+    private nodeMousedownPosition: PIXI.Point | null = null;
 
     /** Callback executed when a node is added */
-    private onAddNode?: (graphData: SerializedSimulationGraph) => void = null;
+    private onAddNode?: (graphData: SerializedSimulationGraph) => void;
 
     /** Callback executed when an edge is added */
-    private onAddEdge?: () => void = null;
+    private onAddEdge?: () => void;
 
     /** Callback executed when engine is being destroyed */
-    private onCleanup?: () => void = null;
+    private onCleanup?: () => void;
 
     /** Container storing group container graphics */
-    private groupContainerLayer: PIXI.Container;
+    private groupContainerLayer!: PIXI.Container;
 
     /** Group ID -> GroupContainerObject cache */
     private groupContainerMap = new Map<string, GroupContainerObject>();
@@ -211,13 +211,13 @@ export class Engine extends EventEmitter<EngineEvents> {
     private onLayoutComputationDoneBound = this.onLayoutComputationDone.bind(this);
 
     /** Callback executed when a drag motion is done */
-    private onEndDrag?: () => void = null;
+    private onEndDrag?: () => void;
 
     /** Callback executed when a node is being moved */
-    private onMove?: (nodeId: string, x: number, y: number) => void = null;
+    private onMove?: (nodeId: string, x: number, y: number) => void;
 
     /** Callback executed when a drag motion is started */
-    private onStartDrag?: () => void = null;
+    private onStartDrag?: () => void;
 
     /** Callback for raising error from a layout build into the Graph component */
     private errorHandler?: (error: NotificationPayload) => void;
@@ -226,13 +226,13 @@ export class Engine extends EventEmitter<EngineEvents> {
     private processEdgeStyle?: (edge: PixiEdgeStyle, attributes: SimulationEdge) => PixiEdgeStyle;
 
     /** Last render request ID - used to skip extra render calls */
-    private renderRequestId: number = null;
+    private renderRequestId: number | null = null;
 
     /** Whether the styles are dirty and need to be updated in the animation frame */
     private isStyleDirty = false;
 
     /** ResizeObserver instance watching window resizes */
-    private resizeObserver: ResizeObserver;
+    private resizeObserver!: ResizeObserver;
 
     /** Current node search results */
     private searchResults: string[] = [];
@@ -244,19 +244,19 @@ export class Engine extends EventEmitter<EngineEvents> {
     private selectedNode: string | null = null;
 
     /** Current range of edge strength values provided in meta attributes */
-    private strengthRange: [number, number] = null;
+    private strengthRange: [number, number] | null = null;
 
     /** Texture cache instance */
-    private textureCache: TextureCache;
+    private textureCache!: TextureCache;
 
     /** Current theme */
     private theme: DefaultTheme;
 
     /** Graph UID */
-    private uid: string;
+    private uid?: string;
 
     /** Viewport instance */
-    private viewport: pixi_viewport.Viewport;
+    private viewport!: pixi_viewport.Viewport;
 
     /** Optional user-provided zoom thresholds */
     private zoomThresholds?: ZoomThresholds;
@@ -281,12 +281,12 @@ export class Engine extends EventEmitter<EngineEvents> {
     ) {
         super();
         this.graph = graph;
-        this.requireFocusToZoom = requireFocusToZoom;
+        this.requireFocusToZoom = requireFocusToZoom ?? false;
         this.editable = editable;
         this.editorMode = editorMode;
         this.layout = layout;
         this.theme = theme;
-        this.constraints = constraints;
+        this.constraints = constraints ?? [];
         this.zoomThresholds = zoomThresholds;
         this.errorHandler = errorHandler;
         this.processEdgeStyle = processEdgeStyle;
@@ -359,8 +359,17 @@ export class Engine extends EventEmitter<EngineEvents> {
                         const edgeStyle = this.getEdgeStyle(edgeObject, attrs);
                         const sourceNode = this.nodeMap.get(source);
                         const targetNode = this.nodeMap.get(target);
-                        const sourceNodePosition = { x: sourceNodeAttributes.x, y: sourceNodeAttributes.y };
-                        const targetNodePosition = { x: targetNodeAttributes.x, y: targetNodeAttributes.y };
+                        if (!sourceNode || !targetNode) {
+                            return;
+                        }
+                        const sourceNodePosition = {
+                            x: sourceNodeAttributes.x ?? 0,
+                            y: sourceNodeAttributes.y ?? 0,
+                        };
+                        const targetNodePosition = {
+                            x: targetNodeAttributes.x ?? 0,
+                            y: targetNodeAttributes.y ?? 0,
+                        };
 
                         edgeObject.updatePosition(
                             edgeStyle,
@@ -390,8 +399,8 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     public resetViewport(): void {
         // figure out the x/y bounds
-        const nodesX = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'x'));
-        const nodesY = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'y'));
+        const nodesX = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'x') ?? 0);
+        const nodesY = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'y') ?? 0);
         let minX = Math.min(...nodesX);
         let maxX = Math.max(...nodesX);
         let minY = Math.min(...nodesY);
@@ -404,8 +413,8 @@ export class Engine extends EventEmitter<EngineEvents> {
                 getGroupToNodesMap(this.graph.nodes(), this.layout.group, this.graph)
             ).flat();
 
-            const updateBoundary = (node: SimulationNode, delta: number): number => {
-                if (nodesInGroups.includes(node?.id)) {
+            const updateBoundary = (node: SimulationNode | undefined, delta: number): number => {
+                if (node && nodesInGroups.includes(node.id)) {
                     return delta;
                 }
                 return 0;
@@ -506,7 +515,7 @@ export class Engine extends EventEmitter<EngineEvents> {
                             graphHasFinalEdge ?
                                 this.graph.getEdgeAttributes(finalSource, finalTarget)[
                                     'meta.rendering_properties.collapsedEdgesCount'
-                                ]
+                                ] ?? 0
                             :   0;
 
                         // upddate the number of collapsed edges count if needed
@@ -616,9 +625,12 @@ export class Engine extends EventEmitter<EngineEvents> {
             // then we need to recreate all the edges that were collapsed
             this.collapsedEdgesMap.forEach((edges) => {
                 edges.forEach((edge) => {
-                    if (!this.edgeMap.has(edge.id)) {
+                    if (edge.id && !this.edgeMap.has(edge.id)) {
                         const source = edge.extras?.source.identifier;
                         const target = edge.extras?.destination.identifier;
+                        if (!source || !target) {
+                            return;
+                        }
                         const sourceNodeAttributes = this.graph.getNodeAttributes(source);
                         const targetNodeAttributes = this.graph.getNodeAttributes(target);
                         this.createEdge(edge.id, edge, source, target, sourceNodeAttributes, targetNodeAttributes);
@@ -670,11 +682,11 @@ export class Engine extends EventEmitter<EngineEvents> {
      *
      * @param id id of the edge
      */
-    public selectEdge(path: [string, string]): void {
+    public selectEdge(path: [string, string] | null): void {
         // If there was a previously selected edge, unselect it
         if (this.selectedEdge) {
             const id = this.graph.edge(this.selectedEdge[0], this.selectedEdge[1]);
-            const edge = this.edgeMap.get(id);
+            const edge = id ? this.edgeMap.get(id) : undefined;
 
             // Check if it exists - could've been removed
             if (edge) {
@@ -697,7 +709,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         if (path) {
             const [source, target] = path;
             const id = this.graph.edge(source, target);
-            const edge = this.edgeMap.get(id);
+            const edge = id ? this.edgeMap.get(id) : undefined;
             if (edge) {
                 edge.state.selected = true;
                 this.selectedEdge = [source, target];
@@ -726,7 +738,7 @@ export class Engine extends EventEmitter<EngineEvents> {
      *
      * @param id id of the node
      */
-    public selectNode(id: string): void {
+    public selectNode(id: string | null | undefined): void {
         // Nodes cannot be selected in edge encoder mode
         if (this.editorMode === EditorMode.EDGE_ENCODER) {
             return;
@@ -745,10 +757,12 @@ export class Engine extends EventEmitter<EngineEvents> {
         // Select new node if specified
         if (id) {
             const node = this.nodeMap.get(id);
-            node.state.selected = true;
+            if (node) {
+                node.state.selected = true;
+            }
         }
 
-        this.selectedNode = id;
+        this.selectedNode = id ?? null;
 
         // Update all visuals as we might need to dim things
         this.markStylesDirty();
@@ -760,7 +774,7 @@ export class Engine extends EventEmitter<EngineEvents> {
      *
      * @param dragMode drag mode to set
      */
-    public setDragMode(dragMode: DragMode): void {
+    public setDragMode(dragMode: DragMode | null): void {
         this.dragMode = dragMode;
     }
 
@@ -1140,7 +1154,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         });
         node.addListener('mouseout', (event: PIXI.FederatedMouseEvent) => {
             const local = node.nodeGfx.toLocal(event.global);
-            const isInNode = node.nodeGfx.hitArea.contains(local.x, local.y);
+            const isInNode = node.nodeGfx.hitArea?.contains(local.x, local.y) ?? false;
 
             // only trigger mouseout if it's actually outside the node (could be within label)
             if (!isInNode) {
@@ -1222,7 +1236,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         });
         groupContainer.addListener('mouseout', (event: PIXI.FederatedMouseEvent) => {
             const local = groupContainer.groupContainerGfx.toLocal(event.global);
-            const isInGroupContainer = groupContainer.groupContainerGfx.hitArea.contains(local.x, local.y);
+            const isInGroupContainer = groupContainer.groupContainerGfx.hitArea?.contains(local.x, local.y) ?? false;
 
             // only trigger mouseout if it's actually outside the group (could be within label)
             if (!isInGroupContainer) {
@@ -1334,8 +1348,8 @@ export class Engine extends EventEmitter<EngineEvents> {
      * @param source edge source
      * @param target edge target
      */
-    private getConstraint(source: string, target: string): EdgeConstraint {
-        return this.constraints?.find(
+    private getConstraint(source: string, target: string): EdgeConstraint | undefined {
+        return this.constraints.find(
             (c) => (c.source === source && c.target === target) || (c.source === target && c.target === source)
         );
     }
@@ -1350,7 +1364,7 @@ export class Engine extends EventEmitter<EngineEvents> {
     private getEdgeStyle(edge: EdgeObject, attributes: SimulationEdge, constraint?: EdgeConstraint): PixiEdgeStyle {
         const edgeStyle = {
             accepted: attributes['meta.rendering_properties.accepted'],
-            color: attributes['meta.rendering_properties.color'],
+            color: attributes['meta.rendering_properties.color'] ?? '#ffffff',
             constraint,
             editorMode: this.editorMode,
             forced: attributes['meta.rendering_properties.forced'],
@@ -1379,13 +1393,13 @@ export class Engine extends EventEmitter<EngineEvents> {
         const group = getNodeCategory(this.graph, attributes.id, attributes['meta.rendering_properties.latent']);
 
         return {
-            color: attributes['meta.rendering_properties.color'],
+            color: attributes['meta.rendering_properties.color'] ?? '#ffffff',
             category: group,
-            highlight_color: attributes['meta.rendering_properties.highlight_color'],
+            highlight_color: attributes['meta.rendering_properties.highlight_color'] ?? '#ffffff',
             isEdgeSelected: !!this.selectedEdge,
             isSourceOfNewEdge: this.isCreatingEdge && this.mousedownNodeKey === attributes.id,
             label: attributes['meta.rendering_properties.label'] ?? attributes.id,
-            label_color: attributes['meta.rendering_properties.label_color'],
+            label_color: attributes['meta.rendering_properties.label_color'] ?? '#ffffff',
             label_size: attributes['meta.rendering_properties.label_size'] ?? this.layout.nodeFontSize,
             size:
                 attributes['meta.rendering_properties.size'] ??
@@ -1403,6 +1417,9 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private hoverEdge(id: string): void {
         const edge = this.edgeMap.get(id);
+        if (!edge) {
+            return;
+        }
         if (edge.state.hover) {
             return;
         }
@@ -1420,6 +1437,9 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private hoverNode(id: string): void {
         const node = this.nodeMap.get(id);
+        if (!node) {
+            return;
+        }
         if (node.state.hover) {
             return;
         }
@@ -1488,14 +1508,18 @@ export class Engine extends EventEmitter<EngineEvents> {
             if (this.isMovingNode) {
                 this.moveNode(this.mousedownNodeKey, eventWorldPosition);
             }
-            if (this.isCreatingEdge) {
+            if (this.isCreatingEdge && this.nodeMousedownCenterPosition) {
                 const nodeWorldPosition = this.viewport.toWorld(this.nodeMousedownCenterPosition);
 
                 // move the temp edge
                 const tempEdge = this.edgeMap.get(TEMP_EDGE_SYMBOL);
+                if (!tempEdge) {
+                    return;
+                }
                 tempEdge.updatePosition(
                     {
                         // use undirected edge / PAG viewer to draw an edge without symbols
+                        color: '#ffffff',
                         editorMode: EditorMode.PAG_VIEWER,
                         isEdgeSelected: false,
                         state: tempEdge.state,
@@ -1527,7 +1551,9 @@ export class Engine extends EventEmitter<EngineEvents> {
         if (this.isCreatingEdge) {
             // remove the temp edge
             const tempEdge = this.edgeMap.get(TEMP_EDGE_SYMBOL);
-            this.edgeLayer.removeChild(tempEdge.edgeGfx);
+            if (tempEdge) {
+                this.edgeLayer.removeChild(tempEdge.edgeGfx);
+            }
 
             if (initialMousedownNodeKey) {
                 this.updateNodeStyleByKey(initialMousedownNodeKey);
@@ -1641,15 +1667,15 @@ export class Engine extends EventEmitter<EngineEvents> {
      *
      * @param attributes edge attributes
      */
-    private getRelativeStrength(attributes: SimulationEdge): EdgeStrengthDefinition {
+    private getRelativeStrength(attributes: SimulationEdge): EdgeStrengthDefinition | undefined {
         //  only work in DAG mode with thickness defined
         if (this.editorMode !== EditorMode.DEFAULT || !attributes['meta.rendering_properties.thickness']) {
-            return null;
+            return undefined;
         }
 
         // If there isn't a range to scale with
         if (!this.strengthRange) {
-            return null;
+            return undefined;
         }
 
         const [sourceMin, sourceMax] = this.strengthRange;
@@ -1661,7 +1687,7 @@ export class Engine extends EventEmitter<EngineEvents> {
 
         const index = Math.round(((value - sourceMin) * targetMax) / (sourceMax - sourceMin));
 
-        return EDGE_STRENGTHS[index];
+        return EDGE_STRENGTHS[index] ?? EDGE_STRENGTHS[0];
     }
 
     /**
@@ -1671,6 +1697,9 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private unhoverEdge(id: string): void {
         const edge = this.edgeMap.get(id);
+        if (!edge) {
+            return;
+        }
         if (!edge.state.hover) {
             return;
         }
@@ -1688,6 +1717,9 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private unhoverNode(id: string): void {
         const node = this.nodeMap.get(id);
+        if (!node) {
+            return;
+        }
         if (!node.state.hover) {
             return;
         }
@@ -1721,13 +1753,16 @@ export class Engine extends EventEmitter<EngineEvents> {
         if (edge && this.viewport) {
             const sourceNode = this.nodeMap.get(source);
             const targetNode = this.nodeMap.get(target);
+            if (!sourceNode || !targetNode) {
+                return;
+            }
 
             const isSourceGroupNode = sourceNodeAttributes.variable_type === 'groupNode';
             const isTargetGroupNode = targetNodeAttributes.variable_type === 'groupNode';
 
             // Recompute edge position
-            const sourceNodePosition = { x: sourceNodeAttributes.x, y: sourceNodeAttributes.y };
-            const targetNodePosition = { x: targetNodeAttributes.x, y: targetNodeAttributes.y };
+            const sourceNodePosition = { x: sourceNodeAttributes.x ?? 0, y: sourceNodeAttributes.y ?? 0 };
+            const targetNodePosition = { x: targetNodeAttributes.x ?? 0, y: targetNodeAttributes.y ?? 0 };
             const edgeStyle = this.getEdgeStyle(edge, attributes, this.getConstraint(source, target));
             edge.updatePosition(
                 edgeStyle,
@@ -1827,9 +1862,10 @@ export class Engine extends EventEmitter<EngineEvents> {
             // eslint-disable-next-line no-console
             console.error(e);
             // call error handler
-            this.errorHandler({
+            const message = e instanceof Error ? e.message : String(e);
+            this.errorHandler?.({
                 key: 'LayoutError',
-                message: e.message,
+                message,
                 status: Status.WARNING,
                 title: 'Defaulting to Fcose Layout',
             });
@@ -1879,7 +1915,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         const node = this.nodeMap.get(id);
 
         if (node) {
-            const nodePosition = { x: attributes.x, y: attributes.y };
+            const nodePosition = { x: attributes.x ?? 0, y: attributes.y ?? 0 };
             node.updatePosition(nodePosition);
             node.updateStyle(this.getNodeStyle(node, attributes), this.textureCache);
         }

--- a/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/engine.tsx
@@ -104,7 +104,7 @@ export class Engine extends EventEmitter<EngineEvents> {
     private background!: Background;
 
     /** Available edge constraints */
-    private constraints: EdgeConstraint[];
+    private constraints?: EdgeConstraint[];
 
     /** Parent container where canvas is rendered in */
     private container!: HTMLElement;
@@ -170,13 +170,13 @@ export class Engine extends EventEmitter<EngineEvents> {
     private nodeMousedownPosition: PIXI.Point | null = null;
 
     /** Callback executed when a node is added */
-    private onAddNode?: (graphData: SerializedSimulationGraph) => void;
+    private onAddNode?: ((graphData: SerializedSimulationGraph) => void | Promise<void>) | null = null;
 
     /** Callback executed when an edge is added */
-    private onAddEdge?: () => void;
+    private onAddEdge?: (() => void | Promise<void>) | null = null;
 
     /** Callback executed when engine is being destroyed */
-    private onCleanup?: () => void;
+    private onCleanup?: (() => void | Promise<void>) | null = null;
 
     /** Container storing group container graphics */
     private groupContainerLayer!: PIXI.Container;
@@ -211,13 +211,13 @@ export class Engine extends EventEmitter<EngineEvents> {
     private onLayoutComputationDoneBound = this.onLayoutComputationDone.bind(this);
 
     /** Callback executed when a drag motion is done */
-    private onEndDrag?: () => void;
+    private onEndDrag?: (() => void | Promise<void>) | null = null;
 
     /** Callback executed when a node is being moved */
-    private onMove?: (nodeId: string, x: number, y: number) => void;
+    private onMove?: ((nodeId: string, x: number, y: number) => void | Promise<void>) | null = null;
 
     /** Callback executed when a drag motion is started */
-    private onStartDrag?: () => void;
+    private onStartDrag?: (() => void | Promise<void>) | null = null;
 
     /** Callback for raising error from a layout build into the Graph component */
     private errorHandler?: (error: NotificationPayload) => void;
@@ -281,12 +281,12 @@ export class Engine extends EventEmitter<EngineEvents> {
     ) {
         super();
         this.graph = graph;
-        this.requireFocusToZoom = requireFocusToZoom ?? false;
+        this.requireFocusToZoom = requireFocusToZoom as boolean;
         this.editable = editable;
         this.editorMode = editorMode;
         this.layout = layout;
         this.theme = theme;
-        this.constraints = constraints ?? [];
+        this.constraints = constraints;
         this.zoomThresholds = zoomThresholds;
         this.errorHandler = errorHandler;
         this.processEdgeStyle = processEdgeStyle;
@@ -359,24 +359,21 @@ export class Engine extends EventEmitter<EngineEvents> {
                         const edgeStyle = this.getEdgeStyle(edgeObject, attrs);
                         const sourceNode = this.nodeMap.get(source);
                         const targetNode = this.nodeMap.get(target);
-                        if (!sourceNode || !targetNode) {
-                            return;
-                        }
                         const sourceNodePosition = {
-                            x: sourceNodeAttributes.x ?? 0,
-                            y: sourceNodeAttributes.y ?? 0,
+                            x: sourceNodeAttributes.x!,
+                            y: sourceNodeAttributes.y!,
                         };
                         const targetNodePosition = {
-                            x: targetNodeAttributes.x ?? 0,
-                            y: targetNodeAttributes.y ?? 0,
+                            x: targetNodeAttributes.x!,
+                            y: targetNodeAttributes.y!,
                         };
 
                         edgeObject.updatePosition(
                             edgeStyle,
                             sourceNodePosition,
                             targetNodePosition,
-                            sourceNode.nodeGfx.width,
-                            targetNode.nodeGfx.width,
+                            sourceNode!.nodeGfx.width,
+                            targetNode!.nodeGfx.width,
                             this.viewport,
                             this.textureCache
                         );
@@ -399,8 +396,8 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     public resetViewport(): void {
         // figure out the x/y bounds
-        const nodesX = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'x') ?? 0);
-        const nodesY = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'y') ?? 0);
+        const nodesX = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'x')!);
+        const nodesY = this.graph.mapNodes((nodeKey) => this.graph.getNodeAttribute(nodeKey, 'y')!);
         let minX = Math.min(...nodesX);
         let maxX = Math.max(...nodesX);
         let minY = Math.min(...nodesY);
@@ -414,7 +411,7 @@ export class Engine extends EventEmitter<EngineEvents> {
             ).flat();
 
             const updateBoundary = (node: SimulationNode | undefined, delta: number): number => {
-                if (node && nodesInGroups.includes(node.id)) {
+                if (nodesInGroups.includes(node?.id as string)) {
                     return delta;
                 }
                 return 0;
@@ -515,7 +512,7 @@ export class Engine extends EventEmitter<EngineEvents> {
                             graphHasFinalEdge ?
                                 this.graph.getEdgeAttributes(finalSource, finalTarget)[
                                     'meta.rendering_properties.collapsedEdgesCount'
-                                ] ?? 0
+                                ]!
                             :   0;
 
                         // upddate the number of collapsed edges count if needed
@@ -625,15 +622,12 @@ export class Engine extends EventEmitter<EngineEvents> {
             // then we need to recreate all the edges that were collapsed
             this.collapsedEdgesMap.forEach((edges) => {
                 edges.forEach((edge) => {
-                    if (edge.id && !this.edgeMap.has(edge.id)) {
-                        const source = edge.extras?.source.identifier;
-                        const target = edge.extras?.destination.identifier;
-                        if (!source || !target) {
-                            return;
-                        }
+                    if (!this.edgeMap.has(edge.id!)) {
+                        const source = edge.extras?.source.identifier as string;
+                        const target = edge.extras?.destination.identifier as string;
                         const sourceNodeAttributes = this.graph.getNodeAttributes(source);
                         const targetNodeAttributes = this.graph.getNodeAttributes(target);
-                        this.createEdge(edge.id, edge, source, target, sourceNodeAttributes, targetNodeAttributes);
+                        this.createEdge(edge.id!, edge, source, target, sourceNodeAttributes, targetNodeAttributes);
                     }
                 });
             });
@@ -686,7 +680,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         // If there was a previously selected edge, unselect it
         if (this.selectedEdge) {
             const id = this.graph.edge(this.selectedEdge[0], this.selectedEdge[1]);
-            const edge = id ? this.edgeMap.get(id) : undefined;
+            const edge = this.edgeMap.get(id as string);
 
             // Check if it exists - could've been removed
             if (edge) {
@@ -709,7 +703,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         if (path) {
             const [source, target] = path;
             const id = this.graph.edge(source, target);
-            const edge = id ? this.edgeMap.get(id) : undefined;
+            const edge = this.edgeMap.get(id as string);
             if (edge) {
                 edge.state.selected = true;
                 this.selectedEdge = [source, target];
@@ -757,12 +751,10 @@ export class Engine extends EventEmitter<EngineEvents> {
         // Select new node if specified
         if (id) {
             const node = this.nodeMap.get(id);
-            if (node) {
-                node.state.selected = true;
-            }
+            node!.state.selected = true;
         }
 
-        this.selectedNode = id ?? null;
+        this.selectedNode = id as string;
 
         // Update all visuals as we might need to dim things
         this.markStylesDirty();
@@ -1154,7 +1146,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         });
         node.addListener('mouseout', (event: PIXI.FederatedMouseEvent) => {
             const local = node.nodeGfx.toLocal(event.global);
-            const isInNode = node.nodeGfx.hitArea?.contains(local.x, local.y) ?? false;
+            const isInNode = node.nodeGfx.hitArea!.contains(local.x, local.y);
 
             // only trigger mouseout if it's actually outside the node (could be within label)
             if (!isInNode) {
@@ -1236,7 +1228,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         });
         groupContainer.addListener('mouseout', (event: PIXI.FederatedMouseEvent) => {
             const local = groupContainer.groupContainerGfx.toLocal(event.global);
-            const isInGroupContainer = groupContainer.groupContainerGfx.hitArea?.contains(local.x, local.y) ?? false;
+            const isInGroupContainer = groupContainer.groupContainerGfx.hitArea!.contains(local.x, local.y);
 
             // only trigger mouseout if it's actually outside the group (could be within label)
             if (!isInGroupContainer) {
@@ -1349,7 +1341,7 @@ export class Engine extends EventEmitter<EngineEvents> {
      * @param target edge target
      */
     private getConstraint(source: string, target: string): EdgeConstraint | undefined {
-        return this.constraints.find(
+        return this.constraints?.find(
             (c) => (c.source === source && c.target === target) || (c.source === target && c.target === source)
         );
     }
@@ -1364,7 +1356,7 @@ export class Engine extends EventEmitter<EngineEvents> {
     private getEdgeStyle(edge: EdgeObject, attributes: SimulationEdge, constraint?: EdgeConstraint): PixiEdgeStyle {
         const edgeStyle = {
             accepted: attributes['meta.rendering_properties.accepted'],
-            color: attributes['meta.rendering_properties.color'] ?? '#ffffff',
+            color: attributes['meta.rendering_properties.color'],
             constraint,
             editorMode: this.editorMode,
             forced: attributes['meta.rendering_properties.forced'],
@@ -1393,13 +1385,13 @@ export class Engine extends EventEmitter<EngineEvents> {
         const group = getNodeCategory(this.graph, attributes.id, attributes['meta.rendering_properties.latent']);
 
         return {
-            color: attributes['meta.rendering_properties.color'] ?? '#ffffff',
+            color: attributes['meta.rendering_properties.color'],
             category: group,
-            highlight_color: attributes['meta.rendering_properties.highlight_color'] ?? '#ffffff',
+            highlight_color: attributes['meta.rendering_properties.highlight_color'],
             isEdgeSelected: !!this.selectedEdge,
             isSourceOfNewEdge: this.isCreatingEdge && this.mousedownNodeKey === attributes.id,
             label: attributes['meta.rendering_properties.label'] ?? attributes.id,
-            label_color: attributes['meta.rendering_properties.label_color'] ?? '#ffffff',
+            label_color: attributes['meta.rendering_properties.label_color'],
             label_size: attributes['meta.rendering_properties.label_size'] ?? this.layout.nodeFontSize,
             size:
                 attributes['meta.rendering_properties.size'] ??
@@ -1417,15 +1409,12 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private hoverEdge(id: string): void {
         const edge = this.edgeMap.get(id);
-        if (!edge) {
-            return;
-        }
-        if (edge.state.hover) {
+        if (edge!.state.hover) {
             return;
         }
 
         // update style
-        edge.state.hover = true;
+        edge!.state.hover = true;
         this.updateEdgeStyleByKey(id);
         this.requestRender();
     }
@@ -1437,15 +1426,12 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private hoverNode(id: string): void {
         const node = this.nodeMap.get(id);
-        if (!node) {
-            return;
-        }
-        if (node.state.hover) {
+        if (node!.state.hover) {
             return;
         }
 
         // update style
-        node.state.hover = true;
+        node!.state.hover = true;
         this.updateNodeStyleByKey(id);
         this.requestRender();
     }
@@ -1508,21 +1494,17 @@ export class Engine extends EventEmitter<EngineEvents> {
             if (this.isMovingNode) {
                 this.moveNode(this.mousedownNodeKey, eventWorldPosition);
             }
-            if (this.isCreatingEdge && this.nodeMousedownCenterPosition) {
-                const nodeWorldPosition = this.viewport.toWorld(this.nodeMousedownCenterPosition);
+            if (this.isCreatingEdge) {
+                const nodeWorldPosition = this.viewport.toWorld(this.nodeMousedownCenterPosition!);
 
                 // move the temp edge
                 const tempEdge = this.edgeMap.get(TEMP_EDGE_SYMBOL);
-                if (!tempEdge) {
-                    return;
-                }
-                tempEdge.updatePosition(
+                tempEdge!.updatePosition(
                     {
                         // use undirected edge / PAG viewer to draw an edge without symbols
-                        color: '#ffffff',
                         editorMode: EditorMode.PAG_VIEWER,
                         isEdgeSelected: false,
-                        state: tempEdge.state,
+                        state: tempEdge!.state,
                         theme: this.theme,
                         type: EdgeType.UNDIRECTED_EDGE,
                     },
@@ -1551,9 +1533,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         if (this.isCreatingEdge) {
             // remove the temp edge
             const tempEdge = this.edgeMap.get(TEMP_EDGE_SYMBOL);
-            if (tempEdge) {
-                this.edgeLayer.removeChild(tempEdge.edgeGfx);
-            }
+            this.edgeLayer.removeChild(tempEdge!.edgeGfx);
 
             if (initialMousedownNodeKey) {
                 this.updateNodeStyleByKey(initialMousedownNodeKey);
@@ -1667,15 +1647,15 @@ export class Engine extends EventEmitter<EngineEvents> {
      *
      * @param attributes edge attributes
      */
-    private getRelativeStrength(attributes: SimulationEdge): EdgeStrengthDefinition | undefined {
+    private getRelativeStrength(attributes: SimulationEdge): EdgeStrengthDefinition | null {
         //  only work in DAG mode with thickness defined
         if (this.editorMode !== EditorMode.DEFAULT || !attributes['meta.rendering_properties.thickness']) {
-            return undefined;
+            return null;
         }
 
         // If there isn't a range to scale with
         if (!this.strengthRange) {
-            return undefined;
+            return null;
         }
 
         const [sourceMin, sourceMax] = this.strengthRange;
@@ -1687,7 +1667,7 @@ export class Engine extends EventEmitter<EngineEvents> {
 
         const index = Math.round(((value - sourceMin) * targetMax) / (sourceMax - sourceMin));
 
-        return EDGE_STRENGTHS[index] ?? EDGE_STRENGTHS[0];
+        return EDGE_STRENGTHS[index];
     }
 
     /**
@@ -1697,15 +1677,12 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private unhoverEdge(id: string): void {
         const edge = this.edgeMap.get(id);
-        if (!edge) {
-            return;
-        }
-        if (!edge.state.hover) {
+        if (!edge!.state.hover) {
             return;
         }
 
         // update style
-        edge.state.hover = false;
+        edge!.state.hover = false;
         this.updateEdgeStyleByKey(id);
         this.requestRender();
     }
@@ -1717,15 +1694,12 @@ export class Engine extends EventEmitter<EngineEvents> {
      */
     private unhoverNode(id: string): void {
         const node = this.nodeMap.get(id);
-        if (!node) {
-            return;
-        }
-        if (!node.state.hover) {
+        if (!node!.state.hover) {
             return;
         }
 
         // update style
-        node.state.hover = false;
+        node!.state.hover = false;
         this.updateNodeStyleByKey(id);
         this.requestRender();
     }
@@ -1753,23 +1727,19 @@ export class Engine extends EventEmitter<EngineEvents> {
         if (edge && this.viewport) {
             const sourceNode = this.nodeMap.get(source);
             const targetNode = this.nodeMap.get(target);
-            if (!sourceNode || !targetNode) {
-                return;
-            }
-
             const isSourceGroupNode = sourceNodeAttributes.variable_type === 'groupNode';
             const isTargetGroupNode = targetNodeAttributes.variable_type === 'groupNode';
 
             // Recompute edge position
-            const sourceNodePosition = { x: sourceNodeAttributes.x ?? 0, y: sourceNodeAttributes.y ?? 0 };
-            const targetNodePosition = { x: targetNodeAttributes.x ?? 0, y: targetNodeAttributes.y ?? 0 };
+            const sourceNodePosition = { x: sourceNodeAttributes.x!, y: sourceNodeAttributes.y! };
+            const targetNodePosition = { x: targetNodeAttributes.x!, y: targetNodeAttributes.y! };
             const edgeStyle = this.getEdgeStyle(edge, attributes, this.getConstraint(source, target));
             edge.updatePosition(
                 edgeStyle,
                 sourceNodePosition,
                 targetNodePosition,
-                sourceNode.nodeGfx.width,
-                targetNode.nodeGfx.width,
+                sourceNode!.nodeGfx.width,
+                targetNode!.nodeGfx.width,
                 this.viewport,
                 this.textureCache,
                 isSourceGroupNode,
@@ -1862,10 +1832,9 @@ export class Engine extends EventEmitter<EngineEvents> {
             // eslint-disable-next-line no-console
             console.error(e);
             // call error handler
-            const message = e instanceof Error ? e.message : String(e);
-            this.errorHandler?.({
+            this.errorHandler!({
                 key: 'LayoutError',
-                message,
+                message: (e as Error).message,
                 status: Status.WARNING,
                 title: 'Defaulting to Fcose Layout',
             });
@@ -1915,7 +1884,7 @@ export class Engine extends EventEmitter<EngineEvents> {
         const node = this.nodeMap.get(id);
 
         if (node) {
-            const nodePosition = { x: attributes.x ?? 0, y: attributes.y ?? 0 };
+            const nodePosition = { x: attributes.x!, y: attributes.y! };
             node.updatePosition(nodePosition);
             node.updateStyle(this.getNodeStyle(node, attributes), this.textureCache);
         }

--- a/packages/ui-causal-graph-editor/src/shared/rendering/grouping/group-container-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/grouping/group-container-object.tsx
@@ -92,12 +92,10 @@ export class GroupContainerObject extends EventEmitter<(typeof MOUSE_EVENTS)[num
         nodes.forEach((node) => {
             let radius = node['meta.rendering_properties.size'] ?? DEFAULT_NODE_SIZE * TARGET_NODE_MULTIPLIER;
             radius += 20; // Add padding
-            const x = node.x ?? 0;
-            const y = node.y ?? 0;
-            minX = Math.min(minX, x - radius);
-            maxX = Math.max(maxX, x + radius);
-            minY = Math.min(minY, y - radius);
-            maxY = Math.max(maxY, y + radius);
+            minX = Math.min(minX, node.x! - radius);
+            maxX = Math.max(maxX, node.x! + radius);
+            minY = Math.min(minY, node.y! - radius);
+            maxY = Math.max(maxY, node.y! + radius);
         });
 
         const height = maxY - minY;
@@ -149,12 +147,10 @@ export class GroupContainerObject extends EventEmitter<(typeof MOUSE_EVENTS)[num
         nodes.forEach((node) => {
             let radius = node['meta.rendering_properties.size'] ?? DEFAULT_NODE_SIZE * TARGET_NODE_MULTIPLIER;
             radius += 20; // Add padding
-            const x = node.x ?? 0;
-            const y = node.y ?? 0;
-            minX = Math.min(minX, x - radius);
-            maxX = Math.max(maxX, x + radius);
-            minY = Math.min(minY, y - radius);
-            maxY = Math.max(maxY, y + radius);
+            minX = Math.min(minX, node.x! - radius);
+            maxX = Math.max(maxX, node.x! + radius);
+            minY = Math.min(minY, node.y! - radius);
+            maxY = Math.max(maxY, node.y! + radius);
         });
 
         const centerX = minX + (maxX - minX) / 2;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/grouping/group-container-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/grouping/group-container-object.tsx
@@ -92,10 +92,12 @@ export class GroupContainerObject extends EventEmitter<(typeof MOUSE_EVENTS)[num
         nodes.forEach((node) => {
             let radius = node['meta.rendering_properties.size'] ?? DEFAULT_NODE_SIZE * TARGET_NODE_MULTIPLIER;
             radius += 20; // Add padding
-            minX = Math.min(minX, node.x - radius);
-            maxX = Math.max(maxX, node.x + radius);
-            minY = Math.min(minY, node.y - radius);
-            maxY = Math.max(maxY, node.y + radius);
+            const x = node.x ?? 0;
+            const y = node.y ?? 0;
+            minX = Math.min(minX, x - radius);
+            maxX = Math.max(maxX, x + radius);
+            minY = Math.min(minY, y - radius);
+            maxY = Math.max(maxY, y + radius);
         });
 
         const height = maxY - minY;
@@ -147,11 +149,12 @@ export class GroupContainerObject extends EventEmitter<(typeof MOUSE_EVENTS)[num
         nodes.forEach((node) => {
             let radius = node['meta.rendering_properties.size'] ?? DEFAULT_NODE_SIZE * TARGET_NODE_MULTIPLIER;
             radius += 20; // Add padding
-
-            minX = Math.min(minX, node.x - radius);
-            maxX = Math.max(maxX, node.x + radius);
-            minY = Math.min(minY, node.y - radius);
-            maxY = Math.max(maxY, node.y + radius);
+            const x = node.x ?? 0;
+            const y = node.y ?? 0;
+            minX = Math.min(minX, x - radius);
+            maxX = Math.max(maxX, x + radius);
+            minY = Math.min(minY, y - radius);
+            maxY = Math.max(maxY, y + radius);
         });
 
         const centerX = minX + (maxX - minX) / 2;

--- a/packages/ui-causal-graph-editor/src/shared/rendering/node/definitions.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/node/definitions.tsx
@@ -25,11 +25,11 @@ export const BORDER_PADDING = 2;
  */
 export interface PixiNodeStyle {
     /** Node background color */
-    color: string;
+    color?: string;
     /** The category the node belongs to */
     category: NodeCategory;
     /** Border/shadow color */
-    highlight_color: string;
+    highlight_color?: string;
     /** Whether there is a edge currently selected */
     isEdgeSelected: boolean;
     /** Whether there is a new edge being created from this node */
@@ -37,9 +37,9 @@ export interface PixiNodeStyle {
     /** Node text */
     label: string;
     /** Node text color */
-    label_color: string;
+    label_color?: string;
     /** Node text font size */
-    label_size: number;
+    label_size?: number;
     /** Node size */
     size: number;
     /** Current node state */

--- a/packages/ui-causal-graph-editor/src/shared/rendering/node/definitions.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/node/definitions.tsx
@@ -25,11 +25,11 @@ export const BORDER_PADDING = 2;
  */
 export interface PixiNodeStyle {
     /** Node background color */
-    color?: string;
+    color: string;
     /** The category the node belongs to */
     category: NodeCategory;
     /** Border/shadow color */
-    highlight_color?: string;
+    highlight_color: string;
     /** Whether there is a edge currently selected */
     isEdgeSelected: boolean;
     /** Whether there is a new edge being created from this node */
@@ -37,9 +37,9 @@ export interface PixiNodeStyle {
     /** Node text */
     label: string;
     /** Node text color */
-    label_color?: string;
+    label_color: string;
     /** Node text font size */
-    label_size?: number;
+    label_size: number;
     /** Node size */
     size: number;
     /** Current node state */

--- a/packages/ui-causal-graph-editor/src/shared/rendering/node/node-object.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/node/node-object.tsx
@@ -166,7 +166,7 @@ export class NodeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         // Set the node texture and adjust its styles
         const nodeBody = nodeGfx.getChildByName(nodeTextureKey) as PIXI.Sprite;
         nodeBody.texture = nodeTexture;
-        [nodeBody.tint, nodeBody.alpha] = colorToPixi(nodeStyle.color);
+        [nodeBody.tint, nodeBody.alpha] = colorToPixi(nodeStyle.color!);
 
         // Get/create border texture
         const borderTexture = textureCache.get(
@@ -186,7 +186,7 @@ export class NodeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         // Set the border texture and adjust its styles
         const border = nodeGfx.getChildByName(nodeBorderTextureKey) as PIXI.Sprite;
         border.texture = borderTexture;
-        [border.tint, border.alpha] = colorToPixi(nodeStyle.highlight_color);
+        [border.tint, border.alpha] = colorToPixi(nodeStyle.highlight_color!);
 
         // Adjust the filter style based on state
         const themeShadows = SHADOWS[nodeStyle.theme.themeType];
@@ -194,7 +194,7 @@ export class NodeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
         let blur = 2;
 
         if (nodeStyle.state.selected) {
-            shadowColor = nodeStyle.highlight_color;
+            shadowColor = nodeStyle.highlight_color!;
             blur = 4;
         } else if (nodeStyle.state.hover || nodeStyle.isSourceOfNewEdge) {
             shadowColor = themeShadows.shadowHover;
@@ -238,7 +238,7 @@ export class NodeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
                 const nodeSize = nodeRadius * 2;
                 const maxSize = nodeSize - 10; // leave space on sides
 
-                const textStyle = getTextStyle(nodeStyle.label_size);
+                const textStyle = getTextStyle(nodeStyle.label_size!);
                 const trimmedText = trimToFit(nodeStyle.label, maxSize, textStyle);
 
                 const txt = new PIXI.Text({ text: trimmedText, style: textStyle });
@@ -250,7 +250,7 @@ export class NodeObject extends EventEmitter<(typeof MOUSE_EVENTS)[number]> {
 
         const nodeLabel = nodeLabelGfx.getChildByName(NODE_LABEL) as PIXI.Sprite;
         nodeLabel.texture = labelTexture;
-        [nodeLabel.tint, nodeLabel.alpha] = colorToPixi(nodeStyle.label_color);
+        [nodeLabel.tint, nodeLabel.alpha] = colorToPixi(nodeStyle.label_color!);
 
         // If selection is active but the node itself is not selected, adjust opacity
         if (

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -38,13 +38,13 @@ interface UseRenderEngineApi {
      *
      * @param path selected edge
      */
-    onEdgeSelected: (path: [string, string]) => void;
+    onEdgeSelected: (path: [string, string] | null) => void;
     /**
      * Should be called whenever node selection should change
      *
      * @param node selected node
      */
-    onNodeSelected: (node: string) => void;
+    onNodeSelected: (node: string | null | undefined) => void;
     /**
      * Should be called wheneve search results change
      *
@@ -124,17 +124,17 @@ export function useRenderEngine({
     errorHandler?: (error: NotificationPayload) => void;
     graph: SimulationGraph;
     layout: GraphLayout;
-    parentRef: React.MutableRefObject<HTMLElement>;
+    parentRef: React.RefObject<HTMLElement>;
     processEdgeStyle?: (edge: PixiEdgeStyle, attributes: SimulationEdge) => PixiEdgeStyle;
     requireFocusToZoom?: boolean;
     zoomThresholds?: ZoomThresholds;
 }): UseRenderEngineApi {
     const theme = useTheme();
-    const engine = React.useRef<Engine>(null);
+    const engineRef = React.useRef<Engine | null>(null);
     const listeners = React.useRef<Partial<EngineEvents>>({});
 
-    if (!engine.current) {
-        engine.current = new Engine(
+    if (!engineRef.current) {
+        engineRef.current = new Engine(
             graph,
             layout,
             editable,
@@ -147,32 +147,36 @@ export function useRenderEngine({
             requireFocusToZoom
         );
     }
+    const engine = engineRef.current;
 
     // Start engine after first render, stop it on destroy
     React.useEffect(() => {
         if (parentRef.current) {
-            engine.current.start(parentRef.current).then(() => {
+            engine.start(parentRef.current).then(() => {
                 // Attach listeners for each event type
                 ENGINE_EVENTS.forEach((eventName) => {
-                    engine.current.addListener(eventName, (...args) => {
-                        listeners.current[eventName]?.apply(null, args);
+                    engine.addListener(eventName, (...args) => {
+                        const listener = listeners.current[eventName] as
+                            | ((...eventArgs: typeof args) => void)
+                            | undefined;
+                        listener?.(...args);
                     });
                 });
             });
         }
 
         return () => {
-            engine.current?.destroy();
+            engine.destroy();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // update engine theme
     React.useEffect(() => {
-        if (engine.current.initialized) {
-            engine.current.setTheme(theme);
+        if (engine.initialized) {
+            engine.setTheme(theme);
         }
-    }, [theme]);
+    }, [engine, theme]);
 
     /**
      * Updates the listener reference in a ref. Engine event listeners are registered just once so
@@ -184,60 +188,61 @@ export function useRenderEngine({
 
     return {
         getCenterPosition: (): PIXI.PointData => {
-            return engine.current.getCenterPosition();
+            return engine.getCenterPosition();
         },
-        onEdgeSelected: (path: [string, string]) => {
-            if (engine.current.initialized) {
-                engine.current.selectEdge(path);
+        onEdgeSelected: (path: [string, string] | null) => {
+            if (engine.initialized) {
+                engine.selectEdge(path);
             }
         },
-        onNodeSelected: (node: string) => {
-            if (engine.current.initialized) {
-                engine.current.selectNode(node);
+        onNodeSelected: (node: string | null | undefined) => {
+            if (engine.initialized) {
+                engine.selectNode(node);
             }
         },
         onSearchResults: (nodes: string[]) => {
-            if (engine.current.initialized) {
-                engine.current.searchNodes(nodes);
+            if (engine.initialized) {
+                engine.searchNodes(nodes);
             }
         },
         onSetDragMode: (dragMode: DragMode | null) => {
-            engine.current.setDragMode(dragMode);
+            engine.setDragMode(dragMode);
         },
         onSetFocus: (isFocused: boolean) => {
-            if (engine.current.initialized) {
-                engine.current.setFocus(isFocused);
+            if (engine.initialized) {
+                engine.setFocus(isFocused);
             }
         },
         onUpdateConstraints: (newConstraints: EdgeConstraint[]) => {
-            if (engine.current.initialized) {
-                engine.current.updateConstraints(newConstraints);
+            if (engine.initialized) {
+                engine.updateConstraints(newConstraints);
             }
         },
         resetLayout: () => {
-            if (engine.current.initialized) {
-                engine.current.debouncedUpdateLayout();
+            if (engine.initialized) {
+                engine.debouncedUpdateLayout();
             }
         },
         resetViewport: () => {
-            if (engine.current.initialized) {
-                engine.current.resetViewport();
+            if (engine.initialized) {
+                engine.resetViewport();
             }
         },
         collapseGroups: () => {
-            if (engine.current.initialized) {
-                engine.current.collapseAllGroups();
+            if (engine.initialized) {
+                engine.collapseAllGroups();
             }
         },
         expandGroups: () => {
-            if (engine.current.initialized) {
-                engine.current.expandAllGroups();
+            if (engine.initialized) {
+                engine.expandAllGroups();
             }
         },
         extractImage: () => {
-            if (engine.current.initialized) {
-                return engine.current.extractImage();
+            if (engine.initialized) {
+                return engine.extractImage();
             }
+            return Promise.resolve(undefined);
         },
         useEngineEvent,
     };

--- a/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/use-render-engine.tsx
@@ -130,11 +130,11 @@ export function useRenderEngine({
     zoomThresholds?: ZoomThresholds;
 }): UseRenderEngineApi {
     const theme = useTheme();
-    const engineRef = React.useRef<Engine | null>(null);
+    const engine = React.useRef<Engine | null>(null);
     const listeners = React.useRef<Partial<EngineEvents>>({});
 
-    if (!engineRef.current) {
-        engineRef.current = new Engine(
+    if (!engine.current) {
+        engine.current = new Engine(
             graph,
             layout,
             editable,
@@ -147,36 +147,35 @@ export function useRenderEngine({
             requireFocusToZoom
         );
     }
-    const engine = engineRef.current;
-
     // Start engine after first render, stop it on destroy
     React.useEffect(() => {
         if (parentRef.current) {
-            engine.start(parentRef.current).then(() => {
+            engine.current!.start(parentRef.current).then(() => {
                 // Attach listeners for each event type
                 ENGINE_EVENTS.forEach((eventName) => {
-                    engine.addListener(eventName, (...args) => {
-                        const listener = listeners.current[eventName] as
-                            | ((...eventArgs: typeof args) => void)
-                            | undefined;
-                        listener?.(...args);
+                    engine.current!.addListener(eventName, (...args) => {
+                        // eslint-disable-next-line prefer-spread
+                        (listeners.current[eventName] as ((...eventArgs: typeof args) => void) | undefined)?.apply(
+                            null,
+                            args
+                        );
                     });
                 });
             });
         }
 
         return () => {
-            engine.destroy();
+            engine.current?.destroy();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // update engine theme
     React.useEffect(() => {
-        if (engine.initialized) {
-            engine.setTheme(theme);
+        if (engine.current!.initialized) {
+            engine.current!.setTheme(theme);
         }
-    }, [engine, theme]);
+    }, [theme]);
 
     /**
      * Updates the listener reference in a ref. Engine event listeners are registered just once so
@@ -188,62 +187,61 @@ export function useRenderEngine({
 
     return {
         getCenterPosition: (): PIXI.PointData => {
-            return engine.getCenterPosition();
+            return engine.current!.getCenterPosition();
         },
         onEdgeSelected: (path: [string, string] | null) => {
-            if (engine.initialized) {
-                engine.selectEdge(path);
+            if (engine.current!.initialized) {
+                engine.current!.selectEdge(path as [string, string]);
             }
         },
         onNodeSelected: (node: string | null | undefined) => {
-            if (engine.initialized) {
-                engine.selectNode(node);
+            if (engine.current!.initialized) {
+                engine.current!.selectNode(node as string);
             }
         },
         onSearchResults: (nodes: string[]) => {
-            if (engine.initialized) {
-                engine.searchNodes(nodes);
+            if (engine.current!.initialized) {
+                engine.current!.searchNodes(nodes);
             }
         },
         onSetDragMode: (dragMode: DragMode | null) => {
-            engine.setDragMode(dragMode);
+            engine.current!.setDragMode(dragMode);
         },
         onSetFocus: (isFocused: boolean) => {
-            if (engine.initialized) {
-                engine.setFocus(isFocused);
+            if (engine.current!.initialized) {
+                engine.current!.setFocus(isFocused);
             }
         },
         onUpdateConstraints: (newConstraints: EdgeConstraint[]) => {
-            if (engine.initialized) {
-                engine.updateConstraints(newConstraints);
+            if (engine.current!.initialized) {
+                engine.current!.updateConstraints(newConstraints);
             }
         },
         resetLayout: () => {
-            if (engine.initialized) {
-                engine.debouncedUpdateLayout();
+            if (engine.current!.initialized) {
+                engine.current!.debouncedUpdateLayout();
             }
         },
         resetViewport: () => {
-            if (engine.initialized) {
-                engine.resetViewport();
+            if (engine.current!.initialized) {
+                engine.current!.resetViewport();
             }
         },
         collapseGroups: () => {
-            if (engine.initialized) {
-                engine.collapseAllGroups();
+            if (engine.current!.initialized) {
+                engine.current!.collapseAllGroups();
             }
         },
         expandGroups: () => {
-            if (engine.initialized) {
-                engine.expandAllGroups();
+            if (engine.current!.initialized) {
+                engine.current!.expandAllGroups();
             }
         },
-        extractImage: () => {
-            if (engine.initialized) {
-                return engine.extractImage();
+        extractImage: (() => {
+            if (engine.current!.initialized) {
+                return engine.current!.extractImage();
             }
-            return Promise.resolve(undefined);
-        },
+        }) as () => Promise<string | undefined>,
         useEngineEvent,
     };
 }

--- a/packages/ui-causal-graph-editor/src/shared/rendering/utils.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/utils.tsx
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ZoomState, ZoomThresholds } from '@types';
+import type { DirectionType, GraphTiers, ZoomState, ZoomThresholds } from '@types';
 
 import type { GraphLayout, GraphLayoutWithGrouping, GraphLayoutWithTiers } from '../graph-layout/common';
 
@@ -31,7 +31,7 @@ const colorCache = new Map<string, [number, number]>();
  */
 export function colorToPixi(color: string): [hex: number, alpha: number] {
     if (colorCache.has(color)) {
-        return colorCache.get(color);
+        return colorCache.get(color)!;
     }
 
     const pixiColor = new PIXI.Color(color);
@@ -74,10 +74,13 @@ export function getZoomState(scale: number, zoomThresholds?: ZoomThresholds): Zo
     );
 }
 
-export function isGraphLayoutWithTiers(layout: GraphLayout): layout is GraphLayoutWithTiers {
-    return (layout as GraphLayoutWithTiers).tiers !== undefined;
+export function isGraphLayoutWithTiers(
+    layout: GraphLayout
+): layout is GraphLayoutWithTiers & { orientation: DirectionType; tiers: GraphTiers } {
+    const tieredLayout = layout as GraphLayoutWithTiers;
+    return tieredLayout.tiers !== undefined && tieredLayout.orientation !== undefined;
 }
 
-export function isGraphLayoutWithGroups(layout: GraphLayout): layout is GraphLayoutWithGrouping {
+export function isGraphLayoutWithGroups(layout: GraphLayout): layout is GraphLayoutWithGrouping & { group: string } {
     return (layout as GraphLayoutWithGrouping).group !== undefined;
 }

--- a/packages/ui-causal-graph-editor/src/shared/rendering/utils.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/rendering/utils.tsx
@@ -77,8 +77,7 @@ export function getZoomState(scale: number, zoomThresholds?: ZoomThresholds): Zo
 export function isGraphLayoutWithTiers(
     layout: GraphLayout
 ): layout is GraphLayoutWithTiers & { orientation: DirectionType; tiers: GraphTiers } {
-    const tieredLayout = layout as GraphLayoutWithTiers;
-    return tieredLayout.tiers !== undefined && tieredLayout.orientation !== undefined;
+    return (layout as GraphLayoutWithTiers).tiers !== undefined;
 }
 
 export function isGraphLayoutWithGroups(layout: GraphLayout): layout is GraphLayoutWithGrouping & { group: string } {

--- a/packages/ui-causal-graph-editor/src/shared/serializer.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/serializer.tsx
@@ -127,7 +127,7 @@ export function serializeGraphNode(attributes: SimulationNode): CausalGraphNode 
 }
 
 type Entries<T> = {
-    [K in keyof T]: [K, T[K]];
+    [K in keyof T]-?: [K, T[K]];
 }[keyof T][];
 
 /**

--- a/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
@@ -46,37 +46,33 @@ export type GraphApi = {
  */
 export default function useCausalGraphEditor(
     graphData: CausalGraph,
-    editorMode: EditorMode,
+    editorMode: EditorMode | undefined,
     graphLayout: GraphLayout,
     availableInputs?: string[]
 ): UseCausalGraphEditorApi {
     const newNodesRequirePosition = graphLayout.requiresPosition;
 
-    const [state, dispatch] = useReducer(
-        GraphReducer,
-        {
-            newNodesRequirePosition,
-        },
-        (initState: GraphState) => {
-            const parsedGraph = causalGraphParser(graphData, availableInputs);
-            const newEditorMode = editorMode ?? (isDag(parsedGraph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
+    const [state, dispatch] = useReducer(GraphReducer, graphData, (initialGraphData): GraphState => {
+        const parsedGraph = causalGraphParser(initialGraphData, availableInputs);
+        const newEditorMode = editorMode ?? (isDag(parsedGraph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
 
-            return {
-                ...initState,
-                graph: parsedGraph,
-                editorMode: newEditorMode,
-            };
-        }
-    );
+        return {
+            graph: parsedGraph,
+            editorMode: newEditorMode,
+            newNodesRequirePosition,
+        };
+    });
 
     // bind each action creator to dispatch
     const api = useMemo(() => {
-        return actionNames.reduce<GraphApi>((acc, actionName) => {
-            const actionCreator = GraphActionCreators[actionName];
-            // eslint-disable-next-line prefer-spread
-            acc[actionName] = (...args: Parameters<typeof actionCreator>) => dispatch(actionCreator.apply(null, args));
-            return acc;
-        }, {} as GraphApi);
+        return Object.fromEntries(
+            actionNames.map((actionName) => {
+                const actionCreator = GraphActionCreators[actionName] as (
+                    ...args: never[]
+                ) => Parameters<typeof dispatch>[0];
+                return [actionName, (...args: never[]) => dispatch(actionCreator(...args))];
+            })
+        ) as GraphApi;
     }, [dispatch]);
 
     const isTimeSeriesCausalGraph = useMemo(() => {

--- a/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-causal-graph-editor.tsx
@@ -52,27 +52,35 @@ export default function useCausalGraphEditor(
 ): UseCausalGraphEditorApi {
     const newNodesRequirePosition = graphLayout.requiresPosition;
 
-    const [state, dispatch] = useReducer(GraphReducer, graphData, (initialGraphData): GraphState => {
-        const parsedGraph = causalGraphParser(initialGraphData, availableInputs);
-        const newEditorMode = editorMode ?? (isDag(parsedGraph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
-
-        return {
-            graph: parsedGraph,
-            editorMode: newEditorMode,
+    const [state, dispatch] = useReducer(
+        GraphReducer,
+        {
             newNodesRequirePosition,
-        };
-    });
+        } as GraphState,
+        (initState: GraphState) => {
+            const parsedGraph = causalGraphParser(graphData, availableInputs);
+            const newEditorMode = editorMode ?? (isDag(parsedGraph) ? EditorMode.DEFAULT : EditorMode.PAG_VIEWER);
+
+            return {
+                ...initState,
+                graph: parsedGraph,
+                editorMode: newEditorMode,
+            };
+        }
+    );
 
     // bind each action creator to dispatch
     const api = useMemo(() => {
-        return Object.fromEntries(
-            actionNames.map((actionName) => {
-                const actionCreator = GraphActionCreators[actionName] as (
-                    ...args: never[]
-                ) => Parameters<typeof dispatch>[0];
-                return [actionName, (...args: never[]) => dispatch(actionCreator(...args))];
-            })
-        ) as GraphApi;
+        return actionNames.reduce<GraphApi>((acc, actionName) => {
+            const actionCreator = GraphActionCreators[actionName];
+            // TypeScript cannot correlate a union key with its mapped function signature.
+            (acc as Record<ActionName, (...args: never[]) => void>)[actionName] = (...args: never[]) =>
+                dispatch(
+                    // eslint-disable-next-line prefer-spread
+                    (actionCreator as (...actionArgs: never[]) => ReturnType<typeof actionCreator>).apply(null, args)
+                );
+            return acc;
+        }, {} as GraphApi);
     }, [dispatch]);
 
     const isTimeSeriesCausalGraph = useMemo(() => {

--- a/packages/ui-causal-graph-editor/src/shared/use-drag-mode.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-drag-mode.tsx
@@ -32,8 +32,12 @@ function useDragMode(
     allowEdgeAdd: boolean,
     allowNodeDrag: boolean,
     onDragModeChange: (dragMode: DragMode | null) => void
-): { dragEnabled: boolean; dragMode: DragMode; setDragMode: React.Dispatch<React.SetStateAction<DragMode>> } {
-    const [dragMode, setDragMode] = useState<DragMode>(() => {
+): {
+    dragEnabled: boolean;
+    dragMode: DragMode | null;
+    setDragMode: React.Dispatch<React.SetStateAction<DragMode | null>>;
+} {
+    const [dragMode, setDragMode] = useState<DragMode | null>(() => {
         if (editMode && allowEdgeAdd) {
             return 'create_edge';
         }

--- a/packages/ui-causal-graph-editor/src/shared/use-edge-encoder.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-edge-encoder.tsx
@@ -71,7 +71,7 @@ interface EdgeConstraintEncoderApi {
     /**
      * Add a new constraint
      */
-    addConstraint: (source?: string, target?: string) => void;
+    addConstraint: (source: string, target: string) => void;
     /**
      * Current constraints
      */
@@ -116,12 +116,12 @@ export function useEdgeConstraintEncoder(
         });
     }
 
-    function addConstraint(source?: string, target?: string): void {
+    function addConstraint(source: string, target: string): void {
         setConstraints((draft) => {
             draft.push({
                 id: nanoid(),
-                source: source ?? null,
-                target: target ?? null,
+                source,
+                target,
                 type: EdgeConstraintType.UNDIRECTED,
             });
         });

--- a/packages/ui-causal-graph-editor/src/shared/use-edge-encoder.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-edge-encoder.tsx
@@ -71,7 +71,7 @@ interface EdgeConstraintEncoderApi {
     /**
      * Add a new constraint
      */
-    addConstraint: (source: string, target: string) => void;
+    addConstraint: (source?: string, target?: string) => void;
     /**
      * Current constraints
      */
@@ -116,12 +116,12 @@ export function useEdgeConstraintEncoder(
         });
     }
 
-    function addConstraint(source: string, target: string): void {
+    function addConstraint(source?: string, target?: string): void {
         setConstraints((draft) => {
             draft.push({
                 id: nanoid(),
-                source,
-                target,
+                source: (source ?? null) as string,
+                target: (target ?? null) as string,
                 type: EdgeConstraintType.UNDIRECTED,
             });
         });

--- a/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
@@ -12,7 +12,7 @@ import usePaneVisibility from './use-pane-visibility';
  */
 export default function useGraphTooltip(
     pane: React.RefObject<HTMLElement>,
-    tooltipRef: React.MutableRefObject<() => DOMRect>
+    tooltipRef: React.MutableRefObject<(() => DOMRect) | null>
 ): {
     setTooltipContent: (content: React.ReactNode) => void;
     tooltipContent: React.ReactNode;
@@ -65,7 +65,12 @@ export default function useGraphTooltip(
         // NOTE: This is technically async but will resolve immediately as it's resolved
         // in response to IntersectionObserver callback, which is guaranteed to fire
         // the next render cycle
-        isRectVisible(tooltipRef.current()).then((isVisible) => {
+        const getTooltipRect = tooltipRef.current;
+        if (!getTooltipRect) {
+            return;
+        }
+
+        isRectVisible(getTooltipRect()).then((isVisible) => {
             setTooltipContent(isVisible ? content : null);
         });
     }

--- a/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-graph-tooltip.tsx
@@ -65,12 +65,7 @@ export default function useGraphTooltip(
         // NOTE: This is technically async but will resolve immediately as it's resolved
         // in response to IntersectionObserver callback, which is guaranteed to fire
         // the next render cycle
-        const getTooltipRect = tooltipRef.current;
-        if (!getTooltipRect) {
-            return;
-        }
-
-        isRectVisible(getTooltipRect()).then((isVisible) => {
+        isRectVisible(tooltipRef.current!()).then((isVisible) => {
             setTooltipContent(isVisible ? content : null);
         });
     }

--- a/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
@@ -44,11 +44,6 @@ export default function usePaneVisibility(
         if (!isPaneVisible.current) {
             return false;
         }
-        const paneElement = pane.current;
-        if (!paneElement) {
-            return false;
-        }
-
         // otherwise create a new one-off observer to check whether given domRect position is on screen
         // NOTE: we're relying on the fact that as per the IntersectionObserver spec, the callback is immediately invoked on observe
         let resolve: (entries: IntersectionObserverEntry | null) => void;
@@ -58,7 +53,7 @@ export default function usePaneVisibility(
         const observer = new IntersectionObserver((entries) => {
             resolve(entries[0]);
         });
-        observer.observe(paneElement);
+        observer.observe(pane.current!);
 
         // create a timeout promise to race with to ensure the promise resolves in a reasonable time
         const timeoutPromise = new Promise<null>((r) => setTimeout(r, 500, null));

--- a/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/use-pane-visibility.tsx
@@ -44,6 +44,10 @@ export default function usePaneVisibility(
         if (!isPaneVisible.current) {
             return false;
         }
+        const paneElement = pane.current;
+        if (!paneElement) {
+            return false;
+        }
 
         // otherwise create a new one-off observer to check whether given domRect position is on screen
         // NOTE: we're relying on the fact that as per the IntersectionObserver spec, the callback is immediately invoked on observe
@@ -54,7 +58,7 @@ export default function usePaneVisibility(
         const observer = new IntersectionObserver((entries) => {
             resolve(entries[0]);
         });
-        observer.observe(pane.current);
+        observer.observe(paneElement);
 
         // create a timeout promise to race with to ensure the promise resolves in a reasonable time
         const timeoutPromise = new Promise<null>((r) => setTimeout(r, 500, null));

--- a/packages/ui-causal-graph-editor/src/shared/utils.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/utils.tsx
@@ -59,6 +59,9 @@ export function willCreateCycle(graphOriginal: SimulationGraph, edge: [string, s
     // keep traversing the graph until we have checked all nodes that are reachable from the destination node
     while (nodesToCheck.length > 0) {
         currentNode = nodesToCheck.pop();
+        if (!currentNode) {
+            continue;
+        }
 
         // Only check this condition after first iteration; if we reach the destination node again, we have a cycle
         if (currentNode === edge[1] && checkedNodes.size > 0) {
@@ -206,6 +209,13 @@ export function getPathInNodeAttribute(attributes: Record<string, any>, path: st
     return undefined;
 }
 
+function getAttributeKey(value: unknown): string | undefined {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    return undefined;
+}
+
 /**
  * Gets nodes grouped by a given attribute
  * @param nodes nodes to be grouped
@@ -223,8 +233,8 @@ export function getGroupToNodesMap(nodes: string[], group: string, graph: Simula
         const nodeGroup = attributePathArray.reduce(getPathInNodeAttribute, nodeAttributes);
 
         // If it is not undefined at this point i.e. node group was found
-        if (nodeGroup !== undefined) {
-            const groupKey = String(nodeGroup);
+        const groupKey = getAttributeKey(nodeGroup);
+        if (groupKey !== undefined) {
             // if group is not in tieredNodes add it, if it is add node to that tier
             if (groupKey in groupAccumulator) {
                 groupAccumulator[groupKey].push(node);
@@ -252,8 +262,8 @@ export function getNodeToGroupMap(nodes: string[], group: string, graph: Simulat
         const nodeGroup = attributePathArray.reduce(getPathInNodeAttribute, nodeAttributes);
 
         // If the node group is found, map the node to its group
-        if (nodeGroup !== undefined) {
-            const groupKey = String(nodeGroup);
+        const groupKey = getAttributeKey(nodeGroup);
+        if (groupKey !== undefined) {
             nodeToGroupMap[node] = groupKey;
         }
         return nodeToGroupMap;
@@ -276,8 +286,8 @@ export function getNodeOrder(nodes: string[], orderPath: string, graph: Simulati
         const nodeOrder = attributePathArray.reduce(getPathInNodeAttribute, nodeAttributes);
 
         // If it is not undefined at this point i.e. node order was found
-        if (nodeOrder !== undefined) {
-            const order = String(nodeOrder);
+        const order = getAttributeKey(nodeOrder);
+        if (order !== undefined) {
             groupAccumulator[node] = order;
         }
         return groupAccumulator;

--- a/packages/ui-causal-graph-editor/src/shared/utils.tsx
+++ b/packages/ui-causal-graph-editor/src/shared/utils.tsx
@@ -59,19 +59,16 @@ export function willCreateCycle(graphOriginal: SimulationGraph, edge: [string, s
     // keep traversing the graph until we have checked all nodes that are reachable from the destination node
     while (nodesToCheck.length > 0) {
         currentNode = nodesToCheck.pop();
-        if (!currentNode) {
-            continue;
-        }
 
         // Only check this condition after first iteration; if we reach the destination node again, we have a cycle
         if (currentNode === edge[1] && checkedNodes.size > 0) {
             return true;
         }
 
-        checkedNodes.add(currentNode);
+        checkedNodes.add(currentNode as string);
 
         // eslint-disable-next-line no-loop-func
-        graph.forEachEdge(currentNode, (_, edgeAttrs, source, target) => {
+        graph.forEachEdge(currentNode as string, (_, edgeAttrs, source, target) => {
             // only if it's an inbound directed edge, check the source node
             if (target === currentNode && edgeAttrs.edge_type === EdgeType.DIRECTED_EDGE) {
                 nodesToCheck.push(source);
@@ -209,13 +206,6 @@ export function getPathInNodeAttribute(attributes: Record<string, any>, path: st
     return undefined;
 }
 
-function getAttributeKey(value: unknown): string | undefined {
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        return String(value);
-    }
-    return undefined;
-}
-
 /**
  * Gets nodes grouped by a given attribute
  * @param nodes nodes to be grouped
@@ -233,8 +223,8 @@ export function getGroupToNodesMap(nodes: string[], group: string, graph: Simula
         const nodeGroup = attributePathArray.reduce(getPathInNodeAttribute, nodeAttributes);
 
         // If it is not undefined at this point i.e. node group was found
-        const groupKey = getAttributeKey(nodeGroup);
-        if (groupKey !== undefined) {
+        if (nodeGroup !== undefined) {
+            const groupKey = String(nodeGroup as unknown as string | number | boolean);
             // if group is not in tieredNodes add it, if it is add node to that tier
             if (groupKey in groupAccumulator) {
                 groupAccumulator[groupKey].push(node);
@@ -262,8 +252,8 @@ export function getNodeToGroupMap(nodes: string[], group: string, graph: Simulat
         const nodeGroup = attributePathArray.reduce(getPathInNodeAttribute, nodeAttributes);
 
         // If the node group is found, map the node to its group
-        const groupKey = getAttributeKey(nodeGroup);
-        if (groupKey !== undefined) {
+        if (nodeGroup !== undefined) {
+            const groupKey = String(nodeGroup as unknown as string | number | boolean);
             nodeToGroupMap[node] = groupKey;
         }
         return nodeToGroupMap;
@@ -286,8 +276,8 @@ export function getNodeOrder(nodes: string[], orderPath: string, graph: Simulati
         const nodeOrder = attributePathArray.reduce(getPathInNodeAttribute, nodeAttributes);
 
         // If it is not undefined at this point i.e. node order was found
-        const order = getAttributeKey(nodeOrder);
-        if (order !== undefined) {
+        if (nodeOrder !== undefined) {
+            const order = String(nodeOrder as unknown as string | number | boolean);
             groupAccumulator[node] = order;
         }
         return groupAccumulator;

--- a/packages/ui-causal-graph-editor/src/types.tsx
+++ b/packages/ui-causal-graph-editor/src/types.tsx
@@ -134,10 +134,10 @@ export enum EdgeType {
 }
 
 export interface GraphState {
-    /** Mode editor is in - set by INIT action */
-    editorMode?: EditorMode;
+    /** Mode the editor is in */
+    editorMode: EditorMode;
     /** Graphology.Graph holding current state */
-    graph?: SimulationGraph;
+    graph: SimulationGraph;
     /** Whether new nodes require a position */
     newNodesRequirePosition?: boolean;
     /** List of removed nodes that can be restored */
@@ -320,7 +320,7 @@ export type GraphTiers = string[][] | TiersConfig;
  */
 export interface TieredGraphLayoutBuilder {
     orientation?: DirectionType;
-    tiers: GraphTiers;
+    tiers?: GraphTiers;
 }
 
 /**
@@ -328,7 +328,7 @@ export interface TieredGraphLayoutBuilder {
  */
 export interface GroupingLayoutBuilder {
     /** The path for the property in the node that should be used for defining their layer */
-    group: string;
+    group?: string;
 }
 
 /**

--- a/packages/ui-components/src/accordion/accordion.tsx
+++ b/packages/ui-components/src/accordion/accordion.tsx
@@ -57,8 +57,8 @@ export interface AccordionProps {
 }
 
 function getInitialOpen(
-    initialItems: Array<number> | number,
-    value: Array<number> | number,
+    initialItems: Array<number> | number | undefined,
+    value: Array<number> | number | undefined,
     itemsArray: Array<AccordionItemType>
 ): Array<boolean> {
     if (value !== undefined) {
@@ -88,7 +88,7 @@ function Accordion({
     initialOpenItems,
     headerRenderer,
     innerRenderer,
-    items,
+    items = [],
     style,
     multi = true,
     onChange,

--- a/packages/ui-components/src/accordion/accordion.tsx
+++ b/packages/ui-components/src/accordion/accordion.tsx
@@ -88,14 +88,14 @@ function Accordion({
     initialOpenItems,
     headerRenderer,
     innerRenderer,
-    items = [],
+    items,
     style,
     multi = true,
     onChange,
     value,
     id,
 }: AccordionProps): JSX.Element {
-    const [openItems, setOpenItems] = useState<boolean[]>(getInitialOpen(initialOpenItems, value, items));
+    const [openItems, setOpenItems] = useState<boolean[]>(getInitialOpen(initialOpenItems, value, items!));
 
     const onClick = useCallback(
         (index: number): void => {
@@ -127,13 +127,13 @@ function Accordion({
     );
 
     useEffect(() => {
-        setOpenItems(getInitialOpen(initialOpenItems, value, items));
+        setOpenItems(getInitialOpen(initialOpenItems, value, items!));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [value]);
 
     return (
         <AccordionWrapper className={className} id={id} style={style}>
-            {items.map((item, index) => (
+            {items!.map((item, index) => (
                 <AccordionItem
                     backgroundColor={backgroundColor}
                     headerRenderer={headerRenderer}

--- a/packages/ui-components/src/button-bar/button-bar.tsx
+++ b/packages/ui-components/src/button-bar/button-bar.tsx
@@ -57,7 +57,12 @@ const shouldForwardProp = (prop: any): boolean => !['selected'].includes(prop);
  * @param disabled whether button is disabled
  * @param theme the current theme being used by the app
  */
-function getButtonStyle(buttonColor: string, disabled: boolean, selected: boolean, theme: DefaultTheme): string {
+function getButtonStyle(
+    buttonColor: string,
+    disabled: boolean | undefined,
+    selected: boolean,
+    theme: DefaultTheme
+): string {
     let color = buttonColor;
     let backgroundColor = 'transparent';
     if (selected) {

--- a/packages/ui-components/src/button/button.tsx
+++ b/packages/ui-components/src/button/button.tsx
@@ -55,7 +55,7 @@ export const BaseButton = styled.button<BaseButtonProps>`
  * @param disabled whether button is disabled
  * @param theme the current theme being used by the app
  */
-function getOutlinedButtonStyle(buttonColor: string, disabled: boolean, theme: DefaultTheme): string {
+function getOutlinedButtonStyle(buttonColor: string, disabled: boolean | undefined, theme: DefaultTheme): string {
     return `
         color: ${disabled ? theme.colors.grey2 : buttonColor};
 
@@ -91,7 +91,7 @@ function getFilledButtonStyle(
     buttonColor: string,
     hoverColor: string,
     clickColor: string,
-    disabled: boolean,
+    disabled: boolean | undefined,
     theme: DefaultTheme,
     textColor?: string
 ): string {

--- a/packages/ui-components/src/chat/chat.tsx
+++ b/packages/ui-components/src/chat/chat.tsx
@@ -26,7 +26,7 @@ import TextArea from '../textarea/textarea';
 import { type InteractiveComponentProps, type Message, type UserData } from '../types';
 import { default as MessageComponent } from './message';
 
-const ChatWrapper = styled.div<{ $isPopup: boolean }>`
+const ChatWrapper = styled.div<{ $isPopup?: boolean }>`
     overflow-y: auto;
     display: flex;
     flex-direction: column;

--- a/packages/ui-components/src/chat/message.tsx
+++ b/packages/ui-components/src/chat/message.tsx
@@ -243,7 +243,7 @@ function MessageComponent(props: MessageProps): JSX.Element {
             updated_at: new Date().toISOString(),
         };
 
-        props.onChange?.(newMessage);
+        props?.onChange!(newMessage);
         setLocalMessage(newMessage);
         // reset the textarea message to the message without the /n and trailing whitespace
         setEditMessage(newMessage.message);
@@ -261,7 +261,7 @@ function MessageComponent(props: MessageProps): JSX.Element {
             role="listitem"
             className={props.className}
             style={props.style}
-            $messageFromActiveUser={Boolean(props.didUserWriteMessage)}
+            $messageFromActiveUser={props.didUserWriteMessage as boolean}
         >
             <MessageTop>
                 <UserInfoWrapper>

--- a/packages/ui-components/src/chat/message.tsx
+++ b/packages/ui-components/src/chat/message.tsx
@@ -146,6 +146,8 @@ const AvatarIcon = styled.div`
 `;
 
 export interface MessageProps extends InteractiveComponentProps<Message> {
+    /** The message to display */
+    value: Message;
     /** An optional onChange handler for listening to changes in the input */
     onChange?: (value: Message, e?: React.SyntheticEvent<HTMLInputElement>) => void | Promise<void>;
     /** An optional event listener for complete events (enter presses) */
@@ -241,7 +243,7 @@ function MessageComponent(props: MessageProps): JSX.Element {
             updated_at: new Date().toISOString(),
         };
 
-        props?.onChange(newMessage);
+        props.onChange?.(newMessage);
         setLocalMessage(newMessage);
         // reset the textarea message to the message without the /n and trailing whitespace
         setEditMessage(newMessage.message);
@@ -259,7 +261,7 @@ function MessageComponent(props: MessageProps): JSX.Element {
             role="listitem"
             className={props.className}
             style={props.style}
-            $messageFromActiveUser={props.didUserWriteMessage}
+            $messageFromActiveUser={Boolean(props.didUserWriteMessage)}
         >
             <MessageTop>
                 <UserInfoWrapper>

--- a/packages/ui-components/src/checkbox/checkbox-group.tsx
+++ b/packages/ui-components/src/checkbox/checkbox-group.tsx
@@ -67,7 +67,7 @@ export interface CheckboxGroupProps {
     values?: Array<Item>;
 }
 
-function getInitialValue(initialValue: Array<Item> | Item): Array<Item> {
+function getInitialValue(initialValue?: Array<Item> | Item): Array<Item> {
     if (Array.isArray(initialValue)) {
         return initialValue;
     }
@@ -78,10 +78,7 @@ function getInitialValue(initialValue: Array<Item> | Item): Array<Item> {
 }
 
 function getInitialCheckedState(items: Array<Item>, initialValues: Array<any>): Array<ItemState> {
-    if (initialValues) {
-        return items.map((item) => ({ state: initialValues.includes(item.value), value: item.value }));
-    }
-    return items.map((item) => ({ state: initialValues.includes(item.value), value: false }));
+    return items.map((item) => ({ state: initialValues.includes(item.value), value: item.value }));
 }
 
 /**
@@ -127,11 +124,7 @@ function CheckboxGroup(props: CheckboxGroupProps): JSX.Element {
 
         // if new values would result in above the number permitted, only allow to uncheck selected checkboxes
         // or if values below above permited/unconstrained then allow it to switch states
-        if (
-            (newValues.length > props.selectMax && checkedState[chosenIndex]) ||
-            newValues.length <= props.selectMax ||
-            !props.selectMax
-        ) {
+        if (!props.selectMax || newValues.length <= props.selectMax || checkedState[chosenIndex]) {
             const indexToUpdate = checkedState.findIndex((item) => item.value === chosenValue);
             checkedState[indexToUpdate].state = !checkedState[indexToUpdate].state;
             setCheckedState(checkedState);

--- a/packages/ui-components/src/checkbox/checkbox-group.tsx
+++ b/packages/ui-components/src/checkbox/checkbox-group.tsx
@@ -77,8 +77,11 @@ function getInitialValue(initialValue?: Array<Item> | Item): Array<Item> {
     return [];
 }
 
-function getInitialCheckedState(items: Array<Item>, initialValues: Array<any>): Array<ItemState> {
-    return items.map((item) => ({ state: initialValues.includes(item.value), value: item.value }));
+function getInitialCheckedState(items: Array<Item>, initialValues?: Array<any>): Array<ItemState> {
+    if (initialValues) {
+        return items.map((item) => ({ state: initialValues.includes(item.value), value: item.value }));
+    }
+    return items.map((item) => ({ state: initialValues!.includes(item.value), value: false }));
 }
 
 /**
@@ -124,7 +127,11 @@ function CheckboxGroup(props: CheckboxGroupProps): JSX.Element {
 
         // if new values would result in above the number permitted, only allow to uncheck selected checkboxes
         // or if values below above permited/unconstrained then allow it to switch states
-        if (!props.selectMax || newValues.length <= props.selectMax || checkedState[chosenIndex]) {
+        if (
+            (newValues.length > props.selectMax! && checkedState[chosenIndex]) ||
+            newValues.length <= props.selectMax! ||
+            !props.selectMax
+        ) {
             const indexToUpdate = checkedState.findIndex((item) => item.value === chosenValue);
             checkedState[indexToUpdate].state = !checkedState[indexToUpdate].state;
             setCheckedState(checkedState);

--- a/packages/ui-components/src/checkbox/checkbox.tsx
+++ b/packages/ui-components/src/checkbox/checkbox.tsx
@@ -21,7 +21,7 @@ import styled from '@darajs/styled-components';
 import { type InteractiveComponentProps } from '../types';
 
 interface CheckboxWrapperProps {
-    disabled: boolean;
+    disabled?: boolean;
     isListStyle?: boolean;
 }
 

--- a/packages/ui-components/src/checkbox/tri-state-checkbox.tsx
+++ b/packages/ui-components/src/checkbox/tri-state-checkbox.tsx
@@ -51,7 +51,7 @@ const StyledTriStateCheckbox = styled.div<TriStateProp>`
     }}
 `;
 
-function computeState(allSelected: boolean, noneSelected: boolean): CheckboxState {
+function computeState(allSelected?: boolean, noneSelected?: boolean): CheckboxState {
     if (noneSelected) {
         return CheckboxState.UNCHECKED;
     }
@@ -67,7 +67,7 @@ export interface CheckboxProps extends InteractiveComponentProps<boolean> {
     onChange?: (state: CheckboxState, e?: React.SyntheticEvent<HTMLInputElement, Event>) => void | Promise<void>;
 }
 
-function getControlledState(allSelected: boolean, noneSelected: boolean): boolean | undefined {
+function getControlledState(allSelected?: boolean, noneSelected?: boolean): boolean | undefined {
     if (allSelected) {
         return allSelected;
     }

--- a/packages/ui-components/src/code-viewer/code-viewer.tsx
+++ b/packages/ui-components/src/code-viewer/code-viewer.tsx
@@ -82,7 +82,6 @@ const StyledPre = styled.pre<{ $isLightTheme?: boolean }>`
 function CodeViewer(props: CodeViewerProps): JSX.Element {
     const themeCtx = useTheme();
     const [isCopied, setIsCopied] = useState(false);
-    const code = props.value ?? '';
 
     useEffect(() => {
         if (isCopied) {
@@ -94,8 +93,8 @@ function CodeViewer(props: CodeViewerProps): JSX.Element {
         }
     }, [isCopied]);
 
-    async function copyCodeToClipboard(sourceCode: string): Promise<void> {
-        const success = await copyToClipboard(sourceCode);
+    async function copyCodeToClipboard(code: string): Promise<void> {
+        const success = await copyToClipboard(code);
 
         if (success) {
             setIsCopied(true);
@@ -133,14 +132,14 @@ function CodeViewer(props: CodeViewerProps): JSX.Element {
                     </CopyToClipboardContainer>
                 :   <CopyToClipboardContainer
                         style={{ cursor: 'pointer' }}
-                        onClick={() => copyCodeToClipboard(code)}
+                        onClick={() => copyCodeToClipboard(props.value!)}
                         role="button"
                     >
                         <Copy /> Copy code
                     </CopyToClipboardContainer>
                 }
             </TopBar>
-            <Highlight {...defaultProps} code={code} language={props.language} theme={viewerTheme}>
+            <Highlight {...defaultProps} code={props.value!} language={props.language} theme={viewerTheme}>
                 {({ className, style, tokens, getLineProps, getTokenProps }) => (
                     <StyledPre
                         className={className}

--- a/packages/ui-components/src/code-viewer/code-viewer.tsx
+++ b/packages/ui-components/src/code-viewer/code-viewer.tsx
@@ -82,6 +82,7 @@ const StyledPre = styled.pre<{ $isLightTheme?: boolean }>`
 function CodeViewer(props: CodeViewerProps): JSX.Element {
     const themeCtx = useTheme();
     const [isCopied, setIsCopied] = useState(false);
+    const code = props.value ?? '';
 
     useEffect(() => {
         if (isCopied) {
@@ -93,8 +94,8 @@ function CodeViewer(props: CodeViewerProps): JSX.Element {
         }
     }, [isCopied]);
 
-    async function copyCodeToClipboard(code: string): Promise<void> {
-        const success = await copyToClipboard(code);
+    async function copyCodeToClipboard(sourceCode: string): Promise<void> {
+        const success = await copyToClipboard(sourceCode);
 
         if (success) {
             setIsCopied(true);
@@ -132,14 +133,14 @@ function CodeViewer(props: CodeViewerProps): JSX.Element {
                     </CopyToClipboardContainer>
                 :   <CopyToClipboardContainer
                         style={{ cursor: 'pointer' }}
-                        onClick={() => copyCodeToClipboard(props.value)}
+                        onClick={() => copyCodeToClipboard(code)}
                         role="button"
                     >
                         <Copy /> Copy code
                     </CopyToClipboardContainer>
                 }
             </TopBar>
-            <Highlight {...defaultProps} code={props.value} language={props.language} theme={viewerTheme}>
+            <Highlight {...defaultProps} code={code} language={props.language} theme={viewerTheme}>
                 {({ className, style, tokens, getLineProps, getTokenProps }) => (
                     <StyledPre
                         className={className}

--- a/packages/ui-components/src/combo-box/combo-box.tsx
+++ b/packages/ui-components/src/combo-box/combo-box.tsx
@@ -178,7 +178,7 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
         itemToString: (item) => (item ? item.label : ''),
         items: filteredItems,
         onInputValueChange: (change) => {
-            setInputValue(change.inputValue ?? '');
+            setInputValue(change.inputValue as string);
         },
         onSelectedItemChange: (changes) => {
             if (props.onSelect) {
@@ -186,9 +186,7 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                     (props.selectedItem && changes.selectedItem?.value !== props.selectedItem?.value) ||
                     !props.selectedItem
                 ) {
-                    if (changes.selectedItem) {
-                        props.onSelect(changes.selectedItem);
-                    }
+                    props.onSelect(changes.selectedItem as Item);
                 }
             }
         },
@@ -201,9 +199,8 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                 (type === stateChangeTypes.ControlledPropUpdatedSelectedItem && changes.isOpen)
             ) {
                 // This is a hack to change the highlight in the next render cycle so filteredItems had time to update
-                const selectedItemValue = changes.selectedItem?.value;
                 setPendingHighlight(
-                    selectedItemValue === undefined ? 0 : props.items.findIndex((i) => i.value === selectedItemValue)
+                    changes.selectedItem ? props.items.findIndex((i) => i.value === changes.selectedItem!.value) : 0
                 );
                 return {
                     ...changes,
@@ -280,13 +277,13 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
         <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
             <Wrapper
                 className={props.className}
-                isDisabled={Boolean(props.disabled)}
+                isDisabled={props.disabled as boolean}
                 isErrored={!!props.errorMsg}
                 isOpen={isOpen}
                 style={props.style}
                 id={props.id}
             >
-                <InputWrapper disabled={Boolean(props.disabled)} isOpen={isOpen} ref={refs.setReference}>
+                <InputWrapper disabled={props.disabled as boolean} isOpen={isOpen} ref={refs.setReference}>
                     <Input
                         {...inputProps}
                         {...inputHandlers}
@@ -296,7 +293,7 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                         size={props.size}
                     />
                     <ChevronButton
-                        disabled={Boolean(props.disabled)}
+                        disabled={props.disabled as boolean}
                         isOpen={isOpen}
                         getToggleButtonProps={getToggleButtonProps}
                     />
@@ -311,7 +308,7 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                         getMenuProps={getMenuProps}
                         size={props.size}
                         ref={refs.setFloating}
-                        selectedItem={selectedItem ?? undefined}
+                        selectedItem={selectedItem as Item}
                         kbdHighlightIdx={kbdHighlightIdx}
                     />,
                     document.body

--- a/packages/ui-components/src/combo-box/combo-box.tsx
+++ b/packages/ui-components/src/combo-box/combo-box.tsx
@@ -138,7 +138,7 @@ export interface ComboBoxProps extends InteractiveComponentProps<Item> {
     /** An optional placeholder for the input field to display when nothing is selected, defaults to '' */
     placeholder?: string;
     /** Set the selected value to a specific value, will put the component in controlled mode. Set to `null` to reset the value. */
-    selectedItem?: Item;
+    selectedItem?: Item | null;
     /** Font size in rem to show in the Select */
     size?: number;
     /** Pass through of style property to the root element */
@@ -153,7 +153,7 @@ export interface ComboBoxProps extends InteractiveComponentProps<Item> {
  */
 function ComboBox(props: ComboBoxProps): JSX.Element {
     const [inputValue, setInputValue] = useState(props.initialValue?.label ?? props.selectedItem?.label ?? '');
-    const [pendingHighlight, setPendingHighlight] = useState(null);
+    const [pendingHighlight, setPendingHighlight] = useState<number | null>(null);
 
     const filteredItems = useMemo(
         () =>
@@ -178,7 +178,7 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
         itemToString: (item) => (item ? item.label : ''),
         items: filteredItems,
         onInputValueChange: (change) => {
-            setInputValue(change.inputValue);
+            setInputValue(change.inputValue ?? '');
         },
         onSelectedItemChange: (changes) => {
             if (props.onSelect) {
@@ -186,7 +186,9 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                     (props.selectedItem && changes.selectedItem?.value !== props.selectedItem?.value) ||
                     !props.selectedItem
                 ) {
-                    props.onSelect(changes.selectedItem);
+                    if (changes.selectedItem) {
+                        props.onSelect(changes.selectedItem);
+                    }
                 }
             }
         },
@@ -199,8 +201,9 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                 (type === stateChangeTypes.ControlledPropUpdatedSelectedItem && changes.isOpen)
             ) {
                 // This is a hack to change the highlight in the next render cycle so filteredItems had time to update
+                const selectedItemValue = changes.selectedItem?.value;
                 setPendingHighlight(
-                    changes.selectedItem ? props.items.findIndex((i) => i.value === changes.selectedItem.value) : 0
+                    selectedItemValue === undefined ? 0 : props.items.findIndex((i) => i.value === selectedItemValue)
                 );
                 return {
                     ...changes,
@@ -277,13 +280,13 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
         <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
             <Wrapper
                 className={props.className}
-                isDisabled={props.disabled}
+                isDisabled={Boolean(props.disabled)}
                 isErrored={!!props.errorMsg}
                 isOpen={isOpen}
                 style={props.style}
                 id={props.id}
             >
-                <InputWrapper disabled={props.disabled} isOpen={isOpen} ref={refs.setReference}>
+                <InputWrapper disabled={Boolean(props.disabled)} isOpen={isOpen} ref={refs.setReference}>
                     <Input
                         {...inputProps}
                         {...inputHandlers}
@@ -293,7 +296,7 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                         size={props.size}
                     />
                     <ChevronButton
-                        disabled={props.disabled}
+                        disabled={Boolean(props.disabled)}
                         isOpen={isOpen}
                         getToggleButtonProps={getToggleButtonProps}
                     />
@@ -308,7 +311,7 @@ function ComboBox(props: ComboBoxProps): JSX.Element {
                         getMenuProps={getMenuProps}
                         size={props.size}
                         ref={refs.setFloating}
-                        selectedItem={selectedItem}
+                        selectedItem={selectedItem ?? undefined}
                         kbdHighlightIdx={kbdHighlightIdx}
                     />,
                     document.body

--- a/packages/ui-components/src/component-select-list/component-select-list.tsx
+++ b/packages/ui-components/src/component-select-list/component-select-list.tsx
@@ -115,7 +115,7 @@ function getSelectedIndex(selectedItems: Array<string>, item: ComponentSelectIte
 function updateSelectedItems(
     prevSelections: Array<string>,
     item: ComponentSelectItem,
-    multiSelect: boolean
+    multiSelect?: boolean
 ): Array<string> {
     const selectedIndex = getSelectedIndex(prevSelections, item);
     // Remove from selections if item is already selected

--- a/packages/ui-components/src/context-menu/context-menu.tsx
+++ b/packages/ui-components/src/context-menu/context-menu.tsx
@@ -230,13 +230,12 @@ function ContextMenu<T extends React.ElementType>(Component: T): (props: Context
             menuItems,
             onClick: handleClick,
         });
-        const RootComponent: React.ElementType = Component;
-
         return (
             <>
-                <RootComponent {...props.elementProps} className={props.className} onContextMenu={onContextMenu}>
+                {/* @ts-expect-error TypeScript cannot resolve JSX props for a generic element type. */}
+                <Component {...props.elementProps} className={props.className} onContextMenu={onContextMenu}>
                     {props.children}
-                </RootComponent>
+                </Component>
                 {contextMenu}
             </>
         );

--- a/packages/ui-components/src/context-menu/context-menu.tsx
+++ b/packages/ui-components/src/context-menu/context-menu.tsx
@@ -26,7 +26,7 @@ export interface MenuAction {
     label: string;
 }
 
-export interface ContextMenuProps<T> {
+export interface ContextMenuProps<T extends React.ElementType> {
     /** An array of actions to show in the context menu */
     actions: Array<MenuAction>;
     /** Pass through children onto the root element */
@@ -34,7 +34,7 @@ export interface ContextMenuProps<T> {
     /** Pass through className onto the root element */
     className?: string;
     /** Any element props for the root element */
-    elementProps?: T;
+    elementProps?: React.ComponentPropsWithoutRef<T>;
 }
 
 export interface UseContextMenuProps {
@@ -201,7 +201,7 @@ export function useContextMenu(props: UseContextMenuProps): UseContextMenuReturn
  *
  * @param Component the component to wrap and draw as the root
  */
-function ContextMenu<T>(Component: React.ComponentType<T> | string): (props: ContextMenuProps<T>) => JSX.Element {
+function ContextMenu<T extends React.ElementType>(Component: T): (props: ContextMenuProps<T>) => JSX.Element {
     function WrappedContextMenu(props: ContextMenuProps<T>): JSX.Element {
         const menuItems = React.useMemo<MenuItem[][]>(() => {
             return [
@@ -230,12 +230,13 @@ function ContextMenu<T>(Component: React.ComponentType<T> | string): (props: Con
             menuItems,
             onClick: handleClick,
         });
+        const RootComponent: React.ElementType = Component;
 
         return (
             <>
-                <Component {...props.elementProps} className={props.className} onContextMenu={onContextMenu}>
+                <RootComponent {...props.elementProps} className={props.className} onContextMenu={onContextMenu}>
                     {props.children}
-                </Component>
+                </RootComponent>
                 {contextMenu}
             </>
         );

--- a/packages/ui-components/src/datepicker/datepicker-select.tsx
+++ b/packages/ui-components/src/datepicker/datepicker-select.tsx
@@ -208,7 +208,7 @@ const DatepickerListItem = React.memo(
 );
 
 interface DropdownListProps {
-    displacement: number;
+    displacement?: number;
 }
 
 const StyledDropdownList = React.memo(styled(DropdownList)<DropdownListProps>`
@@ -238,10 +238,10 @@ const DatepickerSelectButtonPrimary = React.memo(
         isOpen,
         selectedItem,
     }: {
-        disabled: boolean;
-        size: number;
+        disabled?: boolean;
+        size?: number;
         isOpen: boolean;
-        selectedItem: Item;
+        selectedItem?: Item | null;
         getToggleButtonProps: (
             options?: UseSelectGetToggleButtonPropsOptions,
             otherOptions?: GetPropsCommonOptions
@@ -277,7 +277,7 @@ export interface SelectProps extends InteractiveComponentProps<Item> {
     /** Specify a specific placement for the list */
     placement?: Placement;
     /** Set the selected value to a specific value, will put the component in controlled mode */
-    selectedItem?: Item;
+    selectedItem?: Item | null;
     /** Font size in rem to show in the Select */
     size?: number;
 }
@@ -292,11 +292,11 @@ function DatepickerSelect(props: SelectProps): JSX.Element {
     const [kbdHighlightIdx, setKbdHighlightIdx] = React.useState<number | undefined>();
     const { isOpen, selectedItem, getToggleButtonProps, getMenuProps, getItemProps } = useSelect<Item>({
         initialSelectedItem: props.initialValue,
-        itemToString: (item) => item.label,
+        itemToString: (item) => item?.label ?? '',
         items: props.items,
         onSelectedItemChange: (changes) => {
             const selected = changes.selectedItem;
-            if (props.onSelect) {
+            if (props.onSelect && selected) {
                 props.onSelect(selected);
             }
         },
@@ -307,7 +307,7 @@ function DatepickerSelect(props: SelectProps): JSX.Element {
             if (type === stateChangeTypes.ToggleButtonClick && changes?.isOpen && props.selectedItem) {
                 return {
                     ...changes,
-                    highlightedIndex: props.items.findIndex((i) => i.value === changes.selectedItem.value),
+                    highlightedIndex: props.items.findIndex((i) => i.value === changes.selectedItem?.value),
                 };
             }
 
@@ -356,7 +356,7 @@ function DatepickerSelect(props: SelectProps): JSX.Element {
         <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
             <Wrapper
                 className={props.className}
-                isDisabled={props.disabled}
+                isDisabled={Boolean(props.disabled)}
                 isErrored={!!props.errorMsg}
                 onClick={props.onClick}
                 style={props.style}

--- a/packages/ui-components/src/datepicker/datepicker-select.tsx
+++ b/packages/ui-components/src/datepicker/datepicker-select.tsx
@@ -292,12 +292,12 @@ function DatepickerSelect(props: SelectProps): JSX.Element {
     const [kbdHighlightIdx, setKbdHighlightIdx] = React.useState<number | undefined>();
     const { isOpen, selectedItem, getToggleButtonProps, getMenuProps, getItemProps } = useSelect<Item>({
         initialSelectedItem: props.initialValue,
-        itemToString: (item) => item?.label ?? '',
+        itemToString: (item) => item!.label,
         items: props.items,
         onSelectedItemChange: (changes) => {
             const selected = changes.selectedItem;
-            if (props.onSelect && selected) {
-                props.onSelect(selected);
+            if (props.onSelect) {
+                props.onSelect(selected as Item);
             }
         },
         ...syncKbdHighlightIdx(setKbdHighlightIdx),
@@ -307,7 +307,7 @@ function DatepickerSelect(props: SelectProps): JSX.Element {
             if (type === stateChangeTypes.ToggleButtonClick && changes?.isOpen && props.selectedItem) {
                 return {
                     ...changes,
-                    highlightedIndex: props.items.findIndex((i) => i.value === changes.selectedItem?.value),
+                    highlightedIndex: props.items.findIndex((i) => i.value === changes.selectedItem!.value),
                 };
             }
 
@@ -356,7 +356,7 @@ function DatepickerSelect(props: SelectProps): JSX.Element {
         <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
             <Wrapper
                 className={props.className}
-                isDisabled={Boolean(props.disabled)}
+                isDisabled={props.disabled as boolean}
                 isErrored={!!props.errorMsg}
                 onClick={props.onClick}
                 style={props.style}

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -21,7 +21,7 @@ import enGB from 'date-fns/locale/en-GB';
 import range from 'lodash/range';
 import { transparentize } from 'polished';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import ReactDatePicker, { type ReactDatePickerProps } from 'react-datepicker';
+import ReactDatePicker, { type ReactDatePickerCustomHeaderProps } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
 import styled from '@darajs/styled-components';
@@ -34,13 +34,23 @@ import { type InteractiveComponentProps, type Item } from '../types';
 import DatepickerSelect from './datepicker-select';
 
 /**
+ * Get the localized name of a month.
+ */
+function getMonthName(month: number): string {
+    return (
+        enGB.localize?.month(month) ??
+        new Intl.DateTimeFormat('en-GB', { month: 'long' }).format(new Date(2000, month, 1))
+    );
+}
+
+/**
  * Get all names of months as Items
  */
 function getMonths(): Item[] {
     const months: Item[] = [];
 
     for (let i = 0; i < 12; i++) {
-        months.push({ label: enGB.localize.month(i), value: i });
+        months.push({ label: getMonthName(i), value: i });
     }
 
     return months;
@@ -412,6 +422,7 @@ const TimeInput = styled(Input)<TimeInputProps>`
 `;
 
 type DatepickerValue = Date | [Date, Date];
+type InternalDatepickerValue = Date | [Date | null, Date | null] | null;
 type TimeValue = string | [string, string];
 
 /**
@@ -479,7 +490,7 @@ function DatePickerHeader({
     portalsRef,
     minDate,
     maxDate,
-}: Parameters<ReactDatePickerProps['renderCustomHeader']>[0] & {
+}: ReactDatePickerCustomHeaderProps & {
     maxDate?: Date;
     minDate?: Date;
     portalsRef?: React.MutableRefObject<HTMLElement[]>;
@@ -489,7 +500,7 @@ function DatePickerHeader({
     const years = useMemo(() => getYears(minDate, maxDate), [minDate, maxDate]);
 
     const selectedMonth = useMemo(() => {
-        return { label: enGB.localize.month(date.getMonth()), value: date.getMonth() };
+        return { label: getMonthName(date.getMonth()), value: date.getMonth() };
     }, [date]);
     const selectedYear = useMemo(() => ({ label: date.getFullYear().toString(), value: date.getFullYear() }), [date]);
 
@@ -556,7 +567,7 @@ function getTimeFormatted(time: number): string {
  *
  * @returns the time set
  */
-function getInitialTime(initialDate: DatepickerValue, isRange: boolean): TimeValue {
+function getInitialTime(initialDate: DatepickerValue | undefined, isRange: boolean): TimeValue {
     if (!initialDate) {
         if (isRange) {
             return ['00:00', '00:00'];
@@ -581,7 +592,7 @@ function getInitialTime(initialDate: DatepickerValue, isRange: boolean): TimeVal
  * @param formatToApply - the date format that the string should obey
  * @param isStart - for the case of range dates whether to get the first date or the second from the initialDate object
  */
-function getInitialDate(initialDate: DatepickerValue, formatToApply: string, isStart: boolean): string {
+function getInitialDate(initialDate: DatepickerValue | undefined, formatToApply: string, isStart: boolean): string {
     let formattedDate = '';
     if (initialDate) {
         if (Array.isArray(initialDate)) {
@@ -599,18 +610,21 @@ function getInitialDate(initialDate: DatepickerValue, formatToApply: string, isS
  * @param date - the date(s) to have time added to
  * @param time - the time(s) to add to the date(s)
  */
-function getNewDatetime(date: DatepickerValue, time: TimeValue): DatepickerValue {
-    if (!Array.isArray(date) && !Array.isArray(time)) {
-        const [hours, minutes] = time?.split(':') ?? ['00', '00'];
-        const newDate = date ? new Date(date.setHours(Number(hours), Number(minutes))) : null;
-        return newDate;
+function addTime(date: Date | null, time: string): Date | null {
+    if (!date) {
+        return null;
     }
-    const [startHours, startMinutes] = time[0]?.split(':') ?? ['00', '00'];
-    const [endHours, endMinutes] = time[1]?.split(':') ?? ['00', '00'];
-    const dates = date as [Date, Date];
-    const startDate = dates[0] ? new Date(dates[0].setHours(Number(startHours), Number(startMinutes))) : null;
-    const endDate = dates[1] ? new Date(dates[1].setHours(Number(endHours), Number(endMinutes))) : null;
-    return [startDate, endDate];
+    const [hours, minutes] = time.split(':');
+    return new Date(date.setHours(Number(hours), Number(minutes)));
+}
+
+function getNewDatetime(date: InternalDatepickerValue, time: TimeValue): InternalDatepickerValue {
+    if (Array.isArray(date)) {
+        const [startTime, endTime] = Array.isArray(time) ? time : [time, '00:00'];
+        return [addTime(date[0], startTime), addTime(date[1], endTime)];
+    }
+
+    return addTime(date, Array.isArray(time) ? time[0] : time);
 }
 
 /**
@@ -620,30 +634,37 @@ function getNewDatetime(date: DatepickerValue, time: TimeValue): DatepickerValue
  */
 function DatePicker(props: DatePickerProps): JSX.Element {
     const value = props.value ?? props.initialValue;
-    const [selectedDate, setSelectedDate] = useState<DatepickerValue>(
-        value || (props.selectsRange ? [null, null] : null)
+    const [selectedDate, setSelectedDate] = useState<InternalDatepickerValue>(
+        value ?? (props.selectsRange ? [null, null] : null)
     );
-    const [selectedTime, setSelectedTime] = useState<TimeValue>(() => getInitialTime(value, props.selectsRange));
+    const [selectedTime, setSelectedTime] = useState<TimeValue>(() =>
+        getInitialTime(value, Boolean(props.selectsRange))
+    );
     const formatToApply = props.dateFormat ?? 'dd/MM/yyyy';
     const [startDate, setStartDate] = useState<string>(() => getInitialDate(value, formatToApply, true));
     const [endDate, setEndDate] = useState<string>(() => getInitialDate(value, formatToApply, false));
     // state to track which date is being selected based on the input which has been interacted with
-    const [isSelectingStart, setIsSelectingStart] = useState<boolean>(null);
+    const [isSelectingStart, setIsSelectingStart] = useState(true);
 
     // Keep state in refs so we can compare it in useEffect without subscribing
     const selectedDateRef = useRef(selectedDate);
     selectedDateRef.current = selectedDate;
 
-    const datepickerRef = useRef(null);
+    const datepickerRef = useRef<
+        | (ReactDatePicker & {
+              onInputKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+          })
+        | null
+    >(null);
 
     const extraProps = useMemo(() => {
         if (props.selectsRange) {
-            const selectedDates = (selectedDate ?? [null, null]) as [Date, Date];
+            const selectedDates = (selectedDate ?? [null, null]) as [Date | null, Date | null];
             let { minDate } = props;
             // If we are selecting the end date minDate becomes whatever the startDate is
             if (!isSelectingStart) {
                 const [currentStartDate] = selectedDates;
-                minDate = currentStartDate;
+                minDate = currentStartDate ?? props.minDate;
             }
 
             return {
@@ -663,7 +684,11 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         };
     }, [selectedDate, isSelectingStart, props]);
 
-    const onChangeDate = (date: Date): void => {
+    const onChangeDate = (date: Date | null): void => {
+        if (!date) {
+            return;
+        }
+
         // close datepicker when a date is chosen
         if (props.shouldCloseOnSelect) {
             datepickerRef.current?.setOpen(false);
@@ -680,7 +705,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                 // if start date happens after end date then end date should become start
                 currentEndDate = currentEndDate && currentEndDate > date ? currentEndDate : date;
             } else {
-                currentStartDate = Array.isArray(selectedDate) ? selectedDate[0] : null;
+                currentStartDate = Array.isArray(selectedDate) ? selectedDate[0] ?? date : date;
                 currentEndDate = date;
             }
 
@@ -701,19 +726,15 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         if (
             newDate instanceof Date &&
             !Number.isNaN(newDate.valueOf()) &&
-            !(newDate < props.minDate) &&
-            !(newDate > props.maxDate)
+            (!props.minDate || newDate >= props.minDate) &&
+            (!props.maxDate || newDate <= props.maxDate)
         ) {
-            // allows so that changes to the input update the datepicker
-            datepickerRef.current?.setState({
-                preSelection: newDate,
-            });
             // if it is a range datepicker
             if (Array.isArray(selectedDate)) {
                 if (isStartDate) {
                     let end = selectedDate[1];
                     // is start date is after end date, then adjust end date
-                    if (newDate > end) {
+                    if (!end || newDate > end) {
                         end = newDate;
                         setEndDate(target.value);
                     }
@@ -724,7 +745,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
 
                 let start = selectedDate[0];
                 // if end date is before start date, then adjust start date
-                if (newDate < start) {
+                if (!start || newDate < start) {
                     start = newDate;
                     setStartDate(target.value);
                 }
@@ -763,7 +784,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
     useEffect(() => {
         const newValue = props.value ?? props.initialValue;
 
-        const newDate = newValue || (props.selectsRange ? [null, null] : null);
+        const newDate: InternalDatepickerValue = newValue ?? (props.selectsRange ? [null, null] : null);
 
         // Skip if the value is the same as the current state, this is necessary to prevent loops
         if (JSON.stringify(newDate) === JSON.stringify(selectedDateRef.current)) {
@@ -772,7 +793,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
 
         setSelectedDate(newDate);
 
-        const newTime = getInitialTime(newValue, props.selectsRange);
+        const newTime = getInitialTime(newValue, Boolean(props.selectsRange));
         setSelectedTime(newTime);
 
         const newStartDate = getInitialDate(newValue, formatToApply, true);
@@ -792,7 +813,14 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         }
         // We have to typecast to make compiler happy as we don't know which type it is at this point
         const newDateTime = getNewDatetime(selectedDate, time);
-        props.onChange?.(newDateTime as Date & [Date, Date]);
+        if (Array.isArray(newDateTime)) {
+            const [start, end] = newDateTime;
+            if (props.selectsRange && start && end) {
+                props.onChange?.([start, end]);
+            }
+        } else if (!props.selectsRange && newDateTime) {
+            props.onChange?.(newDateTime);
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedDate, selectedTime]);
 
@@ -821,7 +849,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                     datepickerRef.current?.setOpen(true);
                                 }}
                                 onKeyDown={(e) => {
-                                    datepickerRef.current?.onInputKeyDown(e);
+                                    datepickerRef.current?.onInputKeyDown?.(e);
                                 }}
                                 placeholder={formatToApply}
                                 value={startDate}
@@ -855,7 +883,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                             datepickerRef.current?.setOpen(true);
                                         }}
                                         onKeyDown={(e) => {
-                                            datepickerRef.current?.onInputKeyDown(e);
+                                            datepickerRef.current?.onInputKeyDown?.(e);
                                         }}
                                         placeholder={formatToApply}
                                         value={endDate}
@@ -867,7 +895,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                                 onChangeTime(e, false);
                                             }}
                                             type="time"
-                                            value={selectedTime[1]}
+                                            value={Array.isArray(selectedTime) ? selectedTime[1] : '00:00'}
                                         />
                                     )}
                                 </DateTimeWrapper>

--- a/packages/ui-components/src/datepicker/datepicker.tsx
+++ b/packages/ui-components/src/datepicker/datepicker.tsx
@@ -34,23 +34,13 @@ import { type InteractiveComponentProps, type Item } from '../types';
 import DatepickerSelect from './datepicker-select';
 
 /**
- * Get the localized name of a month.
- */
-function getMonthName(month: number): string {
-    return (
-        enGB.localize?.month(month) ??
-        new Intl.DateTimeFormat('en-GB', { month: 'long' }).format(new Date(2000, month, 1))
-    );
-}
-
-/**
  * Get all names of months as Items
  */
 function getMonths(): Item[] {
     const months: Item[] = [];
 
     for (let i = 0; i < 12; i++) {
-        months.push({ label: getMonthName(i), value: i });
+        months.push({ label: enGB.localize!.month(i), value: i });
     }
 
     return months;
@@ -500,7 +490,7 @@ function DatePickerHeader({
     const years = useMemo(() => getYears(minDate, maxDate), [minDate, maxDate]);
 
     const selectedMonth = useMemo(() => {
-        return { label: getMonthName(date.getMonth()), value: date.getMonth() };
+        return { label: enGB.localize!.month(date.getMonth()), value: date.getMonth() };
     }, [date]);
     const selectedYear = useMemo(() => ({ label: date.getFullYear().toString(), value: date.getFullYear() }), [date]);
 
@@ -610,21 +600,18 @@ function getInitialDate(initialDate: DatepickerValue | undefined, formatToApply:
  * @param date - the date(s) to have time added to
  * @param time - the time(s) to add to the date(s)
  */
-function addTime(date: Date | null, time: string): Date | null {
-    if (!date) {
-        return null;
-    }
-    const [hours, minutes] = time.split(':');
-    return new Date(date.setHours(Number(hours), Number(minutes)));
-}
-
 function getNewDatetime(date: InternalDatepickerValue, time: TimeValue): InternalDatepickerValue {
-    if (Array.isArray(date)) {
-        const [startTime, endTime] = Array.isArray(time) ? time : [time, '00:00'];
-        return [addTime(date[0], startTime), addTime(date[1], endTime)];
+    if (!Array.isArray(date) && !Array.isArray(time)) {
+        const [hours, minutes] = time?.split(':') ?? ['00', '00'];
+        const newDate = date ? new Date(date.setHours(Number(hours), Number(minutes))) : null;
+        return newDate;
     }
-
-    return addTime(date, Array.isArray(time) ? time[0] : time);
+    const [startHours, startMinutes] = (time as [string, string])[0]?.split(':') ?? ['00', '00'];
+    const [endHours, endMinutes] = (time as [string, string])[1]?.split(':') ?? ['00', '00'];
+    const dates = date as [Date | null, Date | null];
+    const startDate = dates[0] ? new Date(dates[0].setHours(Number(startHours), Number(startMinutes))) : null;
+    const endDate = dates[1] ? new Date(dates[1].setHours(Number(endHours), Number(endMinutes))) : null;
+    return [startDate, endDate];
 }
 
 /**
@@ -635,16 +622,16 @@ function getNewDatetime(date: InternalDatepickerValue, time: TimeValue): Interna
 function DatePicker(props: DatePickerProps): JSX.Element {
     const value = props.value ?? props.initialValue;
     const [selectedDate, setSelectedDate] = useState<InternalDatepickerValue>(
-        value ?? (props.selectsRange ? [null, null] : null)
+        value || (props.selectsRange ? [null, null] : null)
     );
     const [selectedTime, setSelectedTime] = useState<TimeValue>(() =>
-        getInitialTime(value, Boolean(props.selectsRange))
+        getInitialTime(value, props.selectsRange as boolean)
     );
     const formatToApply = props.dateFormat ?? 'dd/MM/yyyy';
     const [startDate, setStartDate] = useState<string>(() => getInitialDate(value, formatToApply, true));
     const [endDate, setEndDate] = useState<string>(() => getInitialDate(value, formatToApply, false));
     // state to track which date is being selected based on the input which has been interacted with
-    const [isSelectingStart, setIsSelectingStart] = useState(true);
+    const [isSelectingStart, setIsSelectingStart] = useState<boolean | null>(null);
 
     // Keep state in refs so we can compare it in useEffect without subscribing
     const selectedDateRef = useRef(selectedDate);
@@ -652,7 +639,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
 
     const datepickerRef = useRef<
         | (ReactDatePicker & {
-              onInputKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+              onInputKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
           })
         | null
     >(null);
@@ -664,7 +651,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
             // If we are selecting the end date minDate becomes whatever the startDate is
             if (!isSelectingStart) {
                 const [currentStartDate] = selectedDates;
-                minDate = currentStartDate ?? props.minDate;
+                minDate = currentStartDate as Date;
             }
 
             return {
@@ -684,11 +671,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         };
     }, [selectedDate, isSelectingStart, props]);
 
-    const onChangeDate = (date: Date | null): void => {
-        if (!date) {
-            return;
-        }
-
+    const onChangeDate = (date: Date): void => {
         // close datepicker when a date is chosen
         if (props.shouldCloseOnSelect) {
             datepickerRef.current?.setOpen(false);
@@ -705,11 +688,11 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                 // if start date happens after end date then end date should become start
                 currentEndDate = currentEndDate && currentEndDate > date ? currentEndDate : date;
             } else {
-                currentStartDate = Array.isArray(selectedDate) ? selectedDate[0] ?? date : date;
+                currentStartDate = Array.isArray(selectedDate) ? selectedDate[0] : null;
                 currentEndDate = date;
             }
 
-            setStartDate(format(currentStartDate, formatToApply));
+            setStartDate(format(currentStartDate as Date, formatToApply));
             setEndDate(format(currentEndDate, formatToApply));
             setSelectedDate([currentStartDate, currentEndDate]);
         } else {
@@ -726,15 +709,19 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         if (
             newDate instanceof Date &&
             !Number.isNaN(newDate.valueOf()) &&
-            (!props.minDate || newDate >= props.minDate) &&
-            (!props.maxDate || newDate <= props.maxDate)
+            !(newDate < props.minDate!) &&
+            !(newDate > props.maxDate!)
         ) {
+            // allows so that changes to the input update the datepicker
+            datepickerRef.current?.setState({
+                preSelection: newDate,
+            });
             // if it is a range datepicker
             if (Array.isArray(selectedDate)) {
                 if (isStartDate) {
                     let end = selectedDate[1];
                     // is start date is after end date, then adjust end date
-                    if (!end || newDate > end) {
+                    if (newDate > end!) {
                         end = newDate;
                         setEndDate(target.value);
                     }
@@ -745,7 +732,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
 
                 let start = selectedDate[0];
                 // if end date is before start date, then adjust start date
-                if (!start || newDate < start) {
+                if (newDate < start!) {
                     start = newDate;
                     setStartDate(target.value);
                 }
@@ -784,7 +771,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
     useEffect(() => {
         const newValue = props.value ?? props.initialValue;
 
-        const newDate: InternalDatepickerValue = newValue ?? (props.selectsRange ? [null, null] : null);
+        const newDate: InternalDatepickerValue = newValue || (props.selectsRange ? [null, null] : null);
 
         // Skip if the value is the same as the current state, this is necessary to prevent loops
         if (JSON.stringify(newDate) === JSON.stringify(selectedDateRef.current)) {
@@ -793,7 +780,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
 
         setSelectedDate(newDate);
 
-        const newTime = getInitialTime(newValue, Boolean(props.selectsRange));
+        const newTime = getInitialTime(newValue, props.selectsRange as boolean);
         setSelectedTime(newTime);
 
         const newStartDate = getInitialDate(newValue, formatToApply, true);
@@ -813,14 +800,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
         }
         // We have to typecast to make compiler happy as we don't know which type it is at this point
         const newDateTime = getNewDatetime(selectedDate, time);
-        if (Array.isArray(newDateTime)) {
-            const [start, end] = newDateTime;
-            if (props.selectsRange && start && end) {
-                props.onChange?.([start, end]);
-            }
-        } else if (!props.selectsRange && newDateTime) {
-            props.onChange?.(newDateTime);
-        }
+        props.onChange?.(newDateTime as Date & [Date, Date]);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedDate, selectedTime]);
 
@@ -849,7 +829,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                     datepickerRef.current?.setOpen(true);
                                 }}
                                 onKeyDown={(e) => {
-                                    datepickerRef.current?.onInputKeyDown?.(e);
+                                    datepickerRef.current?.onInputKeyDown(e);
                                 }}
                                 placeholder={formatToApply}
                                 value={startDate}
@@ -883,7 +863,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                             datepickerRef.current?.setOpen(true);
                                         }}
                                         onKeyDown={(e) => {
-                                            datepickerRef.current?.onInputKeyDown?.(e);
+                                            datepickerRef.current?.onInputKeyDown(e);
                                         }}
                                         placeholder={formatToApply}
                                         value={endDate}
@@ -895,7 +875,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                                                 onChangeTime(e, false);
                                             }}
                                             type="time"
-                                            value={Array.isArray(selectedTime) ? selectedTime[1] : '00:00'}
+                                            value={(selectedTime as [string, string])[1]}
                                         />
                                     )}
                                 </DateTimeWrapper>
@@ -912,7 +892,7 @@ function DatePicker(props: DatePickerProps): JSX.Element {
                         onChange={onChangeDate}
                         ref={datepickerRef}
                         selectsEnd={!isSelectingStart}
-                        selectsStart={isSelectingStart}
+                        selectsStart={isSelectingStart as boolean}
                         shouldCloseOnSelect={props.shouldCloseOnSelect}
                         {...extraProps}
                         popperProps={{ strategy: props.popperStrategy ?? 'absolute' }}

--- a/packages/ui-components/src/dropzone/dropzone.tsx
+++ b/packages/ui-components/src/dropzone/dropzone.tsx
@@ -89,7 +89,7 @@ function UploadDropzone(props: UploadDropzoneProps): JSX.Element {
             return;
         }
         const handlePaste = (ev: ClipboardEvent): void => {
-            const blob = new Blob([ev.clipboardData?.getData('Text') ?? ''], { type: 'text/plain' });
+            const blob = new Blob([ev.clipboardData!.getData('Text')], { type: 'text/plain' });
             const file = new File([blob], 'pasted_data', { type: 'text/plain' });
             props.onDrop([file], [], ev);
         };

--- a/packages/ui-components/src/dropzone/dropzone.tsx
+++ b/packages/ui-components/src/dropzone/dropzone.tsx
@@ -89,7 +89,7 @@ function UploadDropzone(props: UploadDropzoneProps): JSX.Element {
             return;
         }
         const handlePaste = (ev: ClipboardEvent): void => {
-            const blob = new Blob([ev.clipboardData.getData('Text')], { type: 'text/plain' });
+            const blob = new Blob([ev.clipboardData?.getData('Text') ?? ''], { type: 'text/plain' });
             const file = new File([blob], 'pasted_data', { type: 'text/plain' });
             props.onDrop([file], [], ev);
         };

--- a/packages/ui-components/src/error-boundary/error-boundary.tsx
+++ b/packages/ui-components/src/error-boundary/error-boundary.tsx
@@ -72,7 +72,7 @@ class ErrorBoundary extends React.Component<Props, State> {
     }
 
     componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
-        this.setState({ stackTrace: errorInfo.componentStack?.slice(5) });
+        this.setState({ stackTrace: errorInfo.componentStack!.slice(5) });
     }
 
     render(): React.ReactNode {

--- a/packages/ui-components/src/error-boundary/error-boundary.tsx
+++ b/packages/ui-components/src/error-boundary/error-boundary.tsx
@@ -54,9 +54,9 @@ interface Props {
 }
 
 interface State {
-    error: string;
+    error?: string;
     hasError: boolean;
-    stackTrace: string;
+    stackTrace?: string;
 }
 
 class ErrorBoundary extends React.Component<Props, State> {
@@ -72,7 +72,7 @@ class ErrorBoundary extends React.Component<Props, State> {
     }
 
     componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
-        this.setState({ stackTrace: errorInfo.componentStack.slice(5) });
+        this.setState({ stackTrace: errorInfo.componentStack?.slice(5) });
     }
 
     render(): React.ReactNode {

--- a/packages/ui-components/src/filter/datetime-filter.tsx
+++ b/packages/ui-components/src/filter/datetime-filter.tsx
@@ -181,8 +181,8 @@ function DatetimeFilter(props: DatetimeFilterProps): JSX.Element {
         // if one of the dates is not defined
         if (
             !dateValues ||
-            (selected?.label === 'Between' && Array.isArray(dateValues) && (!dateValues[0] || !dateValues[1])) ||
-            (selected?.label === 'Between' && !Array.isArray(dateValues))
+            (selected!.label === 'Between' && Array.isArray(dateValues) && (!dateValues[0] || !dateValues[1])) ||
+            (selected!.label === 'Between' && !Array.isArray(dateValues))
         ) {
             return true;
         }

--- a/packages/ui-components/src/filter/datetime-filter.tsx
+++ b/packages/ui-components/src/filter/datetime-filter.tsx
@@ -112,8 +112,8 @@ const StyledApply = styled(ApplyButton)`
 `;
 
 export interface FilterResults {
-    selected: string;
-    value: Date | [Date, Date];
+    selected?: string;
+    value?: Date | [Date, Date];
 }
 export interface DatetimeFilterProps extends FilterProps<any> {
     /** Standard react className property */
@@ -159,8 +159,8 @@ const DatetimeFilterItems: Item[] = [
  * @param {DatetimeFilterProps} props - the component props
  */
 function DatetimeFilter(props: DatetimeFilterProps): JSX.Element {
-    const [selected, setSelected] = useState<Item>(null);
-    const [dateValues, setDateValues] = useState<Date | [Date, Date]>(props.values);
+    const [selected, setSelected] = useState<Item | null>(null);
+    const [dateValues, setDateValues] = useState<Date | [Date, Date] | undefined>(props.values);
 
     const filteredValues = useMemo((): FilterResults => {
         let filterDate = dateValues;
@@ -181,8 +181,8 @@ function DatetimeFilter(props: DatetimeFilterProps): JSX.Element {
         // if one of the dates is not defined
         if (
             !dateValues ||
-            (selected.label === 'Between' && Array.isArray(dateValues) && (!dateValues[0] || !dateValues[1])) ||
-            (selected.label === 'Between' && !Array.isArray(dateValues))
+            (selected?.label === 'Between' && Array.isArray(dateValues) && (!dateValues[0] || !dateValues[1])) ||
+            (selected?.label === 'Between' && !Array.isArray(dateValues))
         ) {
             return true;
         }

--- a/packages/ui-components/src/filter/numeric-filter.tsx
+++ b/packages/ui-components/src/filter/numeric-filter.tsx
@@ -108,8 +108,8 @@ const NumericFilterItems: Item[] = [
 ];
 
 export interface FilterResults {
-    selected: string;
-    value: number | [number, number];
+    selected?: string;
+    value: number | [number | null, number | null] | null;
 }
 
 export interface NumericFilterProps extends FilterProps<any> {
@@ -129,9 +129,9 @@ export interface NumericFilterProps extends FilterProps<any> {
  * @param {NumericFilterProps} props - the component props
  */
 function NumericFilter(props: NumericFilterProps): JSX.Element {
-    const [selected, setSelected] = useState<Item>(null);
-    const [firstInput, setFirstInput] = useState<number>(null);
-    const [secondInput, setSecondInput] = useState<number>(null);
+    const [selected, setSelected] = useState<Item | null>(null);
+    const [firstInput, setFirstInput] = useState<number | null>(null);
+    const [secondInput, setSecondInput] = useState<number | null>(null);
 
     const filteredValues = useMemo((): FilterResults => {
         if (selected?.label === 'None') {

--- a/packages/ui-components/src/hierarchy-selector/node/branch.tsx
+++ b/packages/ui-components/src/hierarchy-selector/node/branch.tsx
@@ -140,7 +140,7 @@ interface BranchProps {
     /** Optional function to get id of the node selected by the user */
     selectNode?: (nodeId: string) => void;
     /** The id of the node selected by the user */
-    selectedNodeId: string;
+    selectedNodeId?: string;
     /** Pass through of the style to the node container */
     style?: React.CSSProperties;
 }
@@ -162,7 +162,7 @@ function Branch(props: BranchProps): JSX.Element {
     };
 
     const select = (): void => {
-        props.selectNode(props.content.id);
+        props.selectNode?.(props.content.id);
     };
 
     const selectionAllowed =

--- a/packages/ui-components/src/hierarchy-selector/node/branch.tsx
+++ b/packages/ui-components/src/hierarchy-selector/node/branch.tsx
@@ -162,7 +162,7 @@ function Branch(props: BranchProps): JSX.Element {
     };
 
     const select = (): void => {
-        props.selectNode?.(props.content.id);
+        props.selectNode!(props.content.id);
     };
 
     const selectionAllowed =

--- a/packages/ui-components/src/modal/modal.tsx
+++ b/packages/ui-components/src/modal/modal.tsx
@@ -114,7 +114,7 @@ export interface ModalProps {
  *
  * @param {ModalProps} props - the component props
  */
-function Modal(props: ModalProps): JSX.Element {
+function Modal(props: ModalProps): JSX.Element | null {
     const [mounted, setMounted] = useState(false);
     const [renderModal, setRenderModal] = useState(false);
 

--- a/packages/ui-components/src/multiselect/multiselect.tsx
+++ b/packages/ui-components/src/multiselect/multiselect.tsx
@@ -236,7 +236,7 @@ function MultiSelect({ maxWidth = '100%', maxRows = 3, ...props }: MultiSelectPr
             initialSelectedItems: props.initialValue ?? [],
             onSelectedItemsChange: (changes: UseMultipleSelectionStateChange<Item>) => {
                 if (props.onSelect) {
-                    props.onSelect(changes.selectedItems);
+                    props.onSelect(changes.selectedItems ?? []);
                 }
             },
             // Only set the selectedItems key if it has been explicitly set in props
@@ -367,7 +367,7 @@ function MultiSelect({ maxWidth = '100%', maxRows = 3, ...props }: MultiSelectPr
                         />
                     </TagWrapper>
                     <ChevronButton
-                        disabled={props.disabled}
+                        disabled={Boolean(props.disabled)}
                         isOpen={isOpen}
                         getToggleButtonProps={getToggleButtonProps}
                     />

--- a/packages/ui-components/src/multiselect/multiselect.tsx
+++ b/packages/ui-components/src/multiselect/multiselect.tsx
@@ -236,7 +236,7 @@ function MultiSelect({ maxWidth = '100%', maxRows = 3, ...props }: MultiSelectPr
             initialSelectedItems: props.initialValue ?? [],
             onSelectedItemsChange: (changes: UseMultipleSelectionStateChange<Item>) => {
                 if (props.onSelect) {
-                    props.onSelect(changes.selectedItems ?? []);
+                    props.onSelect(changes.selectedItems as Item[]);
                 }
             },
             // Only set the selectedItems key if it has been explicitly set in props
@@ -367,7 +367,7 @@ function MultiSelect({ maxWidth = '100%', maxRows = 3, ...props }: MultiSelectPr
                         />
                     </TagWrapper>
                     <ChevronButton
-                        disabled={Boolean(props.disabled)}
+                        disabled={props.disabled as boolean}
                         isOpen={isOpen}
                         getToggleButtonProps={getToggleButtonProps}
                     />

--- a/packages/ui-components/src/numeric-input/numeric-input.tsx
+++ b/packages/ui-components/src/numeric-input/numeric-input.tsx
@@ -131,7 +131,7 @@ const numericFilter =
  * @param initialValue the initialValue prop
  * @returns the initial value of the numeric input
  */
-const getInitialValue = (value: number, initialValue: number): string => {
+const getInitialValue = (value?: number, initialValue?: number): string => {
     if (Number.isFinite(value)) {
         return String(value);
     }
@@ -286,7 +286,9 @@ const NumericInput = React.forwardRef<HTMLInputElement, NumericInputProps>(
                         ref={ref}
                         value={input}
                     />
-                    {props.stepper && <InputStepper disabled={props.disabled} step={step} stepSkip={props.stepSkip} />}
+                    {props.stepper && (
+                        <InputStepper disabled={Boolean(props.disabled)} step={step} stepSkip={props.stepSkip} />
+                    )}
                 </InputWrapper>
             </div>
         );

--- a/packages/ui-components/src/numeric-input/numeric-input.tsx
+++ b/packages/ui-components/src/numeric-input/numeric-input.tsx
@@ -287,7 +287,7 @@ const NumericInput = React.forwardRef<HTMLInputElement, NumericInputProps>(
                         value={input}
                     />
                     {props.stepper && (
-                        <InputStepper disabled={Boolean(props.disabled)} step={step} stepSkip={props.stepSkip} />
+                        <InputStepper disabled={props.disabled as boolean} step={step} stepSkip={props.stepSkip} />
                     )}
                 </InputWrapper>
             </div>

--- a/packages/ui-components/src/radio/radio-group.tsx
+++ b/packages/ui-components/src/radio/radio-group.tsx
@@ -208,7 +208,7 @@ function RadioGroup(props: RadioGroupProps): JSX.Element {
                 return (
                     <RadioWrapper
                         aria-disabled={props.disabled}
-                        isListStyle={Boolean(props.isListStyle)}
+                        isListStyle={props.isListStyle as boolean}
                         key={`item-${index}`}
                     >
                         <RadioButton

--- a/packages/ui-components/src/radio/radio-group.tsx
+++ b/packages/ui-components/src/radio/radio-group.tsx
@@ -117,7 +117,7 @@ const RadioButton = styled.input`
 `;
 
 interface StyledCheckmarkProps {
-    disabled: boolean;
+    disabled?: boolean;
 }
 
 // customdot/circle for the radio button
@@ -206,7 +206,11 @@ function RadioGroup(props: RadioGroupProps): JSX.Element {
         >
             {props.items.map((item, index) => {
                 return (
-                    <RadioWrapper aria-disabled={props.disabled} isListStyle={props.isListStyle} key={`item-${index}`}>
+                    <RadioWrapper
+                        aria-disabled={props.disabled}
+                        isListStyle={Boolean(props.isListStyle)}
+                        key={`item-${index}`}
+                    >
                         <RadioButton
                             checked={isControlled ? isEqual(props.value?.value, item.value) : currentSelected === index}
                             disabled={props.disabled}

--- a/packages/ui-components/src/sectioned-list/sectioned-list.tsx
+++ b/packages/ui-components/src/sectioned-list/sectioned-list.tsx
@@ -38,7 +38,7 @@ interface ListSpanProps {
     isSelected?: boolean;
 }
 
-const getTextColor = (heading: boolean, isSelected: boolean, theme: DefaultTheme): string => {
+const getTextColor = (heading: boolean | undefined, isSelected: boolean | undefined, theme: DefaultTheme): string => {
     if (heading) {
         return theme.colors.text;
     }
@@ -111,7 +111,7 @@ export interface SectionedListProps extends InteractiveComponentProps<Item> {
     /** An optional onSelect handler for listening to changes in the selected item */
     onSelect?: (item: ListItem) => void | Promise<void>;
     /** Put the component in controlled mode and pass in the selectedItem */
-    selectedItem?: ListItem | Item;
+    selectedItem?: ListItem | Item | null;
     /** An optional placeholder for the input field to display when nothing is selected, defaults to '' */
     placeholder?: string;
     /** Pass through of style property to the root element */
@@ -170,7 +170,7 @@ const SectionedListItem = ({
 function SectionedList(props: SectionedListProps): JSX.Element {
     const unpackedItems = useMemo(() => unpackSectionedList(props.items), [props.items]);
 
-    const [pendingHighlight, setPendingHighlight] = useState(null);
+    const [pendingHighlight, setPendingHighlight] = useState<number | null>(null);
     const [items, setItems] = useState(unpackedItems);
     const [inputValue, setInputValue] = useState(
         props.selectedItem?.label && props.selectedItem.label !== 'null' ?
@@ -187,10 +187,10 @@ function SectionedList(props: SectionedListProps): JSX.Element {
         getToggleButtonProps,
         getItemProps,
         setHighlightedIndex,
-    } = useCombobox<Item>({
+    } = useCombobox<ListItem>({
         initialIsOpen: false,
         initialSelectedItem: props.initialValue ?? props.selectedItem,
-        itemToString: (item: Item) => (item ? item.label : ''),
+        itemToString: (item) => item?.label ?? '',
         items,
         onInputValueChange: (change) => {
             const shouldUpdateInput = (
@@ -198,17 +198,18 @@ function SectionedList(props: SectionedListProps): JSX.Element {
             ).includes(change.type);
 
             if (shouldUpdateInput) {
-                setInputValue(change.inputValue);
+                setInputValue(change.inputValue ?? '');
             }
 
-            if (!change.inputValue) {
+            const nextInputValue = change.inputValue;
+            if (!nextInputValue) {
                 setItems(unpackedItems);
                 return;
             }
 
             const counts: { [k: string]: number } = {};
             const filteredItems = unpackedItems.filter((item: ListItem) => {
-                const lowercaseInput = change.inputValue.toLowerCase();
+                const lowercaseInput = nextInputValue.toLowerCase();
                 const lowercaseLabel = item.label.toLowerCase();
 
                 // Check if search input matches section item
@@ -219,9 +220,11 @@ function SectionedList(props: SectionedListProps): JSX.Element {
 
                 if (item.heading) {
                     // search for section headers that contain an item that matches the input
-                    const listSections = props.items.filter((propItem: ListSection) =>
-                        propItem.items.find((subItem) => subItem.label.toLowerCase().includes(lowercaseInput))
-                    );
+                    const listSections = props.items
+                        .filter(instanceOfSectionItem)
+                        .filter((section) =>
+                            section.items.some((subItem) => subItem.label.toLowerCase().includes(lowercaseInput))
+                        );
 
                     if (listSections.length) {
                         // display section headers that contain a matching item
@@ -243,12 +246,14 @@ function SectionedList(props: SectionedListProps): JSX.Element {
                     (props.selectedItem && changes.selectedItem?.value !== props.selectedItem?.value) ||
                     !props.selectedItem
                 ) {
-                    props.onSelect(changes.selectedItem);
+                    if (changes.selectedItem) {
+                        props.onSelect(changes.selectedItem);
+                    }
                 }
             }
         },
         ...syncKbdHighlightIdx(setKbdHighlightIdx),
-        stateReducer: (state, { changes, type }): Partial<UseComboboxState<Item>> => {
+        stateReducer: (state, { changes, type }): Partial<UseComboboxState<ListItem>> => {
             // When props is forcefully updated then clear the input as well
             if (type === stateChangeTypes.ControlledPropUpdatedSelectedItem) {
                 return {
@@ -263,10 +268,11 @@ function SectionedList(props: SectionedListProps): JSX.Element {
                 (type === stateChangeTypes.ToggleButtonClick && changes.isOpen)
             ) {
                 // This is a hack to change the highlight in the next render cycle so filteredItems had time to update
+                const selectedItemValue = changes.selectedItem?.value;
                 setPendingHighlight(
-                    changes.selectedItem ?
-                        props.items.findIndex((i: ListItem) => i.value === changes.selectedItem.value)
-                    :   0
+                    selectedItemValue === undefined ? 0 : (
+                        unpackedItems.findIndex((item) => item.value === selectedItemValue)
+                    )
                 );
                 return {
                     ...changes,
@@ -292,17 +298,25 @@ function SectionedList(props: SectionedListProps): JSX.Element {
                 };
             }
             // jump section headings when navigating with keys
-            if (type === stateChangeTypes.InputKeyDownArrowUp && items[changes.highlightedIndex]?.heading) {
+            const { highlightedIndex } = changes;
+            if (
+                type === stateChangeTypes.InputKeyDownArrowUp &&
+                highlightedIndex !== undefined &&
+                items[highlightedIndex]?.heading
+            ) {
                 return {
                     ...changes,
-                    highlightedIndex:
-                        changes.highlightedIndex - 1 < 0 ? items.length - 1 : changes.highlightedIndex - 1,
+                    highlightedIndex: highlightedIndex - 1 < 0 ? items.length - 1 : highlightedIndex - 1,
                 };
             }
-            if (type === stateChangeTypes.InputKeyDownArrowDown && items[changes.highlightedIndex]?.heading) {
+            if (
+                type === stateChangeTypes.InputKeyDownArrowDown &&
+                highlightedIndex !== undefined &&
+                items[highlightedIndex]?.heading
+            ) {
                 return {
                     ...changes,
-                    highlightedIndex: changes.highlightedIndex + 1 === items.length ? 0 : changes.highlightedIndex + 1,
+                    highlightedIndex: highlightedIndex + 1 === items.length ? 0 : highlightedIndex + 1,
                 };
             }
             return changes;
@@ -360,15 +374,19 @@ function SectionedList(props: SectionedListProps): JSX.Element {
     return (
         <Wrapper
             className={props.className}
-            isDisabled={props.disabled}
+            isDisabled={Boolean(props.disabled)}
             isErrored={false}
             isOpen={isOpen}
             style={props.style}
             id={props.id}
         >
-            <InputWrapper disabled={props.disabled} isOpen={isOpen} ref={refs.setReference}>
+            <InputWrapper disabled={Boolean(props.disabled)} isOpen={isOpen} ref={refs.setReference}>
                 <Input {...getInputProps({ value: inputValue })} {...getReferenceProps()} size={props.size} />
-                <ChevronButton disabled={props.disabled} isOpen={isOpen} getToggleButtonProps={getToggleButtonProps} />
+                <ChevronButton
+                    disabled={Boolean(props.disabled)}
+                    isOpen={isOpen}
+                    getToggleButtonProps={getToggleButtonProps}
+                />
             </InputWrapper>
             {ReactDOM.createPortal(
                 <DropdownList

--- a/packages/ui-components/src/sectioned-list/sectioned-list.tsx
+++ b/packages/ui-components/src/sectioned-list/sectioned-list.tsx
@@ -190,7 +190,7 @@ function SectionedList(props: SectionedListProps): JSX.Element {
     } = useCombobox<ListItem>({
         initialIsOpen: false,
         initialSelectedItem: props.initialValue ?? props.selectedItem,
-        itemToString: (item) => item?.label ?? '',
+        itemToString: (item) => (item ? item.label : ''),
         items,
         onInputValueChange: (change) => {
             const shouldUpdateInput = (
@@ -198,18 +198,17 @@ function SectionedList(props: SectionedListProps): JSX.Element {
             ).includes(change.type);
 
             if (shouldUpdateInput) {
-                setInputValue(change.inputValue ?? '');
+                setInputValue(change.inputValue as string);
             }
 
-            const nextInputValue = change.inputValue;
-            if (!nextInputValue) {
+            if (!change.inputValue) {
                 setItems(unpackedItems);
                 return;
             }
 
             const counts: { [k: string]: number } = {};
             const filteredItems = unpackedItems.filter((item: ListItem) => {
-                const lowercaseInput = nextInputValue.toLowerCase();
+                const lowercaseInput = change.inputValue!.toLowerCase();
                 const lowercaseLabel = item.label.toLowerCase();
 
                 // Check if search input matches section item
@@ -220,11 +219,9 @@ function SectionedList(props: SectionedListProps): JSX.Element {
 
                 if (item.heading) {
                     // search for section headers that contain an item that matches the input
-                    const listSections = props.items
-                        .filter(instanceOfSectionItem)
-                        .filter((section) =>
-                            section.items.some((subItem) => subItem.label.toLowerCase().includes(lowercaseInput))
-                        );
+                    const listSections = (props.items as ListSection[]).filter((propItem) =>
+                        propItem.items.find((subItem) => subItem.label.toLowerCase().includes(lowercaseInput))
+                    );
 
                     if (listSections.length) {
                         // display section headers that contain a matching item
@@ -246,9 +243,7 @@ function SectionedList(props: SectionedListProps): JSX.Element {
                     (props.selectedItem && changes.selectedItem?.value !== props.selectedItem?.value) ||
                     !props.selectedItem
                 ) {
-                    if (changes.selectedItem) {
-                        props.onSelect(changes.selectedItem);
-                    }
+                    props.onSelect(changes.selectedItem as ListItem);
                 }
             }
         },
@@ -268,11 +263,10 @@ function SectionedList(props: SectionedListProps): JSX.Element {
                 (type === stateChangeTypes.ToggleButtonClick && changes.isOpen)
             ) {
                 // This is a hack to change the highlight in the next render cycle so filteredItems had time to update
-                const selectedItemValue = changes.selectedItem?.value;
                 setPendingHighlight(
-                    selectedItemValue === undefined ? 0 : (
-                        unpackedItems.findIndex((item) => item.value === selectedItemValue)
-                    )
+                    changes.selectedItem ?
+                        (props.items as ListItem[]).findIndex((i) => i.value === changes.selectedItem!.value)
+                    :   0
                 );
                 return {
                     ...changes,
@@ -298,25 +292,18 @@ function SectionedList(props: SectionedListProps): JSX.Element {
                 };
             }
             // jump section headings when navigating with keys
-            const { highlightedIndex } = changes;
-            if (
-                type === stateChangeTypes.InputKeyDownArrowUp &&
-                highlightedIndex !== undefined &&
-                items[highlightedIndex]?.heading
-            ) {
+            if (type === stateChangeTypes.InputKeyDownArrowUp && items[changes.highlightedIndex!]?.heading) {
                 return {
                     ...changes,
-                    highlightedIndex: highlightedIndex - 1 < 0 ? items.length - 1 : highlightedIndex - 1,
+                    highlightedIndex:
+                        changes.highlightedIndex! - 1 < 0 ? items.length - 1 : changes.highlightedIndex! - 1,
                 };
             }
-            if (
-                type === stateChangeTypes.InputKeyDownArrowDown &&
-                highlightedIndex !== undefined &&
-                items[highlightedIndex]?.heading
-            ) {
+            if (type === stateChangeTypes.InputKeyDownArrowDown && items[changes.highlightedIndex!]?.heading) {
                 return {
                     ...changes,
-                    highlightedIndex: highlightedIndex + 1 === items.length ? 0 : highlightedIndex + 1,
+                    highlightedIndex:
+                        changes.highlightedIndex! + 1 === items.length ? 0 : changes.highlightedIndex! + 1,
                 };
             }
             return changes;
@@ -374,16 +361,16 @@ function SectionedList(props: SectionedListProps): JSX.Element {
     return (
         <Wrapper
             className={props.className}
-            isDisabled={Boolean(props.disabled)}
+            isDisabled={props.disabled as boolean}
             isErrored={false}
             isOpen={isOpen}
             style={props.style}
             id={props.id}
         >
-            <InputWrapper disabled={Boolean(props.disabled)} isOpen={isOpen} ref={refs.setReference}>
+            <InputWrapper disabled={props.disabled as boolean} isOpen={isOpen} ref={refs.setReference}>
                 <Input {...getInputProps({ value: inputValue })} {...getReferenceProps()} size={props.size} />
                 <ChevronButton
-                    disabled={Boolean(props.disabled)}
+                    disabled={props.disabled as boolean}
                     isOpen={isOpen}
                     getToggleButtonProps={getToggleButtonProps}
                 />

--- a/packages/ui-components/src/select/select.tsx
+++ b/packages/ui-components/src/select/select.tsx
@@ -168,13 +168,11 @@ function Select(props: SelectProps): JSX.Element {
     const { isOpen, selectedItem, getToggleButtonProps, getMenuProps, getItemProps } = useSelect<Item>({
         initialIsOpen: props.initialIsOpen,
         initialSelectedItem: props.initialValue,
-        itemToString: (item) => item?.label ?? '',
+        itemToString: (item) => item!.label,
         items: props.items,
         onSelectedItemChange: (changes) => {
             const selected = changes.selectedItem;
-            if (selected) {
-                props.onSelect?.(selected);
-            }
+            props.onSelect?.(selected as Item);
         },
         ...syncKbdHighlightIdx(setKbdHighlightIdx),
         // Only set the selectedItem key if it has been explicitly set in props
@@ -220,7 +218,7 @@ function Select(props: SelectProps): JSX.Element {
         <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
             <Wrapper
                 className={props.className}
-                isDisabled={Boolean(props.disabled)}
+                isDisabled={props.disabled as boolean}
                 isErrored={!!props.errorMsg}
                 isOpen={isOpen}
                 onClick={props.onClick}
@@ -254,7 +252,7 @@ function Select(props: SelectProps): JSX.Element {
                         className={`${menuProps?.className ?? ''} ${props.itemClass}`}
                         itemClass={props.itemClass}
                         maxItems={props.maxItems}
-                        selectedItem={selectedItem ?? undefined}
+                        selectedItem={selectedItem as Item}
                         kbdHighlightIdx={kbdHighlightIdx}
                     />,
                     document.body

--- a/packages/ui-components/src/select/select.tsx
+++ b/packages/ui-components/src/select/select.tsx
@@ -151,7 +151,7 @@ export interface SelectProps extends InteractiveComponentProps<Item> {
     /** Specify a specific placement for the list */
     placement?: Placement;
     /** Set the selected value to a specific value, will put the component in controlled mode. Set to `null` to reset the value */
-    selectedItem?: Item;
+    selectedItem?: Item | null;
     /** Font size in rem to show in the Select */
     size?: number;
 }
@@ -168,11 +168,13 @@ function Select(props: SelectProps): JSX.Element {
     const { isOpen, selectedItem, getToggleButtonProps, getMenuProps, getItemProps } = useSelect<Item>({
         initialIsOpen: props.initialIsOpen,
         initialSelectedItem: props.initialValue,
-        itemToString: (item) => item.label,
+        itemToString: (item) => item?.label ?? '',
         items: props.items,
         onSelectedItemChange: (changes) => {
             const selected = changes.selectedItem;
-            props.onSelect?.(selected);
+            if (selected) {
+                props.onSelect?.(selected);
+            }
         },
         ...syncKbdHighlightIdx(setKbdHighlightIdx),
         // Only set the selectedItem key if it has been explicitly set in props
@@ -218,7 +220,7 @@ function Select(props: SelectProps): JSX.Element {
         <Tooltip content={props.errorMsg} disabled={!props.errorMsg} styling="error">
             <Wrapper
                 className={props.className}
-                isDisabled={props.disabled}
+                isDisabled={Boolean(props.disabled)}
                 isErrored={!!props.errorMsg}
                 isOpen={isOpen}
                 onClick={props.onClick}
@@ -252,7 +254,7 @@ function Select(props: SelectProps): JSX.Element {
                         className={`${menuProps?.className ?? ''} ${props.itemClass}`}
                         itemClass={props.itemClass}
                         maxItems={props.maxItems}
-                        selectedItem={selectedItem}
+                        selectedItem={selectedItem ?? undefined}
                         kbdHighlightIdx={kbdHighlightIdx}
                     />,
                     document.body

--- a/packages/ui-components/src/slider/slider.tsx
+++ b/packages/ui-components/src/slider/slider.tsx
@@ -277,7 +277,7 @@ function useValueCorrection<T>(
         const constraintsChanged =
             !isEqual(previousConstraints.current.domain, domain) || previousConstraints.current.step !== step;
 
-        if (!constraintsChanged || !values?.length || !onChange || !getValueLabel) {
+        if (!constraintsChanged || !values?.length || !onChange) {
             previousConstraints.current = { domain, step };
             return;
         }
@@ -287,7 +287,7 @@ function useValueCorrection<T>(
 
         // Only fire onChange if values actually changed
         if (!isEqual(values, correctedValues)) {
-            const formattedValues = correctedValues.map(getValueLabel);
+            const formattedValues = correctedValues.map(getValueLabel!);
             onChange(formattedValues);
         }
 
@@ -346,8 +346,6 @@ function BaseSlider<T extends string | number | React.ReactNode>({
     className,
     id,
 }: BaseSliderProps<T>): JSX.Element {
-    const formatValue = useMemo(() => getValueLabel ?? ((value: number) => value as T), [getValueLabel]);
-
     // If step isn't set then pick a reasonable one
     const adjustedStep = useMemo(() => {
         if (step) {
@@ -357,7 +355,7 @@ function BaseSlider<T extends string | number | React.ReactNode>({
     }, [domain, step]);
 
     // Handle value correction for controlled mode
-    useValueCorrection(values, domain, adjustedStep, onChange, formatValue);
+    useValueCorrection(values, domain, adjustedStep, onChange, getValueLabel);
 
     const [showInputs, setShowInputs] = useState(false);
 
@@ -386,10 +384,10 @@ function BaseSlider<T extends string | number | React.ReactNode>({
             }
 
             const valueArray = Array.isArray(value) ? value : [value];
-            const formattedValues = valueArray.map(formatValue);
+            const formattedValues = valueArray.map(getValueLabel!);
             onChange(formattedValues);
         },
-        [onChange, formatValue]
+        [onChange, getValueLabel]
     );
 
     // Generate tick values
@@ -506,11 +504,11 @@ function BaseSlider<T extends string | number | React.ReactNode>({
 
                     {/* Thumbs */}
                     {currentValues.map((value, index) => (
-                        <Tooltip content={formatValue(value)} hideOnClick={false} key={index} placement="top">
+                        <Tooltip content={getValueLabel!(value)} hideOnClick={false} key={index} placement="top">
                             <StyledSliderThumb
                                 aria-label={
                                     thumbLabels?.[index] ??
-                                    (formatValue(value) as string | undefined) ??
+                                    (getValueLabel?.(value) as string | undefined) ??
                                     `Thumb ${index + 1}`
                                 }
                                 index={index}
@@ -522,7 +520,7 @@ function BaseSlider<T extends string | number | React.ReactNode>({
                 </>
             );
         },
-        [trackToStart, trackToEnd, ticks, trackLabels, formatValue, thumbLabels]
+        [trackToStart, trackToEnd, ticks, trackLabels, getValueLabel, thumbLabels]
     );
 
     return (
@@ -558,7 +556,7 @@ function BaseSlider<T extends string | number | React.ReactNode>({
                                                     transform: getTickTransform(idx, tickValues.length),
                                                 }}
                                             >
-                                                {formatValue(tickValue)}
+                                                {getValueLabel!(tickValue)}
                                             </Tick>
                                         );
                                     })}

--- a/packages/ui-components/src/slider/slider.tsx
+++ b/packages/ui-components/src/slider/slider.tsx
@@ -277,7 +277,7 @@ function useValueCorrection<T>(
         const constraintsChanged =
             !isEqual(previousConstraints.current.domain, domain) || previousConstraints.current.step !== step;
 
-        if (!constraintsChanged || !values?.length || !onChange) {
+        if (!constraintsChanged || !values?.length || !onChange || !getValueLabel) {
             previousConstraints.current = { domain, step };
             return;
         }
@@ -346,6 +346,8 @@ function BaseSlider<T extends string | number | React.ReactNode>({
     className,
     id,
 }: BaseSliderProps<T>): JSX.Element {
+    const formatValue = useMemo(() => getValueLabel ?? ((value: number) => value as T), [getValueLabel]);
+
     // If step isn't set then pick a reasonable one
     const adjustedStep = useMemo(() => {
         if (step) {
@@ -355,7 +357,7 @@ function BaseSlider<T extends string | number | React.ReactNode>({
     }, [domain, step]);
 
     // Handle value correction for controlled mode
-    useValueCorrection(values, domain, adjustedStep, onChange, getValueLabel);
+    useValueCorrection(values, domain, adjustedStep, onChange, formatValue);
 
     const [showInputs, setShowInputs] = useState(false);
 
@@ -384,10 +386,10 @@ function BaseSlider<T extends string | number | React.ReactNode>({
             }
 
             const valueArray = Array.isArray(value) ? value : [value];
-            const formattedValues = valueArray.map(getValueLabel);
+            const formattedValues = valueArray.map(formatValue);
             onChange(formattedValues);
         },
-        [onChange, getValueLabel]
+        [onChange, formatValue]
     );
 
     // Generate tick values
@@ -504,11 +506,11 @@ function BaseSlider<T extends string | number | React.ReactNode>({
 
                     {/* Thumbs */}
                     {currentValues.map((value, index) => (
-                        <Tooltip content={getValueLabel(value)} hideOnClick={false} key={index} placement="top">
+                        <Tooltip content={formatValue(value)} hideOnClick={false} key={index} placement="top">
                             <StyledSliderThumb
                                 aria-label={
                                     thumbLabels?.[index] ??
-                                    (getValueLabel?.(value) as string | undefined) ??
+                                    (formatValue(value) as string | undefined) ??
                                     `Thumb ${index + 1}`
                                 }
                                 index={index}
@@ -520,7 +522,7 @@ function BaseSlider<T extends string | number | React.ReactNode>({
                 </>
             );
         },
-        [trackToStart, trackToEnd, ticks, trackLabels, getValueLabel, thumbLabels]
+        [trackToStart, trackToEnd, ticks, trackLabels, formatValue, thumbLabels]
     );
 
     return (
@@ -556,7 +558,7 @@ function BaseSlider<T extends string | number | React.ReactNode>({
                                                     transform: getTickTransform(idx, tickValues.length),
                                                 }}
                                             >
-                                                {getValueLabel(tickValue)}
+                                                {formatValue(tickValue)}
                                             </Tick>
                                         );
                                     })}

--- a/packages/ui-components/src/table/cells/action-cell.tsx
+++ b/packages/ui-components/src/table/cells/action-cell.tsx
@@ -98,7 +98,7 @@ interface ActionCellProps {
  *
  * @param {ActionCellProps} props see interface for details
  */
-export function ActionCell(props: ActionCellProps): JSX.Element | null {
+export function ActionCell(props: ActionCellProps): JSX.Element | null | undefined {
     if (!props.column.actions) {
         throw new Error('Must pass an array of actions to the column def when using the ActionCell');
     }
@@ -112,7 +112,7 @@ export function ActionCell(props: ActionCellProps): JSX.Element | null {
         const action = props.column.actions[0];
         const Icon = action.getIcon ? action.getIcon(props.row.original) : action.icon;
         if (Icon === undefined) {
-            return null;
+            return;
         }
         const label = action.getLabel ? action.getLabel(props.row.original) : action.label;
         return (

--- a/packages/ui-components/src/table/cells/action-cell.tsx
+++ b/packages/ui-components/src/table/cells/action-cell.tsx
@@ -98,7 +98,7 @@ interface ActionCellProps {
  *
  * @param {ActionCellProps} props see interface for details
  */
-export function ActionCell(props: ActionCellProps): JSX.Element {
+export function ActionCell(props: ActionCellProps): JSX.Element | null {
     if (!props.column.actions) {
         throw new Error('Must pass an array of actions to the column def when using the ActionCell');
     }
@@ -112,7 +112,7 @@ export function ActionCell(props: ActionCellProps): JSX.Element {
         const action = props.column.actions[0];
         const Icon = action.getIcon ? action.getIcon(props.row.original) : action.icon;
         if (Icon === undefined) {
-            return;
+            return null;
         }
         const label = action.getLabel ? action.getLabel(props.row.original) : action.label;
         return (

--- a/packages/ui-components/src/table/filters.tsx
+++ b/packages/ui-components/src/table/filters.tsx
@@ -118,7 +118,7 @@ function applyNumericOperator(
     operator: NumericOperator,
     value: number,
     filterValue: number | [number, number]
-): boolean {
+): boolean | undefined {
     switch (operator) {
         case NumericOperator.EQ:
             return value === filterValue;
@@ -140,7 +140,7 @@ function applyNumericOperator(
             if (Array.isArray(filterValue)) {
                 return value <= filterValue[1] && value >= filterValue[0];
             }
-            return false;
+            break;
         default:
             return true;
     }
@@ -192,19 +192,11 @@ export function numeric(rows: Array<Row>, columnIds: Array<string>, filterValue:
     const [colId] = columnIds;
 
     // If operator not supported or there's no value to compare to, return all rows
-    if (!isValidOperator(selected) || value === null) {
+    if (!isValidOperator(selected) || (!value && value !== 0)) {
         return rows;
     }
 
-    if (Array.isArray(value)) {
-        const [start, end] = value;
-        if (start === null || end === null) {
-            return rows;
-        }
-        return rows.filter((row) => applyNumericOperator(selected, row.values[colId], [start, end]));
-    }
-
-    return rows.filter((row) => applyNumericOperator(selected, row.values[colId], value));
+    return rows.filter((row) => applyNumericOperator(selected, row.values[colId], value as number | [number, number]));
 }
 
 /**

--- a/packages/ui-components/src/table/filters.tsx
+++ b/packages/ui-components/src/table/filters.tsx
@@ -140,7 +140,7 @@ function applyNumericOperator(
             if (Array.isArray(filterValue)) {
                 return value <= filterValue[1] && value >= filterValue[0];
             }
-            break;
+            return false;
         default:
             return true;
     }
@@ -192,8 +192,16 @@ export function numeric(rows: Array<Row>, columnIds: Array<string>, filterValue:
     const [colId] = columnIds;
 
     // If operator not supported or there's no value to compare to, return all rows
-    if (!isValidOperator(selected) || (!value && value !== 0)) {
+    if (!isValidOperator(selected) || value === null) {
         return rows;
+    }
+
+    if (Array.isArray(value)) {
+        const [start, end] = value;
+        if (start === null || end === null) {
+            return rows;
+        }
+        return rows.filter((row) => applyNumericOperator(selected, row.values[colId], [start, end]));
     }
 
     return rows.filter((row) => applyNumericOperator(selected, row.values[colId], value));

--- a/packages/ui-components/src/table/options-menu.tsx
+++ b/packages/ui-components/src/table/options-menu.tsx
@@ -69,7 +69,7 @@ interface OptionsMenuProps {
     /** filter setter from useTable */
     setAllFilters: (updater: Filters<any> | ((filters: Filters<any>) => Filters<any>)) => void;
     /** Pass through of the style prop to the table options Dropdown */
-    style: React.CSSProperties;
+    style?: React.CSSProperties;
 }
 
 const columnHeaderToString = (header: unknown): string => {
@@ -100,7 +100,7 @@ const OptionsMenu: FunctionComponent<OptionsMenuProps> = ({
     }, []);
 
     const onOptionSelect = useCallback((option: Item): void => {
-        option.onClick();
+        option.onClick?.();
         setIsOpen(false);
     }, []);
 
@@ -157,9 +157,12 @@ const OptionsMenu: FunctionComponent<OptionsMenuProps> = ({
                 .filter((column) => typeof column.Header === 'string')
                 .map((column) => ({
                     label: `${column.isVisible ? 'Hide' : 'Show'} ${columnHeaderToString(column.Header)}`,
-                    onClick: () =>
+                    onClick: () => {
                         /* Don't allow last visible column to be hidden */
-                        !(column.isVisible && numVisibleColumns === 1) ? column.toggleHidden() : null,
+                        if (!(column.isVisible && numVisibleColumns === 1)) {
+                            column.toggleHidden();
+                        }
+                    },
                     value: `${column.isVisible ? 'hide' : 'show'}${columnHeaderToString(column.Header)}`,
                 })),
             label: 'Columns',

--- a/packages/ui-components/src/table/options-menu.tsx
+++ b/packages/ui-components/src/table/options-menu.tsx
@@ -100,7 +100,7 @@ const OptionsMenu: FunctionComponent<OptionsMenuProps> = ({
     }, []);
 
     const onOptionSelect = useCallback((option: Item): void => {
-        option.onClick?.();
+        option.onClick!();
         setIsOpen(false);
     }, []);
 
@@ -157,12 +157,9 @@ const OptionsMenu: FunctionComponent<OptionsMenuProps> = ({
                 .filter((column) => typeof column.Header === 'string')
                 .map((column) => ({
                     label: `${column.isVisible ? 'Hide' : 'Show'} ${columnHeaderToString(column.Header)}`,
-                    onClick: () => {
+                    onClick: (() =>
                         /* Don't allow last visible column to be hidden */
-                        if (!(column.isVisible && numVisibleColumns === 1)) {
-                            column.toggleHidden();
-                        }
-                    },
+                        !(column.isVisible && numVisibleColumns === 1) ? column.toggleHidden() : null) as () => void,
                     value: `${column.isVisible ? 'hide' : 'show'}${columnHeaderToString(column.Header)}`,
                 })),
             label: 'Columns',

--- a/packages/ui-components/src/table/render-row.tsx
+++ b/packages/ui-components/src/table/render-row.tsx
@@ -114,11 +114,11 @@ const arePropsEqual = (prevProps: Props, nextProps: Props): boolean =>
 type Props = {
     data: {
         backgroundColor: string;
-        currentEditCell: [number, string | number];
+        currentEditCell?: [number, string | number];
         getItem: (index: number) => any;
         headerGroups: Array<HeaderGroup<object>>;
         mappedColumns: Array<TableColumn>;
-        onClickRow: (row: any) => void | Promise<void>;
+        onClickRow?: (row: any) => void | Promise<void>;
         prepareRow: (row: any) => void;
         rows: Array<any>;
         throttledClickRow: (row: any) => void | Promise<void>;

--- a/packages/ui-components/src/table/table.tsx
+++ b/packages/ui-components/src/table/table.tsx
@@ -404,7 +404,7 @@ const createActionColumn = (
         disableSortBy: true,
         maxWidth: width,
         minWidth: actions.includes(Actions.SELECT) ? 52 : 48,
-        sticky: sticky || undefined,
+        sticky: (sticky || null) as 'left' | 'right' | undefined,
         width,
     };
 };
@@ -540,8 +540,6 @@ const createItemData = memoize(
     })
 );
 
-const RowRenderer = RenderRow as React.ComponentType<any>;
-
 /**
  * The Table component builds on top of the thirdparty react-table library and aims to provide a simple outward facing
  * api. A table can be completely defined by passing in an array of columns and an array of data. The columns
@@ -604,7 +602,7 @@ const Table = forwardRef(
         >(undefined, 500);
 
         // ClickRow is throttled so multiple or double clicks don't fire multiple events
-        const throttledClickRow = useThrottle((row: T) => onClickRow?.(row), 500);
+        const throttledClickRow = useThrottle(onClickRow!, 500);
 
         const onStopEdit = (): void => {
             throttledSetEditCell(undefined);
@@ -684,9 +682,7 @@ const Table = forwardRef(
                 initialState: {
                     sortBy: currentSortBy.map((sort) => ({
                         ...sort,
-                        id:
-                            mappedColumns.find((col) => [col.sortKey, col.accessor].includes(sort.id))?.accessor ??
-                            sort.id,
+                        id: mappedColumns.find((col) => [col.sortKey, col.accessor].includes(sort.id))!.accessor,
                     })),
                 },
                 // In infinite mode, don't filter client-side
@@ -877,7 +873,7 @@ const Table = forwardRef(
                                 }}
                                 width={width}
                             >
-                                {RowRenderer}
+                                {RenderRow as React.ComponentType<any>}
                             </StyledFixedSizeList>
                         );
                     }}

--- a/packages/ui-components/src/table/table.tsx
+++ b/packages/ui-components/src/table/table.tsx
@@ -21,7 +21,6 @@ import memoize from 'memoize-one';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
 import * as React from 'react';
 import {
-    type FilterProps,
     type Filters,
     type HeaderGroup,
     type SortingRule,
@@ -199,7 +198,7 @@ const TooltipIcon = styled(FontAwesomeIcon)`
  * @param isSorted - whether the column is sorted or not
  * @param isSortedDesc - whether it is sorted in descending order
  */
-const getSortIcon = (isSorted: boolean, isSortedDesc: boolean): IconDefinition => {
+const getSortIcon = (isSorted?: boolean, isSortedDesc?: boolean): IconDefinition => {
     if (!isSorted) {
         return faArrowUp;
     }
@@ -348,7 +347,7 @@ const appendStickyOffsets = (columns: Array<TableColumn>): Array<TableColumn> =>
 };
 
 // Map of filter name -> filter component
-const filterComponentMap: Record<string, (props: FilterProps<any>) => JSX.Element> = {
+const filterComponentMap: Record<string, React.ComponentType<any>> = {
     categorical: CategoricalFilter,
     datetime: DatetimeFilter,
     numeric: NumericFilter,
@@ -405,7 +404,7 @@ const createActionColumn = (
         disableSortBy: true,
         maxWidth: width,
         minWidth: actions.includes(Actions.SELECT) ? 52 : 48,
-        sticky: sticky || null,
+        sticky: sticky || undefined,
         width,
     };
 };
@@ -541,6 +540,8 @@ const createItemData = memoize(
     })
 );
 
+const RowRenderer = RenderRow as React.ComponentType<any>;
+
 /**
  * The Table component builds on top of the thirdparty react-table library and aims to provide a simple outward facing
  * api. A table can be completely defined by passing in an array of columns and an array of data. The columns
@@ -599,11 +600,11 @@ const Table = forwardRef(
         }
 
         const [currentEditCell, throttledSetEditCell, immediateSetEditCell] = useThrottledState<
-            [number, string | number]
+            [number, string | number] | undefined
         >(undefined, 500);
 
         // ClickRow is throttled so multiple or double clicks don't fire multiple events
-        const throttledClickRow = useThrottle(onClickRow, 500);
+        const throttledClickRow = useThrottle((row: T) => onClickRow?.(row), 500);
 
         const onStopEdit = (): void => {
             throttledSetEditCell(undefined);
@@ -672,7 +673,7 @@ const Table = forwardRef(
             setAllFilters,
             resetResizing,
             allColumns,
-        } = useTable(
+        } = useTable<any>(
             {
                 columns: mappedColumns,
                 data: data || infiniteData,
@@ -683,7 +684,9 @@ const Table = forwardRef(
                 initialState: {
                     sortBy: currentSortBy.map((sort) => ({
                         ...sort,
-                        id: mappedColumns.find((col) => [col.sortKey, col.accessor].includes(sort.id)).accessor,
+                        id:
+                            mappedColumns.find((col) => [col.sortKey, col.accessor].includes(sort.id))?.accessor ??
+                            sort.id,
                     })),
                 },
                 // In infinite mode, don't filter client-side
@@ -874,7 +877,7 @@ const Table = forwardRef(
                                 }}
                                 width={width}
                             >
-                                {RenderRow}
+                                {RowRenderer}
                             </StyledFixedSizeList>
                         );
                     }}

--- a/packages/ui-components/src/utils/syncKbdHighlightIdx.ts
+++ b/packages/ui-components/src/utils/syncKbdHighlightIdx.ts
@@ -30,7 +30,7 @@ const setTypes = new Set([
  * });
  */
 export const syncKbdHighlightIdx = (
-    setKbdHighlightIdx: (idx: number) => void
+    setKbdHighlightIdx: (idx: number | undefined) => void
 ): { onHighlightedIndexChange: ({ highlightedIndex, type }: any) => void } => ({
     onHighlightedIndexChange: ({ highlightedIndex, type }: any) => {
         // Hack to force a rerender of an element when highlighted with a keyboard

--- a/packages/ui-components/src/utils/use-infinite-loader.tsx
+++ b/packages/ui-components/src/utils/use-infinite-loader.tsx
@@ -30,7 +30,7 @@ export interface ItemsRenderedPayload {
 
 export interface InfiniteLoader<T> {
     /** A function to get the actual value of an item, based on it's absolute index in the list */
-    getItem: (index: number) => T;
+    getItem: (index: number) => T | undefined;
     /** The total count of items in the list */
     itemCount: number;
     /** A handler for the onItemsRendered function exposed by the react-window components */
@@ -58,7 +58,7 @@ function useInfiniteLoader<T>(
     // Use a ref on the onLoadData function to get the updated version into the onItemsRendered function as only the
     // first instance passed is ever called by react-window
     const onLoadRef = useRef(onLoadData);
-    const [internalData, setInternalData] = useState([]);
+    const [internalData, setInternalData] = useState<Array<T>>([]);
     const [itemCount, setItemCount] = useState(0);
     const [currentStartIdx, setStartIdx] = useState(0);
     const [currentStopIdx, setStopIdx] = useState(0);
@@ -70,7 +70,7 @@ function useInfiniteLoader<T>(
     const getItem = useCallback(
         (index: number) => {
             const adjustedIndex = index - currentStartIdx;
-            if (adjustedIndex < 0 || adjustedIndex > internalData.length) {
+            if (adjustedIndex < 0 || adjustedIndex >= internalData.length) {
                 return;
             }
             return internalData[adjustedIndex];
@@ -127,7 +127,7 @@ function useInfiniteLoader<T>(
                 setInternalData((current) => [...current, ...data]);
                 setItemCount(totalCount);
             } catch (err) {
-                onError?.(err);
+                onError?.(err instanceof Error ? err : new Error(String(err)));
             }
         },
         [batchSize, currentStartIdx, currentStopIdx, onError]

--- a/packages/ui-components/src/utils/use-infinite-loader.tsx
+++ b/packages/ui-components/src/utils/use-infinite-loader.tsx
@@ -70,7 +70,7 @@ function useInfiniteLoader<T>(
     const getItem = useCallback(
         (index: number) => {
             const adjustedIndex = index - currentStartIdx;
-            if (adjustedIndex < 0 || adjustedIndex >= internalData.length) {
+            if (adjustedIndex < 0 || adjustedIndex > internalData.length) {
                 return;
             }
             return internalData[adjustedIndex];
@@ -127,7 +127,7 @@ function useInfiniteLoader<T>(
                 setInternalData((current) => [...current, ...data]);
                 setItemCount(totalCount);
             } catch (err) {
-                onError?.(err instanceof Error ? err : new Error(String(err)));
+                onError?.(err as Error);
             }
         },
         [batchSize, currentStartIdx, currentStopIdx, onError]

--- a/packages/ui-components/src/utils/use-on-click-outside.tsx
+++ b/packages/ui-components/src/utils/use-on-click-outside.tsx
@@ -18,7 +18,7 @@ import { useEffect } from 'react';
 
 function useOnClickOutside(element: any, handler: () => void): void {
     useEffect(() => {
-        const listener = (event: MouseEvent): void => {
+        const listener = (event: Event): void => {
             // Do nothing if clicking ref's element or descendent elements
             if (!element || element.contains(event.target)) {
                 return;

--- a/packages/ui-hierarchy-viewer/src/hierarchy-viewer/treemap.tsx
+++ b/packages/ui-hierarchy-viewer/src/hierarchy-viewer/treemap.tsx
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import * as d3 from 'd3';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type RefObject, useCallback, useEffect, useRef, useState } from 'react';
 
 import styled, { useTheme } from '@darajs/styled-components';
 import { useDeepCompare } from '@darajs/ui-utils';
@@ -182,7 +182,7 @@ function Treemap(props: TreemapProps): JSX.Element | null {
 
     const maxDepth = treemap.leaves() ? treemap.leaves()[0].depth : 0;
     return (
-        <svg height={props.height} ref={ref} width={props.width}>
+        <svg height={props.height} ref={ref as RefObject<SVGSVGElement>} width={props.width}>
             <NodeRenderer
                 allowLeafClick={props.allowLeafClick}
                 allowParentClick={props.allowParentClick}

--- a/packages/ui-hierarchy-viewer/src/hierarchy-viewer/treemap.tsx
+++ b/packages/ui-hierarchy-viewer/src/hierarchy-viewer/treemap.tsx
@@ -59,7 +59,7 @@ interface NodeRendererProps {
     color: d3.ScaleOrdinal<string, string, never>;
     maxDepth: number;
     node: d3.HierarchyRectangularNode<Node>;
-    onClick: (node: Node) => void | Promise<void>;
+    onClick?: (node: Node) => void | Promise<void>;
 }
 
 /**
@@ -74,11 +74,11 @@ function NodeRenderer(props: NodeRendererProps): JSX.Element {
     const fill = props.color(depth).toString();
     const width = Number.isNaN(node.x1 - node.x0) ? undefined : node.x1 - node.x0;
     const height = Number.isNaN(node.y1 - node.y0) ? undefined : node.y1 - node.y0;
-    const hasChildren = node.children && node.children.length > 0;
-    const isInteractive = (hasChildren && props.allowParentClick) || (!hasChildren && props.allowLeafClick);
+    const hasChildren = Boolean(node.children && node.children.length > 0);
+    const isInteractive = Boolean((hasChildren && props.allowParentClick) || (!hasChildren && props.allowLeafClick));
 
     const onClick = useCallback(() => {
-        onClickProp(node.data);
+        onClickProp?.(node.data);
     }, [node, onClickProp]);
 
     return (
@@ -106,7 +106,7 @@ function NodeRenderer(props: NodeRendererProps): JSX.Element {
                 </NodeLabel>
             </foreignObject>
             {node.children &&
-                node.children.map((child: any) => (
+                node.children.map((child) => (
                     <NodeRenderer
                         allowLeafClick={props.allowLeafClick}
                         allowParentClick={props.allowParentClick}
@@ -133,7 +133,7 @@ interface TreemapProps {
     /** Component height */
     height: number;
     /** onClick handler for when a node is clicked on */
-    onClick: (node: Node) => void | Promise<void>;
+    onClick?: (node: Node) => void | Promise<void>;
     /** Component width */
     width: number;
 }
@@ -144,27 +144,27 @@ interface TreemapProps {
  *
  * @param {TreemapProps} params - the component props
  */
-function Treemap(props: TreemapProps): JSX.Element {
+function Treemap(props: TreemapProps): JSX.Element | null {
     const theme = useTheme();
-    const ref = useRef();
+    const ref = useRef<SVGSVGElement>(null);
 
-    const [treemap, setTreemap] = useState<any>();
+    const [treemap, setTreemap] = useState<d3.HierarchyRectangularNode<Node> | null>(null);
 
     useEffect(
         () => {
             if (props.data) {
                 const root = d3.hierarchy(props.data).sum((node) => {
-                    return node.children && node.children.length > 0 ? 0 : node.weight;
+                    return node.children && node.children.length > 0 ? 0 : node.weight ?? 0;
                 });
-                d3
-                    .treemap()
+                const layout = d3
+                    .treemap<Node>()
                     .size([props.width, props.height])
                     .paddingTop(28)
                     .paddingBottom(8)
                     .paddingRight(7)
                     .paddingLeft(7)
-                    .paddingInner(3)(root);
-                setTreemap(root);
+                    .paddingInner(3);
+                setTreemap(layout(root));
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -180,7 +180,7 @@ function Treemap(props: TreemapProps): JSX.Element {
         return null;
     }
 
-    const maxDepth = treemap.leaves() ? treemap.leaves()[0].depth : 0;
+    const maxDepth = treemap.leaves()[0]?.depth ?? 0;
     return (
         <svg height={props.height} ref={ref} width={props.width}>
             <NodeRenderer

--- a/packages/ui-hierarchy-viewer/src/hierarchy-viewer/treemap.tsx
+++ b/packages/ui-hierarchy-viewer/src/hierarchy-viewer/treemap.tsx
@@ -74,11 +74,11 @@ function NodeRenderer(props: NodeRendererProps): JSX.Element {
     const fill = props.color(depth).toString();
     const width = Number.isNaN(node.x1 - node.x0) ? undefined : node.x1 - node.x0;
     const height = Number.isNaN(node.y1 - node.y0) ? undefined : node.y1 - node.y0;
-    const hasChildren = Boolean(node.children && node.children.length > 0);
-    const isInteractive = Boolean((hasChildren && props.allowParentClick) || (!hasChildren && props.allowLeafClick));
+    const hasChildren = node.children && node.children.length > 0;
+    const isInteractive = (hasChildren && props.allowParentClick) || (!hasChildren && props.allowLeafClick);
 
     const onClick = useCallback(() => {
-        onClickProp?.(node.data);
+        onClickProp!(node.data);
     }, [node, onClickProp]);
 
     return (
@@ -98,8 +98,8 @@ function NodeRenderer(props: NodeRendererProps): JSX.Element {
                 y={Number.isNaN(node.y0) ? undefined : node.y0}
             >
                 <NodeLabel
-                    hasChildren={hasChildren}
-                    isInteractive={isInteractive}
+                    hasChildren={hasChildren as boolean}
+                    isInteractive={isInteractive as boolean}
                     title={`${node.data?.label} (${node.data?.weight})`}
                 >
                     <span>{node.data?.label}</span>
@@ -146,25 +146,25 @@ interface TreemapProps {
  */
 function Treemap(props: TreemapProps): JSX.Element | null {
     const theme = useTheme();
-    const ref = useRef<SVGSVGElement>(null);
+    const ref = useRef<SVGSVGElement>();
 
-    const [treemap, setTreemap] = useState<d3.HierarchyRectangularNode<Node> | null>(null);
+    const [treemap, setTreemap] = useState<d3.HierarchyRectangularNode<Node> | null>();
 
     useEffect(
         () => {
             if (props.data) {
                 const root = d3.hierarchy(props.data).sum((node) => {
-                    return node.children && node.children.length > 0 ? 0 : node.weight ?? 0;
+                    return node.children && node.children.length > 0 ? 0 : node.weight!;
                 });
-                const layout = d3
+                d3
                     .treemap<Node>()
                     .size([props.width, props.height])
                     .paddingTop(28)
                     .paddingBottom(8)
                     .paddingRight(7)
                     .paddingLeft(7)
-                    .paddingInner(3);
-                setTreemap(layout(root));
+                    .paddingInner(3)(root);
+                setTreemap(root as d3.HierarchyRectangularNode<Node>);
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -180,7 +180,7 @@ function Treemap(props: TreemapProps): JSX.Element | null {
         return null;
     }
 
-    const maxDepth = treemap.leaves()[0]?.depth ?? 0;
+    const maxDepth = treemap.leaves() ? treemap.leaves()[0].depth : 0;
     return (
         <svg height={props.height} ref={ref} width={props.width}>
             <NodeRenderer

--- a/packages/ui-hierarchy-viewer/tsconfig.json
+++ b/packages/ui-hierarchy-viewer/tsconfig.json
@@ -13,7 +13,7 @@
         "rootDir": "./src/",
         "skipLibCheck": true,
         "sourceMap": true,
-        "strict": false,
+        "strict": true,
         "target": "es2015",
     }
 }

--- a/packages/ui-notifications/src/notification-wrapper.tsx
+++ b/packages/ui-notifications/src/notification-wrapper.tsx
@@ -56,9 +56,8 @@ const baseNotifications$ = new Subject<NotificationPayload>();
  * generic push method for sending a new one
  * Additionally, it exposes a callback for when the notification is too small and more details are needed and clicked
  */
-export const NotificationContext = React.createContext({
+export const NotificationContext = React.createContext<NotificationContext>({
     notifications$: baseNotifications$,
-    onMoreDetailsClick: null,
     push: (notification: NotificationPayload) => baseNotifications$.next(notification),
 });
 
@@ -115,7 +114,9 @@ function NotificationWrapper(props: NotificationWrapperProps): JSX.Element {
                     key={notification.key}
                     notification={notification}
                     onDismiss={onDismiss}
-                    onMoreDetailsClick={onMoreDetailsClick}
+                    onMoreDetailsClick={
+                        onMoreDetailsClick ? (_event, payload) => onMoreDetailsClick(payload) : undefined
+                    }
                 />
             ))}
         </Container>

--- a/packages/ui-notifications/src/notification-wrapper.tsx
+++ b/packages/ui-notifications/src/notification-wrapper.tsx
@@ -22,7 +22,7 @@ import { delay } from 'rxjs/operators';
 import styled from '@darajs/styled-components';
 import { useSubscription } from '@darajs/ui-utils';
 
-import Notification from './notification';
+import Notification, { type NotificationProps } from './notification';
 import { type NotificationPayload } from './notification-payload';
 
 const Container = styled.div`
@@ -45,7 +45,7 @@ const Container = styled.div`
 
 interface NotificationContext {
     notifications$: Subject<NotificationPayload>;
-    onMoreDetailsClick?: (notification: NotificationPayload) => void;
+    onMoreDetailsClick?: ((notification: NotificationPayload) => void) | null;
     push: (notification: NotificationPayload) => void;
 }
 
@@ -58,6 +58,7 @@ const baseNotifications$ = new Subject<NotificationPayload>();
  */
 export const NotificationContext = React.createContext<NotificationContext>({
     notifications$: baseNotifications$,
+    onMoreDetailsClick: null,
     push: (notification: NotificationPayload) => baseNotifications$.next(notification),
 });
 
@@ -114,9 +115,7 @@ function NotificationWrapper(props: NotificationWrapperProps): JSX.Element {
                     key={notification.key}
                     notification={notification}
                     onDismiss={onDismiss}
-                    onMoreDetailsClick={
-                        onMoreDetailsClick ? (_event, payload) => onMoreDetailsClick(payload) : undefined
-                    }
+                    onMoreDetailsClick={onMoreDetailsClick as NotificationProps['onMoreDetailsClick']}
                 />
             ))}
         </Container>

--- a/packages/ui-notifications/src/notification.tsx
+++ b/packages/ui-notifications/src/notification.tsx
@@ -152,7 +152,7 @@ export interface NotificationProps {
  */
 function Notification(props: NotificationProps): JSX.Element {
     const isOverflowing = props.notification.message.length > 30;
-    const showMoreDetails = props.onMoreDetailsClick && isOverflowing;
+    const showMoreDetails = Boolean(props.onMoreDetailsClick && isOverflowing);
 
     return (
         <NotificationWrapper hasTitle={!!props.notification.title} status={props.notification.status}>
@@ -161,14 +161,14 @@ function Notification(props: NotificationProps): JSX.Element {
                 <Heading>{props.notification.title}</Heading>
                 <Body moreDetailsShown={showMoreDetails}>{props.notification.message}</Body>
                 {showMoreDetails && (
-                    <MoreDetailsButton onClick={(e) => props.onMoreDetailsClick(e, props.notification)} type="button">
+                    <MoreDetailsButton onClick={(e) => props.onMoreDetailsClick?.(e, props.notification)} type="button">
                         Details &gt;
                     </MoreDetailsButton>
                 )}
             </Message>
             <CloseBtn
                 asButton
-                onClick={() => props.onDismiss(props.notification.key)}
+                onClick={() => props.onDismiss?.(props.notification.key)}
                 status={props.notification.status}
             />
         </NotificationWrapper>

--- a/packages/ui-notifications/src/notification.tsx
+++ b/packages/ui-notifications/src/notification.tsx
@@ -152,23 +152,23 @@ export interface NotificationProps {
  */
 function Notification(props: NotificationProps): JSX.Element {
     const isOverflowing = props.notification.message.length > 30;
-    const showMoreDetails = Boolean(props.onMoreDetailsClick && isOverflowing);
+    const showMoreDetails = props.onMoreDetailsClick && isOverflowing;
 
     return (
         <NotificationWrapper hasTitle={!!props.notification.title} status={props.notification.status}>
             <Icon status={props.notification.status}>{getIcon(props.notification.status)}</Icon>
             <Message>
                 <Heading>{props.notification.title}</Heading>
-                <Body moreDetailsShown={showMoreDetails}>{props.notification.message}</Body>
+                <Body moreDetailsShown={showMoreDetails as boolean}>{props.notification.message}</Body>
                 {showMoreDetails && (
-                    <MoreDetailsButton onClick={(e) => props.onMoreDetailsClick?.(e, props.notification)} type="button">
+                    <MoreDetailsButton onClick={(e) => props.onMoreDetailsClick!(e, props.notification)} type="button">
                         Details &gt;
                     </MoreDetailsButton>
                 )}
             </Message>
             <CloseBtn
                 asButton
-                onClick={() => props.onDismiss?.(props.notification.key)}
+                onClick={() => props.onDismiss!(props.notification.key)}
                 status={props.notification.status}
             />
         </NotificationWrapper>

--- a/packages/ui-utils/src/request-utils.tsx
+++ b/packages/ui-utils/src/request-utils.tsx
@@ -63,23 +63,21 @@ export const getQueryStr = (options?: RequestOptions, extras?: { [k: string]: st
     }
 
     let query = '?';
-    const requestOptions = options ?? {};
-
-    if (Number.isInteger(requestOptions.startIndex)) {
-        query += `offset=${requestOptions.startIndex}&`;
+    if (Number.isInteger(options!.startIndex)) {
+        query += `offset=${options!.startIndex}&`;
     }
-    if (Number.isInteger(requestOptions.limit)) {
-        query += `limit=${requestOptions.limit}&`;
+    if (Number.isInteger(options!.limit)) {
+        query += `limit=${options!.limit}&`;
     }
-    if (requestOptions.searchTerm) {
-        query += `query=${requestOptions.searchTerm}&`;
+    if (options!.searchTerm) {
+        query += `query=${options!.searchTerm}&`;
     }
-    if (requestOptions.sort && requestOptions.sort.length > 0) {
+    if (options!.sort && options!.sort.length > 0) {
         // Handle all items in array of sorting rules
-        query += `order_by=${requestOptions.sort.map((sort) => `${sort.desc ? '-' : ''}${sort.id}`).join(',')}&`;
+        query += `order_by=${options!.sort.map((sort) => `${sort.desc ? '-' : ''}${sort.id}`).join(',')}&`;
     }
-    if (requestOptions.filter && requestOptions.filter.length > 0) {
-        for (const filter of requestOptions.filter) {
+    if (options!.filter && options!.filter.length > 0) {
+        for (const filter of options!.filter) {
             // Handle single filters or arrays of filter terms
             if (typeof filter.value === 'string') {
                 query += `${filter.id}=${filter.value}&`;
@@ -91,9 +89,13 @@ export const getQueryStr = (options?: RequestOptions, extras?: { [k: string]: st
         }
     }
 
-    Object.entries(extras ?? {}).forEach(([key, value]) => {
-        query += `${key}=${String(value)}&`;
-    });
+    try {
+        Object.keys(extras!).forEach((key) => {
+            query += `${key}=${String(extras![key])}&`;
+        });
+    } catch {
+        // Do nothing as it was probably empty
+    }
 
     return query.replace(/&$/, '');
 };
@@ -190,7 +192,7 @@ export async function chunkedFileUpload(
             currentChunk += 1;
         } catch (err) {
             if (sub) {
-                sub.error(err instanceof Error ? err.message : String(err));
+                sub.error((err as Error).message);
             } else {
                 throw err;
             }

--- a/packages/ui-utils/src/request-utils.tsx
+++ b/packages/ui-utils/src/request-utils.tsx
@@ -40,7 +40,7 @@ export interface RequestOptions {
 
 /** Error class for request errors that allow them to be caught more easily */
 export class RequestError extends Error {
-    requestParams: { [k: string]: any };
+    requestParams?: { [k: string]: any };
 
     status: number;
 
@@ -63,22 +63,23 @@ export const getQueryStr = (options?: RequestOptions, extras?: { [k: string]: st
     }
 
     let query = '?';
+    const requestOptions = options ?? {};
 
-    if (Number.isInteger(options.startIndex)) {
-        query += `offset=${options.startIndex}&`;
+    if (Number.isInteger(requestOptions.startIndex)) {
+        query += `offset=${requestOptions.startIndex}&`;
     }
-    if (Number.isInteger(options.limit)) {
-        query += `limit=${options.limit}&`;
+    if (Number.isInteger(requestOptions.limit)) {
+        query += `limit=${requestOptions.limit}&`;
     }
-    if (options.searchTerm) {
-        query += `query=${options.searchTerm}&`;
+    if (requestOptions.searchTerm) {
+        query += `query=${requestOptions.searchTerm}&`;
     }
-    if (options.sort && options.sort.length > 0) {
+    if (requestOptions.sort && requestOptions.sort.length > 0) {
         // Handle all items in array of sorting rules
-        query += `order_by=${options.sort.map((sort) => `${sort.desc ? '-' : ''}${sort.id}`).join(',')}&`;
+        query += `order_by=${requestOptions.sort.map((sort) => `${sort.desc ? '-' : ''}${sort.id}`).join(',')}&`;
     }
-    if (options.filter && options.filter.length > 0) {
-        for (const filter of options.filter) {
+    if (requestOptions.filter && requestOptions.filter.length > 0) {
+        for (const filter of requestOptions.filter) {
             // Handle single filters or arrays of filter terms
             if (typeof filter.value === 'string') {
                 query += `${filter.id}=${filter.value}&`;
@@ -90,13 +91,9 @@ export const getQueryStr = (options?: RequestOptions, extras?: { [k: string]: st
         }
     }
 
-    try {
-        Object.keys(extras).forEach((key) => {
-            query += `${key}=${String(extras[key])}&`;
-        });
-    } catch {
-        // Do nothing as it was probably empty
-    }
+    Object.entries(extras ?? {}).forEach(([key, value]) => {
+        query += `${key}=${String(value)}&`;
+    });
 
     return query.replace(/&$/, '');
 };
@@ -193,7 +190,7 @@ export async function chunkedFileUpload(
             currentChunk += 1;
         } catch (err) {
             if (sub) {
-                sub.error(err.message);
+                sub.error(err instanceof Error ? err.message : String(err));
             } else {
                 throw err;
             }

--- a/packages/ui-utils/src/use-d3-axis.tsx
+++ b/packages/ui-utils/src/use-d3-axis.tsx
@@ -49,8 +49,8 @@ export function useD3Axis<T>(
     const valueScale = useMemo(() => getScale(data, domain), useDeepCompare([data, domain, getScale]));
 
     return useCallback(
-        (axisSize = 0): AxisProps<T> => {
-            const scale = valueScale.range([0, axisSize]).nice();
+        (axisSize?: number): AxisProps<T> => {
+            const scale = valueScale.range([0, axisSize!]).nice();
             return {
                 domain: domainFormatter(scale.domain()),
                 tickFormatter: scale.tickFormat(),
@@ -64,8 +64,7 @@ export function useD3Axis<T>(
 
 /** Helper function for getting a linear d3Scale instance, based on data and domain */
 const getLinearScale = (data: Array<number>, domain?: [number, number]): ScaleLinear<number, number> => {
-    const scaleDomain = data.length > 0 ? [Math.min(...data), Math.max(...data)] : domain ?? [0, 0];
-    return scaleLinear().domain(scaleDomain);
+    return scaleLinear().domain([data ? Math.min(...data) : domain![0], data ? Math.max(...data) : domain![1]]);
 };
 
 /**
@@ -84,8 +83,7 @@ export function useD3LinearAxis(
 
 /** Helper function for getting a time d3Scale instance, based on data and domain */
 const getTimeScale = (data: Array<Date>, domain?: [Date, Date]): ScaleTime<number, number> => {
-    const scaleDomain = data.length > 0 ? [data[0], data[data.length - 1]] : domain ?? [new Date(0), new Date(0)];
-    return scaleTime().domain(scaleDomain);
+    return scaleTime().domain([data ? data[0] : domain![0], data ? data[data.length - 1] : domain![1]]);
 };
 
 /**

--- a/packages/ui-utils/src/use-d3-axis.tsx
+++ b/packages/ui-utils/src/use-d3-axis.tsx
@@ -24,7 +24,7 @@ export type AxisDomain = string | number | 'auto' | 'dataMin' | 'dataMax';
 
 interface AxisProps<T> {
     domain?: [T, T];
-    tickFormatter: (tick?: number) => string;
+    tickFormatter: (tick: number) => string;
     ticks?: Array<number>;
     type: 'number' | 'category';
 }
@@ -49,7 +49,7 @@ export function useD3Axis<T>(
     const valueScale = useMemo(() => getScale(data, domain), useDeepCompare([data, domain, getScale]));
 
     return useCallback(
-        (axisSize: number): AxisProps<T> => {
+        (axisSize = 0): AxisProps<T> => {
             const scale = valueScale.range([0, axisSize]).nice();
             return {
                 domain: domainFormatter(scale.domain()),
@@ -63,8 +63,9 @@ export function useD3Axis<T>(
 }
 
 /** Helper function for getting a linear d3Scale instance, based on data and domain */
-const getLinearScale = (data: Array<number>, domain: [number, number]): ScaleLinear<number, number> => {
-    return scaleLinear().domain([data ? Math.min(...data) : domain[0], data ? Math.max(...data) : domain[1]]);
+const getLinearScale = (data: Array<number>, domain?: [number, number]): ScaleLinear<number, number> => {
+    const scaleDomain = data.length > 0 ? [Math.min(...data), Math.max(...data)] : domain ?? [0, 0];
+    return scaleLinear().domain(scaleDomain);
 };
 
 /**
@@ -82,8 +83,9 @@ export function useD3LinearAxis(
 }
 
 /** Helper function for getting a time d3Scale instance, based on data and domain */
-const getTimeScale = (data: Array<Date>, domain: [Date, Date]): ScaleTime<number, number> => {
-    return scaleTime().domain([data ? data[0] : domain[0], data ? data[data.length - 1] : domain[1]]);
+const getTimeScale = (data: Array<Date>, domain?: [Date, Date]): ScaleTime<number, number> => {
+    const scaleDomain = data.length > 0 ? [data[0], data[data.length - 1]] : domain ?? [new Date(0), new Date(0)];
+    return scaleTime().domain(scaleDomain);
 };
 
 /**

--- a/packages/ui-utils/src/use-deep-compare.tsx
+++ b/packages/ui-utils/src/use-deep-compare.tsx
@@ -29,11 +29,11 @@ import { useRef } from 'react';
  * @param value - an array of values to check the equality of
  */
 export default function useDeepCompare<T>(value: T): T {
-    const ref = useRef<T>(value);
+    const ref = useRef<T>();
 
     if (!isEqual(value, ref.current)) {
         ref.current = value;
     }
 
-    return ref.current;
+    return ref.current as T;
 }

--- a/packages/ui-utils/src/use-deep-compare.tsx
+++ b/packages/ui-utils/src/use-deep-compare.tsx
@@ -29,7 +29,7 @@ import { useRef } from 'react';
  * @param value - an array of values to check the equality of
  */
 export default function useDeepCompare<T>(value: T): T {
-    const ref = useRef<T>();
+    const ref = useRef<T>(value);
 
     if (!isEqual(value, ref.current)) {
         ref.current = value;

--- a/packages/ui-utils/src/use-dimensions.tsx
+++ b/packages/ui-utils/src/use-dimensions.tsx
@@ -27,7 +27,7 @@ export interface DimensionObject {
     y: number;
 }
 
-export type UseDimensionsHook<T extends HTMLElement> = [(node: T) => void, { [k: string]: number }, T];
+export type UseDimensionsHook<T extends HTMLElement> = [(node: T | null) => void, { [k: string]: number }, T | null];
 
 /**
  * The useDimensions hook allows for a component to track the dimensions of a given element by passing the returned ref
@@ -37,9 +37,9 @@ export type UseDimensionsHook<T extends HTMLElement> = [(node: T) => void, { [k:
  */
 function useDimensions<T extends HTMLElement>(liveMeasure = true): UseDimensionsHook<T> {
     const [dimensions, setDimensions] = useState({});
-    const [node, setNode] = useState<T>(null);
+    const [node, setNode] = useState<T | null>(null);
 
-    const ref = useCallback((_node: T) => {
+    const ref = useCallback((_node: T | null) => {
         setNode(_node);
     }, []);
 

--- a/packages/ui-utils/src/use-on-click-outside.tsx
+++ b/packages/ui-utils/src/use-on-click-outside.tsx
@@ -23,9 +23,9 @@ import { useEffect } from 'react';
  * @param handler callback for when a click outside of the given element occurs
  */
 
-function useOnClickOutside(element: HTMLElement, handler: () => void): void {
+function useOnClickOutside(element: HTMLElement | null, handler: () => void): void {
     useEffect(() => {
-        const listener = (event: MouseEvent): void => {
+        const listener = (event: Event): void => {
             // Do nothing if clicking ref's element or descendent elements
             if (!element || element.contains(event.target as Node)) {
                 return;

--- a/packages/ui-widgets/src/confirmation-modal/use-confirmation-modal.tsx
+++ b/packages/ui-widgets/src/confirmation-modal/use-confirmation-modal.tsx
@@ -32,12 +32,12 @@ interface ConfirmationModalHook<T> {
  * @param getMessage a function the should return the message to display based off the item passed
  * @param confirm a function that will be called with the item upon confirmation
  */
-function useConfirmationModal<T>(
+function useConfirmationModal<T extends object>(
     getMessage: (item: T) => string,
     confirm: (item: T) => void | Promise<void>
 ): ConfirmationModalHook<T> {
     const [render, setRender] = useState(false);
-    const [canceledItem, setCanceledItem] = useState<T>();
+    const [canceledItem, setCanceledItem] = useState<T | null>(null);
     const [message, setMessage] = useState('');
 
     const onConfirmation = (item: T): void => {
@@ -52,7 +52,7 @@ function useConfirmationModal<T>(
 
     const onConfirm = (): void => {
         setRender(false);
-        if (confirm) {
+        if (canceledItem) {
             confirm(canceledItem);
         }
     };

--- a/packages/ui-widgets/src/confirmation-modal/use-confirmation-modal.tsx
+++ b/packages/ui-widgets/src/confirmation-modal/use-confirmation-modal.tsx
@@ -32,12 +32,12 @@ interface ConfirmationModalHook<T> {
  * @param getMessage a function the should return the message to display based off the item passed
  * @param confirm a function that will be called with the item upon confirmation
  */
-function useConfirmationModal<T extends object>(
+function useConfirmationModal<T>(
     getMessage: (item: T) => string,
     confirm: (item: T) => void | Promise<void>
 ): ConfirmationModalHook<T> {
     const [render, setRender] = useState(false);
-    const [canceledItem, setCanceledItem] = useState<T | null>(null);
+    const [canceledItem, setCanceledItem] = useState<T>();
     const [message, setMessage] = useState('');
 
     const onConfirmation = (item: T): void => {
@@ -52,8 +52,8 @@ function useConfirmationModal<T extends object>(
 
     const onConfirm = (): void => {
         setRender(false);
-        if (canceledItem) {
-            confirm(canceledItem);
+        if (confirm) {
+            confirm(canceledItem as T);
         }
     };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "preserveSymlinks": true,
     "skipLibCheck": true,
     "sourceMap": true,
-    "strict": false,
+    "strict": true,
     "target": "es2015",
     "types": ["node"],
     "verbatimModuleSyntax": true


### PR DESCRIPTION
## Motivation and Context

Enable TypeScript's full strict checking across the JavaScript workspace now that the compiler migration is isolated and compiling cleanly.

This PR is stacked on #661 and should be reviewed after that PR. It intentionally contains no changelog entry because this is internal tooling and type-safety work.

## Implementation Description

- Enable `strict: true` in the root and standalone TypeScript configurations.
- Model initialized causal-graph state, selections, refs, callbacks, optional layout features, and third-party API boundaries accurately.
- Resolve strict errors through type declarations, narrowing, and compile-time assertions without changing existing runtime behavior.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `pnpm lerna run prepare-dev`
- `pnpm lerna run lint`
- `pnpm lerna run format:check`
- `pnpm lerna run test` — 57 files and 478 tests passed.

The runtime output was audited 1:1 against the pre-strict base commit. Every changed `.ts` and `.tsx` file was transpiled with types and comments removed, the output was normalized, and the comparison produced **zero JavaScript differences**.

The lint run retains one pre-existing, non-failing CSS property-order warning in `ui-components/src/sectioned-list/sectioned-list.tsx`.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] No changelog entry is required for internal tooling-only changes.

## Screenshots (if appropriate):

Not applicable; this is type-safety tooling work with no intended UI changes.