### PR TITLE
Fix: DO-12269 isolate Dara metrics registry

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Isolated Dara's Prometheus collectors from the process-wide default registry so applications can register their own metrics without name collisions.
+
 ## 1.29.3
 
 - Internal: Upgraded build tooling to Vite 8 for faster builds.

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -80,6 +80,7 @@ from dara.core.js_tooling.js_utils import (
     rebuild_js,
 )
 from dara.core.logging import LoggingMiddleware, dev_logger, eng_logger, http_logger
+from dara.core.metrics.registry import DARA_METRICS_REGISTRY
 from dara.core.router import convert_template_to_router
 
 
@@ -399,7 +400,7 @@ def _start_application(config: Configuration):
     # Start metrics server in a daemon thread
     if os.environ.get('DARA_DISABLE_METRICS') != 'TRUE' and os.environ.get('DARA_TEST_FLAG', None) is None:
         port = int(os.environ.get('DARA_METRICS_PORT', '10000'))
-        start_http_server(port)
+        start_http_server(port, registry=DARA_METRICS_REGISTRY)
 
     # Start profiling server in a daemon thread if explicitly enabled (only works on linux)
     if os.environ.get('DARA_PYPPROF_PORT', None) is not None:

--- a/packages/dara-core/dara/core/metrics/__init__.py
+++ b/packages/dara-core/dara/core/metrics/__init__.py
@@ -17,11 +17,13 @@ limitations under the License.
 
 from dara.core.metrics.cache import CACHE_METRICS_TRACKER
 from dara.core.metrics.http import HTTP_REQUEST_DURATION_SECONDS, HTTP_REQUESTS_TOTAL
+from dara.core.metrics.registry import DARA_METRICS_REGISTRY
 from dara.core.metrics.runtime import RUNTIME_METRICS_TRACKER
 from dara.core.metrics.utils import total_size
 
 __all__ = [
     'CACHE_METRICS_TRACKER',
+    'DARA_METRICS_REGISTRY',
     'HTTP_REQUEST_DURATION_SECONDS',
     'HTTP_REQUESTS_TOTAL',
     'RUNTIME_METRICS_TRACKER',

--- a/packages/dara-core/dara/core/metrics/cache.py
+++ b/packages/dara-core/dara/core/metrics/cache.py
@@ -18,8 +18,14 @@ limitations under the License.
 from prometheus_client import Info
 
 from dara.core.base_definitions import DaraBaseModel as BaseModel
+from dara.core.metrics.registry import DARA_METRICS_REGISTRY
 
-cache_metric = Info('cache_size', 'Current size of cache stores and registries', labelnames=['registry_name'])
+cache_metric = Info(
+    'cache_size',
+    'Current size of cache stores and registries',
+    labelnames=['registry_name'],
+    registry=DARA_METRICS_REGISTRY,
+)
 
 
 def format_bytes(num: int | float) -> str:

--- a/packages/dara-core/dara/core/metrics/http.py
+++ b/packages/dara-core/dara/core/metrics/http.py
@@ -22,10 +22,13 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 
+from dara.core.metrics.registry import DARA_METRICS_REGISTRY
+
 HTTP_REQUESTS_TOTAL = Counter(
     'http_requests_total',
     'Total HTTP requests',
     labelnames=['method', 'status', 'path'],
+    registry=DARA_METRICS_REGISTRY,
 )
 
 HTTP_REQUEST_DURATION_SECONDS = Histogram(
@@ -33,6 +36,7 @@ HTTP_REQUEST_DURATION_SECONDS = Histogram(
     'HTTP request duration in seconds',
     labelnames=['method', 'status', 'path'],
     buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, float('inf')),
+    registry=DARA_METRICS_REGISTRY,
 )
 
 

--- a/packages/dara-core/dara/core/metrics/registry.py
+++ b/packages/dara-core/dara/core/metrics/registry.py
@@ -1,0 +1,27 @@
+"""
+Copyright 2023 Impulse Innovations Limited
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from prometheus_client import CollectorRegistry, GCCollector, PlatformCollector, ProcessCollector
+
+# Keep Dara's collectors isolated so importing Dara does not mutate Prometheus's process-wide default registry.
+DARA_METRICS_REGISTRY = CollectorRegistry()
+
+# These constructors self-register, but only with Dara's private registry, so their side effects cannot collide with
+# collectors owned by other packages. They preserve the runtime metrics previously exposed by Dara's metrics server.
+GCCollector(registry=DARA_METRICS_REGISTRY)
+PlatformCollector(registry=DARA_METRICS_REGISTRY)
+ProcessCollector(registry=DARA_METRICS_REGISTRY)

--- a/packages/dara-core/dara/core/metrics/runtime.py
+++ b/packages/dara-core/dara/core/metrics/runtime.py
@@ -17,6 +17,8 @@ limitations under the License.
 
 from prometheus_client import Histogram
 
+from dara.core.metrics.registry import DARA_METRICS_REGISTRY
+
 BUCKETS = (
     0.05,
     0.1,
@@ -45,9 +47,19 @@ BUCKETS = (
 
 class RuntimeMetricsTracker:
     def __init__(self) -> None:
-        self.task_histogram = Histogram('task_runtimes', 'Task Runtimes', labelnames=['task_name'], buckets=BUCKETS)
+        self.task_histogram = Histogram(
+            'task_runtimes',
+            'Task Runtimes',
+            labelnames=['task_name'],
+            buckets=BUCKETS,
+            registry=DARA_METRICS_REGISTRY,
+        )
         self.dv_histogram = Histogram(
-            'dv_runtimes', 'Derived Variable Runtimes', labelnames=['dv_name'], buckets=BUCKETS
+            'dv_runtimes',
+            'Derived Variable Runtimes',
+            labelnames=['dv_name'],
+            buckets=BUCKETS,
+            registry=DARA_METRICS_REGISTRY,
         )
 
     def clean_name(self, name: str) -> str:

--- a/packages/dara-core/tests/python/test_main.py
+++ b/packages/dara-core/tests/python/test_main.py
@@ -15,6 +15,7 @@ from dara.core.definitions import ComponentInstance
 from dara.core.http import get
 from dara.core.internal.websocket import WebsocketManager
 from dara.core.main import _start_application
+from dara.core.metrics import DARA_METRICS_REGISTRY
 from dara.core.router import LayoutRoute, Outlet
 from dara.core.visual.components.router_content import RouterContent
 from dara.core.visual.components.sidebar_frame import SideBarFrame
@@ -84,6 +85,21 @@ async def test_validates_configuration(config: Configuration):
 
     with pytest.raises(ValueError):
         _start_application(1)
+
+
+async def test_metrics_server_uses_dara_registry(monkeypatch: pytest.MonkeyPatch):
+    """The built-in metrics server only exposes collectors owned by Dara."""
+    monkeypatch.delenv('DARA_DISABLE_METRICS', raising=False)
+    monkeypatch.delenv('DARA_TEST_FLAG', raising=False)
+    monkeypatch.setenv('DARA_METRICS_PORT', '12345')
+
+    builder = ConfigurationBuilder()
+    config = create_app(builder)
+
+    with patch('dara.core.main.start_http_server') as start_http_server:
+        _start_application(config)
+
+    start_http_server.assert_called_once_with(12345, registry=DARA_METRICS_REGISTRY)
 
 
 def assert_dict_subset(haystack: dict, needle: dict):

--- a/packages/dara-core/tests/python/test_metrics.py
+++ b/packages/dara-core/tests/python/test_metrics.py
@@ -1,0 +1,50 @@
+import subprocess
+import sys
+
+from prometheus_client import REGISTRY
+
+from dara.core.metrics import DARA_METRICS_REGISTRY
+
+DARA_METRIC_NAMES = {
+    'cache_size',
+    'dv_runtimes',
+    'http_request_duration_seconds',
+    'http_requests',
+    'task_runtimes',
+}
+
+
+def _metric_names(registry) -> set[str]:
+    return {metric.name for metric in registry.collect()}
+
+
+def test_dara_metrics_use_isolated_registry():
+    """Dara metrics are available without being added to Prometheus's default registry."""
+    assert _metric_names(DARA_METRICS_REGISTRY) >= DARA_METRIC_NAMES
+    assert DARA_METRIC_NAMES.isdisjoint(_metric_names(REGISTRY))
+
+
+def test_dara_import_allows_matching_metrics_in_default_registry():
+    """Applications can own metric names that match Dara's without causing import failures."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            '-c',
+            """
+from prometheus_client import Counter, Histogram, Info
+
+Counter('http_requests_total', 'Application request count')
+Histogram('http_request_duration_seconds', 'Application request duration')
+Info('cache_size', 'Application cache size')
+Histogram('task_runtimes', 'Application task runtimes')
+Histogram('dv_runtimes', 'Application derived variable runtimes')
+
+import dara.core
+""",
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Motivation and Context

Importing Dara registered its Prometheus collectors in the process-wide default registry. Applications that owned the same metric names, such as `http_requests_total`, then failed to import Dara with a duplicated timeseries error.

## Implementation Description

Dara now owns a dedicated `CollectorRegistry`. Its HTTP, cache, and runtime collectors register there, and the built-in metrics server serves that registry. Existing Python, GC, and process metrics remain available on Dara's endpoint, while application metrics in the default registry no longer collide. `DARA_METRICS_REGISTRY` is exported for applications that intentionally want custom collectors on Dara's endpoint.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `DARA_TEST_FLAG=True poetry run pytest tests/python/test_metrics.py tests/python/test_main.py -q` — 20 passed.
- `poetry anthology run lint`.
- `poetry anthology run format-check`.
- Added a fresh-process regression test that registers all matching metric names before importing `dara.core`.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

Not applicable; backend-only change.