### PR TITLE
Fix: DO-12420 improve StreamVariable SSE reliability

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,7 +4,7 @@ title: Changelog
 
 ## NEXT
 
-- Fixed StreamVariable clean connection closures not reconnecting and fatal stream errors silently leaving stale values visible, and added configurable SSE keepalive comments for idle browser connections.
+- Fixed StreamVariable clean connection closures not reconnecting and fatal stream errors silently leaving stale values visible, and added configurable SSE keepalive comments with robust parsing and cleanup across the full stream lifecycle.
 - Fixed FastAPI telemetry cleanup errors when application construction fails by attaching instrumentation only after
   the application has been built successfully.
 

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -9,6 +9,7 @@ title: Changelog
 
 ## 1.29.6
 
+- Fixed StreamVariable clean connection closures not reconnecting and fatal stream errors silently leaving stale values visible.
 - Added a development-only server handshake that reports mismatched projects and supports overriding Vite's port with `dara start --dev-port` and `dara dev --port`.
 - Fixed `dara dev` to use the application's configured static files directory instead of always assuming `dist`.
 - Added opt-in, vendor-neutral OpenTelemetry traces, logs, and metrics through Pydantic Logfire, covering HTTP,

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,12 +4,12 @@ title: Changelog
 
 ## NEXT
 
+- Fixed StreamVariable clean connection closures not reconnecting and fatal stream errors silently leaving stale values visible, and added configurable SSE keepalive comments for idle browser connections.
 - Fixed FastAPI telemetry cleanup errors when application construction fails by attaching instrumentation only after
   the application has been built successfully.
 
 ## 1.29.6
 
-- Fixed StreamVariable clean connection closures not reconnecting and fatal stream errors silently leaving stale values visible.
 - Added a development-only server handshake that reports mismatched projects and supports overriding Vite's port with `dara start --dev-port` and `dara dev --port`.
 - Fixed `dara dev` to use the application's configured static files directory instead of always assuming `dist`.
 - Added opt-in, vendor-neutral OpenTelemetry traces, logs, and metrics through Pydantic Logfire, covering HTTP,

--- a/packages/dara-core/dara/core/interactivity/stream_utils.py
+++ b/packages/dara-core/dara/core/interactivity/stream_utils.py
@@ -1,6 +1,7 @@
 import asyncio
+import contextlib
 import signal
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncGenerator, Callable
 from typing import Any
 
 from dara.core.logging import dev_logger
@@ -49,7 +50,7 @@ def setup_signal_handlers():
         signal.signal(signal.SIGTERM, _chained_signal_handler)
 
 
-def track_stream(func: Callable[[], AsyncIterator[Any]]):
+def track_stream(func: Callable[[], AsyncGenerator[Any, None]]):
     """
     Decorator to track active streaming connections.
     Keeps track of the current task in active_connections while it's live.
@@ -61,8 +62,12 @@ def track_stream(func: Callable[[], AsyncIterator[Any]]):
         _active_connections.add(current_task)
 
         try:
-            async for item in func():
-                yield item
+            # The tracked wrapper is the iterator consumed by StreamingResponse.
+            # Own the wrapped generator explicitly so closing the HTTP-facing
+            # iterator while suspended at yield propagates teardown immediately.
+            async with contextlib.aclosing(func()) as stream:
+                async for item in stream:
+                    yield item
         finally:
             _active_connections.discard(current_task)
 

--- a/packages/dara-core/dara/core/interactivity/stream_variable.py
+++ b/packages/dara-core/dara/core/interactivity/stream_variable.py
@@ -327,18 +327,35 @@ async def run_stream(
     values: list[Any],
     store: CacheStore,
     task_mgr: TaskManager,
+    keepalive_interval_seconds: float | None = None,
 ):
     """
     Run a StreamVariable under one lifecycle span.
 
-    Stream events are intentionally not traced individually.
+    Stream events and optional SSE keepalive comments are intentionally not
+    traced individually.
+
+    :param entry: registered StreamVariable definition
+    :param disconnect_event: signal set when the browser connection closes
+    :param values: serialized dependency values for the stream
+    :param store: cache used to resolve dependencies
+    :param task_mgr: task manager used to resolve dependencies
+    :param keepalive_interval_seconds: maximum quiet period before emitting an SSE comment
     """
     stream_name = (
         f'{getattr(entry.func, "__module__", "unknown")}.'
         f'{getattr(entry.func, "__qualname__", type(entry.func).__name__)}'
     )
     with observe_stream(stream_name) as observation:
-        async for event in _run_stream(entry, disconnect_event, values, store, task_mgr, observation):
+        async for event in _run_stream(
+            entry,
+            disconnect_event,
+            values,
+            store,
+            task_mgr,
+            observation,
+            keepalive_interval_seconds,
+        ):
             yield event
 
 
@@ -349,6 +366,7 @@ async def _run_stream(
     store: CacheStore,
     task_mgr: TaskManager,
     observation: _OperationObservation,
+    keepalive_interval_seconds: float | None,
 ):
     """Implement a StreamVariable lifecycle and report handled terminal outcomes."""
     started = perf_counter()
@@ -405,25 +423,37 @@ async def _run_stream(
         # event-loop machinery with negligible cost compared to the HTTP I/O the
         # generator performs (hundreds of ms to seconds per event).
         disconnect_task = asyncio.ensure_future(disconnect_event.wait())
+        next_task: asyncio.Task[StreamEvent] | None = None
         try:
             while True:
-                next_task: asyncio.Task[StreamEvent] = asyncio.ensure_future(generator.__anext__())
+                if next_task is None:
+                    next_task = asyncio.ensure_future(generator.__anext__())
                 done, _ = await asyncio.wait(
                     {next_task, disconnect_task},
+                    timeout=keepalive_interval_seconds,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
+
+                if not done:
+                    # SSE comments keep the browser-facing connection active but
+                    # are ignored by event parsers and StreamVariable reducers.
+                    yield ': keepalive\n\n'
+                    continue
 
                 if disconnect_task in done:
                     observation.set_outcome('cancelled')
                     next_task.cancel()
                     with contextlib.suppress(asyncio.CancelledError):
                         await next_task
+                    next_task = None
                     break
 
                 try:
                     event = next_task.result()
                 except StopAsyncIteration:
+                    next_task = None
                     break
+                next_task = None
 
                 _validate_event_mode(event, entry.key_accessor)
                 emitted_at = perf_counter()
@@ -439,6 +469,11 @@ async def _run_stream(
         except StopAsyncIteration:
             pass
         finally:
+            if next_task is not None:
+                if not next_task.done():
+                    next_task.cancel()
+                with contextlib.suppress(Exception, asyncio.CancelledError, StopAsyncIteration):
+                    await next_task
             disconnect_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await disconnect_task

--- a/packages/dara-core/dara/core/interactivity/stream_variable.py
+++ b/packages/dara-core/dara/core/interactivity/stream_variable.py
@@ -321,6 +321,28 @@ def _validate_event_mode(event: StreamEvent, key_accessor: str | None) -> None:
         )
 
 
+@dataclass(frozen=True)
+class _StreamChunk:
+    """A serialized SSE chunk produced by the stream lifecycle."""
+
+    value: str
+
+
+@dataclass(frozen=True)
+class _StreamFinished:
+    """Signal that the stream lifecycle completed normally."""
+
+
+@dataclass(frozen=True)
+class _StreamFailed:
+    """Signal that the stream lifecycle failed outside its normal error handling."""
+
+    error: BaseException
+
+
+_StreamQueueItem = _StreamChunk | _StreamFinished | _StreamFailed
+
+
 async def run_stream(
     entry: StreamVariableRegistryEntry,
     disconnect_event: asyncio.Event,
@@ -347,26 +369,97 @@ async def run_stream(
         f'{getattr(entry.func, "__qualname__", type(entry.func).__name__)}'
     )
     with observe_stream(stream_name) as observation:
-        async for event in _run_stream(
-            entry,
-            disconnect_event,
-            values,
-            store,
-            task_mgr,
-            observation,
-            keepalive_interval_seconds,
-        ):
-            yield event
+        queue: asyncio.Queue[_StreamQueueItem] = asyncio.Queue(maxsize=1)
+        producer_task = asyncio.create_task(
+            _produce_stream(
+                queue,
+                entry,
+                values,
+                store,
+                task_mgr,
+                observation,
+            )
+        )
+        disconnect_task = asyncio.create_task(disconnect_event.wait())
+        item_task: asyncio.Task[_StreamQueueItem] | None = None
+
+        try:
+            while True:
+                if item_task is None:
+                    item_task = asyncio.create_task(queue.get())
+
+                done, _ = await asyncio.wait(
+                    {item_task, disconnect_task},
+                    timeout=keepalive_interval_seconds,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                # Once the browser disconnects, cancellation owns the outcome
+                # even if the producer completed in the same event-loop turn.
+                if disconnect_event.is_set() or disconnect_task in done:
+                    observation.set_outcome('cancelled')
+                    break
+
+                if not done:
+                    yield ': keepalive\n\n'
+                    continue
+
+                item = item_task.result()
+                item_task = None
+                if isinstance(item, _StreamChunk):
+                    yield item.value
+                    continue
+                if isinstance(item, _StreamFailed):
+                    raise item.error
+                break
+        finally:
+            if item_task is not None:
+                if not item_task.done():
+                    item_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await item_task
+
+            if not producer_task.done():
+                producer_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await producer_task
+
+            disconnect_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await disconnect_task
 
 
-async def _run_stream(
+async def _produce_stream(
+    queue: asyncio.Queue[_StreamQueueItem],
     entry: StreamVariableRegistryEntry,
-    disconnect_event: asyncio.Event,
     values: list[Any],
     store: CacheStore,
     task_mgr: TaskManager,
     observation: _OperationObservation,
-    keepalive_interval_seconds: float | None,
+) -> None:
+    """
+    Run the entire stream lifecycle in one task and serialize its outcomes.
+
+    Keeping dependency resolution, generator iteration, and cleanup in the same
+    task preserves generator-local ContextVar state across yields.
+    """
+    try:
+        async for chunk in _generate_stream(entry, values, store, task_mgr, observation):
+            await queue.put(_StreamChunk(chunk))
+    except asyncio.CancelledError:
+        raise
+    except BaseException as error:
+        await queue.put(_StreamFailed(error))
+    else:
+        await queue.put(_StreamFinished())
+
+
+async def _generate_stream(
+    entry: StreamVariableRegistryEntry,
+    values: list[Any],
+    store: CacheStore,
+    task_mgr: TaskManager,
+    observation: _OperationObservation,
 ):
     """Implement a StreamVariable lifecycle and report handled terminal outcomes."""
     started = perf_counter()
@@ -390,93 +483,18 @@ async def _run_stream(
     try:
         generator = entry.func(*resolved_values)
 
-        # --- Disconnect-aware iteration ---
-        #
-        # A StreamVariable generator may open its own long-lived HTTP connections
-        # internally (e.g. connecting to an upstream SSE endpoint). The naive loop:
-        #
-        #     async for event in generator:
-        #         if await request.is_disconnected(): break
-        #
-        # only checks for disconnection *after* the generator yields. If the generator
-        # is suspended in an `await` on an inner HTTP read, `is_disconnected()` never
-        # runs and the inner connection stays open indefinitely -- one leaked connection
-        # per stream restart.
-        #
-        # To fix this we race each `generator.__anext__()` call against a
-        # `disconnect_event.wait()` using `asyncio.wait(return_when=FIRST_COMPLETED)`.
-        # If the client disconnects while the generator is blocked, the disconnect
-        # event completes first, and we cancel the pending `__anext__()` task. The
-        # resulting `CancelledError` propagates into whatever `await` the generator is
-        # suspended in, triggering cleanup via standard Python `finally` blocks -- which
-        # is what closes the inner HTTP connection.
-        #
-        # We use an `asyncio.Event` rather than polling `request.is_disconnected()`
-        # because the latter reads from the ASGI receive channel. Polling it from a
-        # background task would steal messages from the channel, interfering with
-        # Starlette's own request/response handling. The event is set by the caller
-        # (the stream endpoint in routing.py) when it detects the client has
-        # disconnected.
-        #
-        # Performance: the only overhead is a single `disconnect_event.wait()` future
-        # reused across iterations and the `asyncio.wait` call -- both standard
-        # event-loop machinery with negligible cost compared to the HTTP I/O the
-        # generator performs (hundreds of ms to seconds per event).
-        disconnect_task = asyncio.ensure_future(disconnect_event.wait())
-        next_task: asyncio.Task[StreamEvent] | None = None
-        try:
-            while True:
-                if next_task is None:
-                    next_task = asyncio.ensure_future(generator.__anext__())
-                done, _ = await asyncio.wait(
-                    {next_task, disconnect_task},
-                    timeout=keepalive_interval_seconds,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-
-                if not done:
-                    # SSE comments keep the browser-facing connection active but
-                    # are ignored by event parsers and StreamVariable reducers.
-                    yield ': keepalive\n\n'
-                    continue
-
-                if disconnect_task in done:
-                    observation.set_outcome('cancelled')
-                    next_task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await next_task
-                    next_task = None
-                    break
-
-                try:
-                    event = next_task.result()
-                except StopAsyncIteration:
-                    next_task = None
-                    break
-                next_task = None
-
-                _validate_event_mode(event, entry.key_accessor)
-                emitted_at = perf_counter()
-                event_interval = emitted_at - last_event_at if last_event_at is not None else None
-                last_event_at = emitted_at
-                event_count += 1
-                record_stream_event(event_interval)
-                if event_interval is not None:
-                    max_event_interval = max(max_event_interval or 0, event_interval)
-                if time_to_first_event is None:
-                    time_to_first_event = emitted_at - started
-                yield f'data: {event.model_dump_json()}\n\n'
-        except StopAsyncIteration:
-            pass
-        finally:
-            if next_task is not None:
-                if not next_task.done():
-                    next_task.cancel()
-                with contextlib.suppress(Exception, asyncio.CancelledError, StopAsyncIteration):
-                    await next_task
-            disconnect_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await disconnect_task
+        async for event in generator:
+            _validate_event_mode(event, entry.key_accessor)
+            emitted_at = perf_counter()
+            event_interval = emitted_at - last_event_at if last_event_at is not None else None
+            last_event_at = emitted_at
+            event_count += 1
+            record_stream_event(event_interval)
+            if event_interval is not None:
+                max_event_interval = max(max_event_interval or 0, event_interval)
+            if time_to_first_event is None:
+                time_to_first_event = emitted_at - started
+            yield f'data: {event.model_dump_json()}\n\n'
 
     except ReconnectException:
         event_count += 1

--- a/packages/dara-core/dara/core/interactivity/stream_variable.py
+++ b/packages/dara-core/dara/core/interactivity/stream_variable.py
@@ -369,6 +369,9 @@ async def run_stream(
         f'{getattr(entry.func, "__qualname__", type(entry.func).__name__)}'
     )
     with observe_stream(stream_name) as observation:
+        # Keep at most one produced chunk ahead of the browser. Besides bounding
+        # memory, this makes cancellation deterministic when the browser stops
+        # consuming while the producer is blocked on an upstream stream.
         queue: asyncio.Queue[_StreamQueueItem] = asyncio.Queue(maxsize=1)
         producer_task = asyncio.create_task(
             _produce_stream(
@@ -388,6 +391,9 @@ async def run_stream(
                 if item_task is None:
                     item_task = asyncio.create_task(queue.get())
 
+                # Reuse the same queue.get() task after a heartbeat timeout.
+                # Replacing it could abandon a concurrently completed get and
+                # silently drop the next application event.
                 done, _ = await asyncio.wait(
                     {item_task, disconnect_task},
                     timeout=keepalive_interval_seconds,
@@ -419,6 +425,10 @@ async def run_stream(
                 with contextlib.suppress(asyncio.CancelledError):
                     await item_task
 
+            # Cancelling the single lifecycle owner injects cancellation into
+            # whichever dependency/upstream read is blocked. Awaiting it ensures
+            # the async generator's finally blocks close subscriptions before
+            # this browser-facing stream returns.
             if not producer_task.done():
                 producer_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -441,7 +451,9 @@ async def _produce_stream(
     Run the entire stream lifecycle in one task and serialize its outcomes.
 
     Keeping dependency resolution, generator iteration, and cleanup in the same
-    task preserves generator-local ContextVar state across yields.
+    task preserves generator-local ContextVar state across yields. Advancing one
+    async generator from a fresh task per yield can otherwise make a ContextVar
+    token impossible to reset during generator cleanup.
     """
     try:
         async for chunk in _generate_stream(entry, values, store, task_mgr, observation):

--- a/packages/dara-core/dara/core/interactivity/stream_variable.py
+++ b/packages/dara-core/dara/core/interactivity/stream_variable.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from time import perf_counter
 from typing import TYPE_CHECKING, Any, Generic, Literal
 
+import anyio
 from pydantic import ConfigDict, Field, SerializerFunctionWrapHandler, field_validator, model_serializer
 from typing_extensions import TypeVar
 
@@ -343,6 +344,38 @@ class _StreamFailed:
 _StreamQueueItem = _StreamChunk | _StreamFinished | _StreamFailed
 
 
+async def _cancel_and_wait_for_task(task: asyncio.Task[Any]) -> asyncio.CancelledError | None:
+    """
+    Cancel and await an owned child without forwarding parent cancellation.
+
+    ``asyncio`` normally propagates cancellation from a task awaiting another
+    task. During stream teardown that can cancel the producer a second time
+    while it is already inside an awaited user-generator ``aclose()``. Wait
+    indirectly until the child's cleanup finishes, but remember a new parent
+    cancellation so it can be re-raised after all teardown completes.
+
+    :param task: child task whose termination and cleanup must be awaited
+    :return: cancellation received by the waiting parent, if any
+    """
+    deferred_cancellation: asyncio.CancelledError | None = None
+
+    if not task.done():
+        task.cancel()
+
+    while not task.done():
+        try:
+            # Unlike directly awaiting a task (even through shield()),
+            # cancelling this waiter never forwards cancellation to ``task``.
+            await asyncio.wait((task,))
+        except asyncio.CancelledError as error:
+            deferred_cancellation = error
+
+    if not task.cancelled():
+        task.result()
+
+    return deferred_cancellation
+
+
 async def run_stream(
     entry: StreamVariableRegistryEntry,
     disconnect_event: asyncio.Event,
@@ -419,24 +452,33 @@ async def run_stream(
                     raise item.error
                 break
         finally:
-            if item_task is not None:
-                if not item_task.done():
-                    item_task.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await item_task
+            deferred_cancellation: asyncio.CancelledError | None = None
 
-            # Cancelling the single lifecycle owner injects cancellation into
-            # whichever dependency/upstream read is blocked. Awaiting it ensures
-            # the async generator's finally blocks close subscriptions before
-            # this browser-facing stream returns.
-            if not producer_task.done():
-                producer_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await producer_task
+            # The ASGI response task can enter this block from an already
+            # cancelled AnyIO task group. Shield the lifecycle owner here—not
+            # only at the later StreamingResponse boundary—so level-triggered
+            # parent cancellation cannot interrupt a user generator while its
+            # async context is closing a real upstream transport.
+            with anyio.CancelScope(shield=True):
+                if item_task is not None:
+                    cancellation = await _cancel_and_wait_for_task(item_task)
+                    if cancellation is not None:
+                        deferred_cancellation = cancellation
 
-            disconnect_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await disconnect_task
+                # Cancelling the single lifecycle owner injects cancellation
+                # into whichever dependency/upstream read is blocked. Awaiting
+                # it ensures async generator finally blocks close subscriptions
+                # before this browser-facing stream returns.
+                cancellation = await _cancel_and_wait_for_task(producer_task)
+                if cancellation is not None:
+                    deferred_cancellation = cancellation
+
+                cancellation = await _cancel_and_wait_for_task(disconnect_task)
+                if cancellation is not None:
+                    deferred_cancellation = cancellation
+
+            if deferred_cancellation is not None:
+                raise deferred_cancellation
 
 
 async def _produce_stream(

--- a/packages/dara-core/dara/core/interactivity/stream_variable.py
+++ b/packages/dara-core/dara/core/interactivity/stream_variable.py
@@ -456,8 +456,14 @@ async def _produce_stream(
     token impossible to reset during generator cleanup.
     """
     try:
-        async for chunk in _generate_stream(entry, values, store, task_mgr, observation):
-            await queue.put(_StreamChunk(chunk))
+        # async for does not own iterator teardown. In particular, cancellation
+        # can land while queue.put() is blocked, leaving _generate_stream
+        # suspended at yield and deferring its finally block until GC. Owning it
+        # explicitly ensures upstream subscriptions close before cancellation
+        # returns to the browser-facing parent.
+        async with contextlib.aclosing(_generate_stream(entry, values, store, task_mgr, observation)) as stream:
+            async for chunk in stream:
+                await queue.put(_StreamChunk(chunk))
     except asyncio.CancelledError:
         raise
     except BaseException as error:

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -22,7 +22,7 @@ import json
 import math
 import os
 import traceback
-from collections.abc import Callable, Mapping
+from collections.abc import AsyncGenerator, Callable, Mapping
 from functools import wraps
 from importlib.metadata import version
 from typing import Annotated, Any, Literal
@@ -51,6 +51,7 @@ from pandas import DataFrame
 from pydantic import BaseModel, Field
 from starlette.background import BackgroundTask
 from starlette.status import HTTP_415_UNSUPPORTED_MEDIA_TYPE
+from starlette.types import Send
 
 from dara.core.auth.routes import verify_session
 from dara.core.base_definitions import ActionResolverDef, BaseTask, NonTabularDataError, UploadResolverDef
@@ -523,6 +524,26 @@ class StreamRequestBody(BaseModel):
     """Normalized payload of resolved variable values to pass to the stream generator."""
 
 
+class _ClosableStreamingResponse(StreamingResponse):
+    """StreamingResponse that deterministically closes its async-generator body."""
+
+    def __init__(self, content: AsyncGenerator[Any, None], **kwargs: Any):
+        super().__init__(content, **kwargs)
+        self._closable_body_iterator = content
+
+    async def stream_response(self, send: Send) -> None:
+        """Stream the response and close its body even when ASGI cancels during send."""
+        try:
+            await super().stream_response(send)
+        finally:
+            # For ASGI <2.4 Starlette cancels this task when http.disconnect
+            # wins its task-group race. AnyIO cancellation is level-triggered,
+            # so cleanup must be shielded or aclose() can itself be cancelled
+            # before the nested run_stream producer releases its subscription.
+            with anyio.CancelScope(shield=True):
+                await self._closable_body_iterator.aclose()
+
+
 @core_api_router.post('/stream/{stream_uid}', dependencies=[Depends(verify_session)])
 async def stream_endpoint(
     request: Request,
@@ -578,7 +599,7 @@ async def stream_endpoint(
             # generator exhaustion, or task cancellation).
             disconnect_event.set()
 
-    return StreamingResponse(
+    return _ClosableStreamingResponse(
         stream(),
         media_type='text/event-stream',
         headers={

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 import asyncio
+import contextlib
 import inspect
 import json
 import math
@@ -555,15 +556,22 @@ async def stream_endpoint(
     async def stream():
         try:
             interval_seconds = get_settings().dara_stream_keepalive_interval_seconds
-            async for event in run_stream(
-                entry,
-                disconnect_event,
-                values,
-                store,
-                task_mgr,
-                keepalive_interval_seconds=interval_seconds,
-            ):
-                yield event
+            # A forwarding async generator does not implicitly close the
+            # iterator used by async for. StreamingResponse can close this
+            # wrapper while it is suspended at yield, so explicitly own
+            # run_stream to await its producer and upstream subscription cleanup.
+            async with contextlib.aclosing(
+                run_stream(
+                    entry,
+                    disconnect_event,
+                    values,
+                    store,
+                    task_mgr,
+                    keepalive_interval_seconds=interval_seconds,
+                )
+            ) as source:
+                async for event in source:
+                    yield event
         finally:
             # Signal disconnect so run_stream's race loop can cancel a blocked generator.
             # This fires when StreamingResponse stops consuming (client disconnect,

--- a/packages/dara-core/dara/core/internal/routing.py
+++ b/packages/dara-core/dara/core/internal/routing.py
@@ -81,6 +81,7 @@ from dara.core.internal.registries import (
     utils_registry,
 )
 from dara.core.internal.registry_lookup import RegistryLookup
+from dara.core.internal.settings import get_settings
 from dara.core.internal.tasks import TaskManager, TaskManagerError
 from dara.core.internal.utils import get_cache_scope
 from dara.core.internal.websocket import WS_CHANNEL, ws_handler
@@ -553,7 +554,15 @@ async def stream_endpoint(
     @track_stream
     async def stream():
         try:
-            async for event in run_stream(entry, disconnect_event, values, store, task_mgr):
+            interval_seconds = get_settings().dara_stream_keepalive_interval_seconds
+            async for event in run_stream(
+                entry,
+                disconnect_event,
+                values,
+                store,
+                task_mgr,
+                keepalive_interval_seconds=interval_seconds,
+            ):
                 yield event
         finally:
             # Signal disconnect so run_stream's race loop can cancel a blocked generator.

--- a/packages/dara-core/dara/core/internal/settings.py
+++ b/packages/dara-core/dara/core/internal/settings.py
@@ -18,9 +18,10 @@ limitations under the License.
 import os
 from functools import lru_cache
 from secrets import token_hex
+from typing import Annotated
 
 from dotenv import dotenv_values
-from pydantic import PositiveFloat, PositiveInt
+from pydantic import Field, FiniteFloat, PositiveInt
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from dara.core.internal.signing_key import PROCESS_JWT_SECRET, resolve_jwt_secret
@@ -46,7 +47,7 @@ class Settings(BaseSettings):
 
     dara_metrics_port: int = 10000
     dara_disable_metrics: bool = False
-    dara_stream_keepalive_interval_seconds: PositiveFloat = 15
+    dara_stream_keepalive_interval_seconds: Annotated[FiniteFloat, Field(ge=1, le=30)] = 15
 
     model_config = SettingsConfigDict(env_file='.env', extra='allow')
 

--- a/packages/dara-core/dara/core/internal/settings.py
+++ b/packages/dara-core/dara/core/internal/settings.py
@@ -20,7 +20,7 @@ from functools import lru_cache
 from secrets import token_hex
 
 from dotenv import dotenv_values
-from pydantic import PositiveInt
+from pydantic import PositiveFloat, PositiveInt
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from dara.core.internal.signing_key import PROCESS_JWT_SECRET, resolve_jwt_secret
@@ -46,6 +46,7 @@ class Settings(BaseSettings):
 
     dara_metrics_port: int = 10000
     dara_disable_metrics: bool = False
+    dara_stream_keepalive_interval_seconds: PositiveFloat = 15
 
     model_config = SettingsConfigDict(env_file='.env', extra='allow')
 

--- a/packages/dara-core/docs/advanced/stream-variable.md
+++ b/packages/dara-core/docs/advanced/stream-variable.md
@@ -48,6 +48,18 @@ page = Stack(For(items=events, renderer=Card(Text(events.list_item.get('message'
 
 When the user changes the `category` variable, the current stream closes and a new one opens with the new category value.
 
+### Keeping Idle Connections Alive
+
+Dara sends an SSE protocol comment to the browser every 15 seconds while a
+`StreamVariable` generator is quiet. This keeps the Dara-to-browser connection
+active even when an upstream SSE client has consumed its own heartbeat comments.
+Protocol comments are not application events: they do not update the
+`StreamVariable`, wake components, or reset the browser's reconnect retry count.
+
+The interval is intentionally shorter than common 30-60 second proxy idle
+timeouts. Deployments with different infrastructure requirements can set
+`DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS` to any positive number of seconds.
+
 ## Handling Reconnection (Important)
 
 :::warning

--- a/packages/dara-core/docs/advanced/stream-variable.md
+++ b/packages/dara-core/docs/advanced/stream-variable.md
@@ -51,14 +51,15 @@ When the user changes the `category` variable, the current stream closes and a n
 ### Keeping Idle Connections Alive
 
 Dara sends an SSE protocol comment to the browser every 15 seconds while a
-`StreamVariable` generator is quiet. This keeps the Dara-to-browser connection
-active even when an upstream SSE client has consumed its own heartbeat comments.
-Protocol comments are not application events: they do not update the
-`StreamVariable`, wake components, or reset the browser's reconnect retry count.
+`StreamVariable` lifecycle is quiet, including while its dependencies are being
+resolved. This keeps the Dara-to-browser connection active even when an upstream
+SSE client has consumed its own heartbeat comments. Protocol comments are not
+application events: they do not update the `StreamVariable`, wake components,
+produce browser errors, or reset the browser's reconnect retry count.
 
 The interval is intentionally shorter than common 30-60 second proxy idle
 timeouts. Deployments with different infrastructure requirements can set
-`DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS` to any positive number of seconds.
+`DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS` from 1 to 30 seconds.
 
 ## Handling Reconnection (Important)
 

--- a/packages/dara-core/js/shared/interactivity/stream-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/stream-variable.tsx
@@ -75,6 +75,52 @@ export interface StreamEvent {
     data: unknown;
 }
 
+const STREAM_EVENT_TYPES = new Set<StreamEventType>([
+    'add',
+    'remove',
+    'clear',
+    'replace',
+    'json_snapshot',
+    'json_patch',
+    'reconnect',
+    'error',
+]);
+
+/**
+ * Parse an SSE message into a supported StreamEvent.
+ *
+ * Comment-only SSE frames are delivered by fetch-event-source as messages with
+ * empty data. They are transport heartbeats rather than application events.
+ */
+function parseStreamEventMessage(message: EventSourceMessage): StreamEvent | null {
+    if (message.data.trim() === '') {
+        return null;
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(message.data);
+    } catch (parseError) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to parse SSE event:', parseError, message.data);
+        return null;
+    }
+
+    if (
+        parsed === null ||
+        typeof parsed !== 'object' ||
+        !('type' in parsed) ||
+        typeof parsed.type !== 'string' ||
+        !STREAM_EVENT_TYPES.has(parsed.type as StreamEventType)
+    ) {
+        // eslint-disable-next-line no-console
+        console.error('Unsupported SSE event:', parsed);
+        return null;
+    }
+
+    return parsed as StreamEvent;
+}
+
 /**
  * State of a stream connection.
  * 'loading' is the initial state before first data arrives.
@@ -390,11 +436,24 @@ function startStreamConnection(
     let retryCount = 0;
     let isFirstMessage = true;
     let currentState: StreamState = INITIAL_CONNECTED_STATE;
+    let terminalErrorReported = false;
 
     // Normalize values for the request
     const normalizedValues = normalizeRequest(params.resolvedValues, params.variables as any[]);
 
+    const reportTerminalError = (error: unknown): void => {
+        if (terminalErrorReported) {
+            return;
+        }
+        terminalErrorReported = true;
+        callbacks.onError(error instanceof Error ? error.message : String(error));
+    };
+
     void fetchEventSource(`/api/core/stream/${params.uid}`, {
+        // Request extras may customize headers, credentials, and other fetch
+        // behavior, but the StreamVariable module owns its method, body, and
+        // cancellation lifecycle.
+        ...params.extras,
         method: HTTP_METHOD.POST,
         body: JSON.stringify({ values: normalizedValues }),
         signal: controller.signal,
@@ -415,12 +474,8 @@ function startStreamConnection(
         },
 
         onmessage: (msg: EventSourceMessage) => {
-            let event: StreamEvent;
-            try {
-                event = JSON.parse(msg.data) as StreamEvent;
-            } catch (parseError) {
-                // eslint-disable-next-line no-console
-                console.error('Failed to parse SSE event:', parseError, msg.data);
+            const event = parseStreamEventMessage(msg);
+            if (event === null) {
                 return;
             }
 
@@ -435,10 +490,14 @@ function startStreamConnection(
                 throw new FatalStreamError(message);
             }
 
-            // Receiving valid data proves the connection recovered.
-            retryCount = 0;
-            currentState = applyStreamEvent(currentState, event, params.keyAccessor);
+            const nextState = applyStreamEvent(currentState, event, params.keyAccessor);
+            if (nextState === currentState || nextState.status === 'error') {
+                throw new FatalStreamError(nextState.error ?? `Stream event "${event.type}" could not be applied`);
+            }
 
+            // Only successfully applied application data proves recovery.
+            retryCount = 0;
+            currentState = nextState;
             if (isFirstMessage) {
                 isFirstMessage = false;
                 callbacks.onFirstData(currentState);
@@ -453,13 +512,13 @@ function startStreamConnection(
             }
 
             if (err instanceof FatalStreamError) {
-                callbacks.onError(err.message);
+                reportTerminalError(err);
                 throw err;
             }
 
             retryCount++;
             if (retryCount > MAX_RETRIES) {
-                callbacks.onError(err instanceof Error ? err.message : String(err));
+                reportTerminalError(err);
                 throw err;
             }
 
@@ -477,11 +536,13 @@ function startStreamConnection(
         // @ts-expect-error - fetch signature differs slightly but works
         fetch: request,
 
-        // Pass through extras (headers, etc.)
-        ...params.extras,
         // @ts-expect-error - Headers type doesn't match exactly
         headers: params.extras.headers,
-    }).catch(() => undefined);
+    }).catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+            reportTerminalError(error);
+        }
+    });
 
     // Return cleanup function and controller
     return {

--- a/packages/dara-core/js/shared/interactivity/stream-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/stream-variable.tsx
@@ -34,7 +34,7 @@ import { HTTP_METHOD } from '@darajs/ui-utils';
 import { type WebSocketClientInterface } from '@/api';
 import { type RequestExtras, RequestExtrasSerializable, request } from '@/api/http';
 import { handleAuthErrors } from '@/auth/auth';
-import { type GlobalTaskContext, type StreamVariable, isVariable } from '@/types';
+import { type GlobalTaskContext, type StreamVariable, UserError, isVariable } from '@/types';
 
 import { getUniqueIdentifier } from '../utils/hashing';
 import { normalizeRequest } from '../utils/normalization';
@@ -303,6 +303,10 @@ export function applyStreamEvent(
  * @returns The value to expose to components
  */
 export function getStreamValue(state: StreamState, keyAccessor: string | null): unknown {
+    if (state.status === 'error') {
+        throw new UserError(state.error ?? 'Stream failed');
+    }
+
     if (keyAccessor !== null && state.data !== null && typeof state.data === 'object' && !Array.isArray(state.data)) {
         // Keyed mode: expose as array
         return Object.values(state.data as Record<string, unknown>);
@@ -313,6 +317,12 @@ export function getStreamValue(state: StreamState, keyAccessor: string | null): 
 const MAX_RETRIES = 5;
 const BASE_DELAY_MS = 1000;
 const MAX_DELAY_MS = 30000;
+
+/** Error that should stop the SSE connection rather than be retried. */
+class FatalStreamError extends Error {}
+
+/** Error that should be handled by the SSE retry policy. */
+class RetriableStreamError extends Error {}
 
 /**
  * Calculate exponential backoff delay.
@@ -360,7 +370,7 @@ interface StreamConnectionCallbacks {
     onFirstData: (state: StreamState) => void;
     /** Called for subsequent data updates */
     onUpdate: (state: StreamState) => void;
-    /** Called on error after max retries */
+    /** Called when the stream reaches a terminal error */
     onError: (error: string) => void;
 }
 
@@ -392,7 +402,6 @@ function startStreamConnection(
         // eslint-disable-next-line @typescript-eslint/require-await
         onopen: async (response) => {
             if (response.ok) {
-                retryCount = 0; // Reset retry count on successful connection
                 return;
             }
 
@@ -415,14 +424,19 @@ function startStreamConnection(
                 return;
             }
 
-            // Handle reconnect event - throw to trigger retry logic
             if (event.type === 'reconnect') {
                 // eslint-disable-next-line no-console
                 console.info('StreamVariable: Server requested reconnect, reconnecting...');
-                throw new Error('Server requested reconnect');
+                throw new RetriableStreamError('Server requested reconnect');
             }
 
-            // Apply event to current state (accumulate)
+            if (event.type === 'error') {
+                const message = typeof event.data === 'string' ? event.data : 'Unknown error';
+                throw new FatalStreamError(message);
+            }
+
+            // Receiving valid data proves the connection recovered.
+            retryCount = 0;
             currentState = applyStreamEvent(currentState, event, params.keyAccessor);
 
             if (isFirstMessage) {
@@ -435,18 +449,20 @@ function startStreamConnection(
 
         onerror: (err) => {
             if (controller.signal.aborted) {
-                // Connection was intentionally aborted, don't retry
-                return;
+                throw err;
+            }
+
+            if (err instanceof FatalStreamError) {
+                callbacks.onError(err.message);
+                throw err;
             }
 
             retryCount++;
             if (retryCount > MAX_RETRIES) {
                 callbacks.onError(err instanceof Error ? err.message : String(err));
-                // Return undefined to stop retrying
-                return;
+                throw err;
             }
 
-            // Return delay to retry
             const delay = getBackoffDelay(retryCount - 1);
             // eslint-disable-next-line no-console
             console.warn(`Stream connection failed, retrying in ${delay}ms (attempt ${retryCount}/${MAX_RETRIES})...`);
@@ -454,8 +470,7 @@ function startStreamConnection(
         },
 
         onclose: () => {
-            // Stream closed normally - could be server shutting down
-            // The library will attempt to reconnect
+            throw new RetriableStreamError('Stream closed unexpectedly');
         },
 
         // Use our request wrapper for auth headers
@@ -466,7 +481,7 @@ function startStreamConnection(
         ...params.extras,
         // @ts-expect-error - Headers type doesn't match exactly
         headers: params.extras.headers,
-    });
+    }).catch(() => undefined);
 
     // Return cleanup function and controller
     return {
@@ -490,14 +505,12 @@ function streamConnectionEffect(atomKey: string): AtomEffect<StreamState> {
         // Deserialize params from atom key
         const params = deserializeAtomParams(atomKey);
 
-        // Create a Promise that resolves when first data arrives.
+        // Create a Promise that resolves when the stream produces its initial data or terminal error state.
         // Following recoil-sync pattern: setSelf(promise) enables native Suspense.
         let resolveInitialData: ((state: StreamState) => void) | null = null;
-        let rejectInitialData: ((error: Error) => void) | null = null;
 
-        const initialDataPromise = new Promise<StreamState>((resolve, reject) => {
+        const initialDataPromise = new Promise<StreamState>((resolve) => {
             resolveInitialData = resolve;
-            rejectInitialData = reject;
         });
 
         // Set atom to the Promise - Recoil will handle Suspense natively
@@ -511,7 +524,6 @@ function streamConnectionEffect(atomKey: string): AtomEffect<StreamState> {
                     if (resolveInitialData) {
                         resolveInitialData(state);
                         resolveInitialData = null;
-                        rejectInitialData = null;
                     }
                     // Also explicitly set the atom value to ensure Recoil sees the update
                     setSelf(state);
@@ -521,19 +533,20 @@ function streamConnectionEffect(atomKey: string): AtomEffect<StreamState> {
                     setSelf(state);
                 },
                 onError: (error) => {
-                    if (rejectInitialData) {
-                        // If we haven't received first data yet, reject the Promise
-                        rejectInitialData(new Error(error));
+                    const errorState: StreamState = {
+                        data: undefined,
+                        status: 'error',
+                        error,
+                    };
+
+                    if (resolveInitialData) {
+                        // Resolve Suspense with an explicit error state. The value selector
+                        // throws UserError without creating an unhandled rejected Promise.
+                        resolveInitialData(errorState);
                         resolveInitialData = null;
-                        rejectInitialData = null;
-                    } else {
-                        // Otherwise update the state with error
-                        setSelf({
-                            data: undefined,
-                            status: 'error',
-                            error,
-                        });
                     }
+
+                    setSelf(errorState);
                 },
             });
         };

--- a/packages/dara-core/js/shared/interactivity/stream-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/stream-variable.tsx
@@ -508,6 +508,8 @@ function startStreamConnection(
 
         onerror: (err) => {
             if (controller.signal.aborted) {
+                // An intentional cleanup must terminate fetch-event-source's
+                // retry loop even if abort is reported through onerror.
                 throw err;
             }
 
@@ -529,6 +531,9 @@ function startStreamConnection(
         },
 
         onclose: () => {
+            // StreamVariables are long-lived: a clean transport EOF without an
+            // explicit server event is still unexpected and must use the same
+            // bounded retry policy as other transient failures.
             throw new RetriableStreamError('Stream closed unexpectedly');
         },
 

--- a/packages/dara-core/tests/js/stream-variable.spec.tsx
+++ b/packages/dara-core/tests/js/stream-variable.spec.tsx
@@ -737,6 +737,41 @@ describe('StreamVariable', () => {
             expect(controller.signal.aborted).toBe(true);
         });
 
+        it('keeps ownership of cancellation when request extras contain a serialized signal', async () => {
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    return new HttpResponse(new ReadableStream(), {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(
+                createMockParams({
+                    // AbortSignal becomes an empty object when StreamAtomParams
+                    // cross the serialized Recoil seam.
+                    extras: { signal: {} as AbortSignal },
+                }),
+                callbacks
+            );
+
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(1);
+            });
+
+            connection.cleanup();
+
+            expect(connection.controller.signal.aborted).toBe(true);
+            expect(callbacks.onError).not.toHaveBeenCalled();
+        });
+
         it('routes auth failures on stream open through auth handling', async () => {
             const originalWindowLocation = window.location;
             const originalDara = window.dara;
@@ -932,6 +967,7 @@ describe('StreamVariable', () => {
         it('ignores heartbeat comments without resetting the retry budget', async () => {
             vi.useFakeTimers();
             vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
             let connectionCount = 0;
             server.use(
@@ -983,6 +1019,125 @@ describe('StreamVariable', () => {
             expect(callbacks.onFirstData).not.toHaveBeenCalled();
             expect(callbacks.onUpdate).not.toHaveBeenCalled();
             expect(callbacks.onError).not.toHaveBeenCalled();
+            expect(consoleError).not.toHaveBeenCalled();
+            connection.cleanup();
+        });
+
+        it('does not reset the retry budget for an unsupported event', async () => {
+            vi.useFakeTimers();
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    if (connectionCount === 1) {
+                        return new HttpResponse(null, {
+                            status: 503,
+                            statusText: 'Unavailable',
+                        });
+                    }
+
+                    if (connectionCount === 2) {
+                        const encoder = new TextEncoder();
+                        const stream = new ReadableStream({
+                            start(controller) {
+                                controller.enqueue(
+                                    encoder.encode(
+                                        `data: ${JSON.stringify({
+                                            type: 'future_event',
+                                            data: null,
+                                        })}\n\n`
+                                    )
+                                );
+                                controller.close();
+                            },
+                        });
+                        return new HttpResponse(stream, {
+                            headers: { 'Content-Type': 'text/event-stream' },
+                        });
+                    }
+
+                    return new HttpResponse(new ReadableStream(), {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams(), callbacks);
+
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(1);
+            });
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(2);
+            });
+
+            // The unsupported event did not prove recovery, so the clean EOF
+            // uses the second backoff delay.
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(connectionCount).toBe(2);
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(3);
+            });
+
+            expect(callbacks.onFirstData).not.toHaveBeenCalled();
+            expect(callbacks.onUpdate).not.toHaveBeenCalled();
+            expect(callbacks.onError).not.toHaveBeenCalled();
+            connection.cleanup();
+        });
+
+        it('surfaces an application event that cannot be applied as fatal', async () => {
+            vi.useFakeTimers();
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    const encoder = new TextEncoder();
+                    const stream = new ReadableStream({
+                        start(controller) {
+                            controller.enqueue(
+                                encoder.encode(
+                                    `data: ${JSON.stringify({
+                                        type: 'json_patch',
+                                        data: [{ op: 'remove', path: '/missing' }],
+                                    })}\n\n`
+                                )
+                            );
+                            controller.close();
+                        },
+                    });
+                    return new HttpResponse(stream, {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams({ keyAccessor: null }), callbacks);
+
+            await vi.waitFor(() => {
+                expect(callbacks.onError).toHaveBeenCalledWith('Stream event "json_patch" could not be applied');
+            });
+            await vi.advanceTimersByTimeAsync(60000);
+
+            expect(connectionCount).toBe(1);
+            expect(callbacks.onFirstData).not.toHaveBeenCalled();
+            expect(callbacks.onUpdate).not.toHaveBeenCalled();
             connection.cleanup();
         });
 

--- a/packages/dara-core/tests/js/stream-variable.spec.tsx
+++ b/packages/dara-core/tests/js/stream-variable.spec.tsx
@@ -20,6 +20,7 @@ import {
     extractKey,
     getStreamValue,
 } from '@/shared/interactivity/stream-variable';
+import { UserError } from '@/types';
 
 import { server } from './utils';
 import { mockLocalStorage } from './utils/mock-storage';
@@ -34,6 +35,7 @@ describe('StreamVariable', () => {
     });
 
     beforeEach(() => {
+        vi.useRealTimers();
         window.localStorage.clear();
         vi.restoreAllMocks();
         setSessionIdentifier(SESSION_TOKEN);
@@ -44,6 +46,7 @@ describe('StreamVariable', () => {
     afterEach(() => {
         setSessionIdentifier(null);
         vi.clearAllTimers();
+        vi.useRealTimers();
         server.resetHandlers();
         clearStreamUsage_TEST();
     });
@@ -633,6 +636,17 @@ describe('StreamVariable', () => {
             expect(getStreamValue(nullState, 'id')).toBeNull();
             expect(getStreamValue(undefinedState, 'id')).toBeUndefined();
         });
+
+        it('throws a user-visible error instead of returning stale data', () => {
+            const state: StreamState = {
+                data: { stale: true },
+                status: 'error',
+                error: 'Stream failed permanently',
+            };
+
+            expect(() => getStreamValue(state, null)).toThrow(UserError);
+            expect(() => getStreamValue(state, null)).toThrow('Stream failed permanently');
+        });
     });
 
     describe('helper functions', () => {
@@ -809,6 +823,180 @@ describe('StreamVariable', () => {
             // Clean up
             first.cleanup();
             second.cleanup();
+        });
+
+        it('reconnects when an SSE response reaches a clean EOF', async () => {
+            vi.useFakeTimers();
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    const stream = new ReadableStream({
+                        start(controller) {
+                            controller.close();
+                        },
+                    });
+                    return new HttpResponse(stream, {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams(), callbacks);
+
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(1);
+                expect(console.warn).toHaveBeenCalledTimes(1);
+            });
+
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(2);
+            });
+
+            expect(callbacks.onError).not.toHaveBeenCalled();
+            connection.cleanup();
+        });
+
+        it('exposes a fatal event after data and does not retry it', async () => {
+            vi.useFakeTimers();
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    const encoder = new TextEncoder();
+                    const stream = new ReadableStream({
+                        start(controller) {
+                            controller.enqueue(
+                                encoder.encode(
+                                    `data: ${JSON.stringify({
+                                        type: 'json_snapshot',
+                                        data: { stale: true },
+                                    })}\n\n`
+                                )
+                            );
+                            controller.enqueue(
+                                encoder.encode(
+                                    `data: ${JSON.stringify({
+                                        type: 'error',
+                                        data: 'Fatal stream failure',
+                                    })}\n\n`
+                                )
+                            );
+                            controller.close();
+                        },
+                    });
+                    return new HttpResponse(stream, {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams({ keyAccessor: null }), callbacks);
+
+            await vi.waitFor(() => {
+                expect(callbacks.onFirstData).toHaveBeenCalledWith({
+                    data: { stale: true },
+                    status: 'connected',
+                    error: undefined,
+                });
+                expect(callbacks.onError).toHaveBeenCalledWith('Fatal stream failure');
+            });
+
+            await vi.advanceTimersByTimeAsync(60000);
+
+            expect(connectionCount).toBe(1);
+            expect(callbacks.onUpdate).not.toHaveBeenCalled();
+            expect(callbacks.onError).toHaveBeenCalledTimes(1);
+            connection.cleanup();
+        });
+
+        it('stops after exhausting the retry budget', async () => {
+            vi.useFakeTimers();
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    return new HttpResponse(null, {
+                        status: 503,
+                        statusText: 'Unavailable',
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams(), callbacks);
+
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(1);
+            });
+
+            for (const [index, delay] of [1000, 2000, 4000, 8000, 16000].entries()) {
+                // eslint-disable-next-line no-await-in-loop
+                await vi.advanceTimersByTimeAsync(delay);
+                // eslint-disable-next-line no-await-in-loop
+                await vi.waitFor(() => {
+                    expect(connectionCount).toBe(index + 2);
+                });
+            }
+
+            await vi.waitFor(() => {
+                expect(callbacks.onError).toHaveBeenCalledWith('Stream request failed: 503 Unavailable');
+            });
+            await vi.advanceTimersByTimeAsync(60000);
+
+            expect(connectionCount).toBe(6);
+            expect(callbacks.onError).toHaveBeenCalledTimes(1);
+            connection.cleanup();
+        });
+
+        it('does not retry an intentionally aborted connection', async () => {
+            vi.useFakeTimers();
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    return new HttpResponse(new ReadableStream(), {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams(), callbacks);
+
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(1);
+            });
+            connection.cleanup();
+            await vi.advanceTimersByTimeAsync(60000);
+
+            expect(connectionCount).toBe(1);
+            expect(callbacks.onError).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/dara-core/tests/js/stream-variable.spec.tsx
+++ b/packages/dara-core/tests/js/stream-variable.spec.tsx
@@ -865,6 +865,127 @@ describe('StreamVariable', () => {
             connection.cleanup();
         });
 
+        it('resets the retry budget only after receiving valid data', async () => {
+            vi.useFakeTimers();
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    if (connectionCount === 1) {
+                        return new HttpResponse(null, {
+                            status: 503,
+                            statusText: 'Unavailable',
+                        });
+                    }
+
+                    const encoder = new TextEncoder();
+                    const stream = new ReadableStream({
+                        start(controller) {
+                            if (connectionCount === 2) {
+                                controller.enqueue(
+                                    encoder.encode(
+                                        `data: ${JSON.stringify({
+                                            type: 'json_snapshot',
+                                            data: { recovered: true },
+                                        })}\n\n`
+                                    )
+                                );
+                            }
+                            controller.close();
+                        },
+                    });
+                    return new HttpResponse(stream, {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams({ keyAccessor: null }), callbacks);
+
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(1);
+            });
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.waitFor(() => {
+                expect(callbacks.onFirstData).toHaveBeenCalledTimes(1);
+                expect(connectionCount).toBe(2);
+            });
+
+            // The valid snapshot reset the budget, so the following clean EOF
+            // uses the first backoff delay rather than the second.
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(3);
+            });
+
+            expect(callbacks.onError).not.toHaveBeenCalled();
+            connection.cleanup();
+        });
+
+        it('ignores heartbeat comments without resetting the retry budget', async () => {
+            vi.useFakeTimers();
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            let connectionCount = 0;
+            server.use(
+                http.post('/api/core/stream/test-stream', () => {
+                    connectionCount++;
+                    if (connectionCount === 1) {
+                        return new HttpResponse(null, {
+                            status: 503,
+                            statusText: 'Unavailable',
+                        });
+                    }
+
+                    const encoder = new TextEncoder();
+                    const stream = new ReadableStream({
+                        start(controller) {
+                            controller.enqueue(encoder.encode(': keepalive\n\n'));
+                            controller.close();
+                        },
+                    });
+                    return new HttpResponse(stream, {
+                        headers: { 'Content-Type': 'text/event-stream' },
+                    });
+                })
+            );
+
+            const callbacks = {
+                onFirstData: vi.fn(),
+                onUpdate: vi.fn(),
+                onError: vi.fn(),
+            };
+            const connection = _internal.startStreamConnection(createMockParams(), callbacks);
+
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(1);
+            });
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(2);
+            });
+
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(connectionCount).toBe(2);
+
+            await vi.advanceTimersByTimeAsync(1000);
+            await vi.waitFor(() => {
+                expect(connectionCount).toBe(3);
+            });
+
+            expect(callbacks.onFirstData).not.toHaveBeenCalled();
+            expect(callbacks.onUpdate).not.toHaveBeenCalled();
+            expect(callbacks.onError).not.toHaveBeenCalled();
+            connection.cleanup();
+        });
+
         it('exposes a fatal event after data and does not retry it', async () => {
             vi.useFakeTimers();
 

--- a/packages/dara-core/tests/js/use-stream-variable.spec.tsx
+++ b/packages/dara-core/tests/js/use-stream-variable.spec.tsx
@@ -5,6 +5,7 @@
 import { act, cleanup, screen, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import { Suspense, useContext, useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { useRecoilValue } from 'recoil';
 
 import { setSessionIdentifier } from '@/auth/session-state';
@@ -150,6 +151,21 @@ function StreamWithSuspenseDirect({ variable }: { variable: StreamVariable }): J
     );
 }
 
+/**
+ * Component with the same Suspense and error boundaries used by Dara components.
+ */
+function StreamWithBoundaries({ variable }: { variable: StreamVariable }): JSX.Element {
+    return (
+        <ErrorBoundary
+            fallbackRender={({ error }) => (
+                <div data-testid="stream-error">{error instanceof Error ? error.message : String(error)}</div>
+            )}
+        >
+            <StreamWithSuspenseDirect variable={variable} />
+        </ErrorBoundary>
+    );
+}
+
 describe('useVariable with StreamVariable', () => {
     beforeAll(() => {
         server.listen({ onUnhandledRequest: 'bypass' });
@@ -237,6 +253,103 @@ describe('useVariable with StreamVariable', () => {
 
         expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
         expect(screen.getByTestId('stream-data')).toHaveTextContent('{"message":"hello"}');
+    });
+
+    it('rejects the initial load with a user-visible fatal stream error', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const streamVar: StreamVariable = {
+            __typename: 'StreamVariable',
+            uid: 'test-initial-fatal-error',
+            variables: [],
+            key_accessor: null,
+            nested: [],
+        };
+
+        server.use(
+            createSSEHandler('test-initial-fatal-error', [
+                {
+                    type: 'error',
+                    data: 'Initial stream failure',
+                },
+            ])
+        );
+
+        wrappedRender(<StreamWithBoundaries variable={streamVar} />);
+
+        expect(screen.getByTestId('loading')).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId('stream-error')).toHaveTextContent('Initial stream failure');
+        });
+
+        expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('stream-data')).not.toBeInTheDocument();
+    });
+
+    it('replaces previously rendered data with a user-visible fatal stream error', async () => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        const streamVar: StreamVariable = {
+            __typename: 'StreamVariable',
+            uid: 'test-fatal-error-after-data',
+            variables: [],
+            key_accessor: null,
+            nested: [],
+        };
+
+        let sendFatalError: (() => void) | undefined;
+        server.use(
+            http.post('/api/core/stream/test-fatal-error-after-data', () => {
+                const encoder = new TextEncoder();
+                const stream = new ReadableStream({
+                    start(controller) {
+                        controller.enqueue(
+                            encoder.encode(
+                                `data: ${JSON.stringify({
+                                    type: 'json_snapshot',
+                                    data: { stale: true },
+                                })}\n\n`
+                            )
+                        );
+                        sendFatalError = () => {
+                            controller.enqueue(
+                                encoder.encode(
+                                    `data: ${JSON.stringify({
+                                        type: 'error',
+                                        data: 'Fatal stream failure',
+                                    })}\n\n`
+                                )
+                            );
+                            controller.close();
+                        };
+                    },
+                });
+
+                return new HttpResponse(stream, {
+                    headers: {
+                        'Content-Type': 'text/event-stream',
+                        'Cache-Control': 'no-cache',
+                        Connection: 'keep-alive',
+                    },
+                });
+            })
+        );
+
+        wrappedRender(<StreamWithBoundaries variable={streamVar} />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('stream-data')).toHaveTextContent('{"stale":true}');
+        });
+
+        await act(async () => {
+            sendFatalError?.();
+            await Promise.resolve();
+        });
+
+        await waitFor(() => {
+            expect(screen.getByTestId('stream-error')).toHaveTextContent('Fatal stream failure');
+        });
+        expect(screen.queryByTestId('stream-data')).not.toBeInTheDocument();
     });
 
     it('suspends again when dependencies change', async () => {

--- a/packages/dara-core/tests/python/test_settings.py
+++ b/packages/dara-core/tests/python/test_settings.py
@@ -85,14 +85,21 @@ def test_otel_shutdown_timeout_uses_dara_settings(monkeypatch: pytest.MonkeyPatc
 
 
 def test_stream_keepalive_interval_uses_dara_settings(monkeypatch: pytest.MonkeyPatch):
-    """The StreamVariable SSE heartbeat is configurable and must remain positive."""
+    """The StreamVariable SSE heartbeat is configurable within safe operational bounds."""
     monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '2.5')
 
     assert Settings(_env_file=None).dara_stream_keepalive_interval_seconds == 2.5
     assert Settings.model_fields['dara_stream_keepalive_interval_seconds'].default == 15
+    assert (
+        Settings(_env_file=None, dara_stream_keepalive_interval_seconds=1).dara_stream_keepalive_interval_seconds == 1
+    )
+    assert (
+        Settings(_env_file=None, dara_stream_keepalive_interval_seconds=30).dara_stream_keepalive_interval_seconds == 30
+    )
 
-    with pytest.raises(ValueError):
-        Settings(_env_file=None, dara_stream_keepalive_interval_seconds=0)
+    for invalid_interval in (0, 0.5, 30.1, float('inf'), '1e999'):
+        with pytest.raises(ValueError):
+            Settings(_env_file=None, dara_stream_keepalive_interval_seconds=invalid_interval)
 
 
 def _use_cache_dir(monkeypatch: pytest.MonkeyPatch, cache_dir: Path):

--- a/packages/dara-core/tests/python/test_settings.py
+++ b/packages/dara-core/tests/python/test_settings.py
@@ -26,6 +26,7 @@ def _clear_runtime_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv('DARA_OTEL_SHUTDOWN_TIMEOUT_MILLIS', raising=False)
     monkeypatch.delenv('DARA_METRICS_PORT', raising=False)
     monkeypatch.delenv('DARA_DISABLE_METRICS', raising=False)
+    monkeypatch.delenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', raising=False)
     monkeypatch.delenv('OTEL_METRICS_EXPORTER', raising=False)
     monkeypatch.delenv('OTEL_SEMCONV_STABILITY_OPT_IN', raising=False)
 
@@ -81,6 +82,17 @@ def test_otel_shutdown_timeout_uses_dara_settings(monkeypatch: pytest.MonkeyPatc
 
     with pytest.raises(ValueError):
         Settings(_env_file=None, dara_otel_shutdown_timeout_millis=0)
+
+
+def test_stream_keepalive_interval_uses_dara_settings(monkeypatch: pytest.MonkeyPatch):
+    """The StreamVariable SSE heartbeat is configurable and must remain positive."""
+    monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '2.5')
+
+    assert Settings(_env_file=None).dara_stream_keepalive_interval_seconds == 2.5
+    assert Settings.model_fields['dara_stream_keepalive_interval_seconds'].default == 15
+
+    with pytest.raises(ValueError):
+        Settings(_env_file=None, dara_stream_keepalive_interval_seconds=0)
 
 
 def _use_cache_dir(monkeypatch: pytest.MonkeyPatch, cache_dir: Path):

--- a/packages/dara-core/tests/python/test_stream_variable.py
+++ b/packages/dara-core/tests/python/test_stream_variable.py
@@ -16,6 +16,7 @@ from dara.core.definitions import ComponentInstance
 from dara.core.interactivity.stream_event import ReconnectException, StreamEvent, StreamEventType
 from dara.core.interactivity.stream_variable import StreamVariable, StreamVariableRegistryEntry, run_stream
 from dara.core.internal.dependency_resolution import ResolvedDerivedVariable
+from dara.core.internal.settings import get_settings
 from dara.core.main import _start_application
 
 from tests.python.utils import _get_auth_headers, create_app, normalize_request
@@ -521,6 +522,119 @@ async def test_stream_endpoint_reconnect_exception():
         assert len(events) == 2
         assert events[0]['type'] == 'clear'
         assert events[1]['type'] == 'reconnect'
+
+
+async def test_stream_endpoint_sends_protocol_comments_while_quiet(monkeypatch: pytest.MonkeyPatch):
+    """Quiet browser-facing streams emit heartbeats without creating application events."""
+    builder = ConfigurationBuilder()
+    release_generator = asyncio.Event()
+    generator_cleaned_up = asyncio.Event()
+
+    async def quiet_stream():
+        try:
+            await release_generator.wait()
+            yield StreamEvent.json_snapshot({'ready': True})
+        finally:
+            generator_cleaned_up.set()
+
+    stream_var = StreamVariable(quiet_stream, variables=[])
+    builder.add_page('Test', content=MockComponent(stream=stream_var))
+    config = create_app(builder)
+
+    monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '0.01')
+    get_settings.cache_clear()
+
+    app = _start_application(config)
+    async with AsyncClient(app) as client:
+        normalized_values, lookup = normalize_request([], stream_var.variables)
+        started_at = asyncio.get_running_loop().time()
+        response = await client.post(
+            f'/api/core/stream/{str(stream_var.uid)}',
+            json={'values': {'data': normalized_values, 'lookup': lookup}},
+            headers=await _get_auth_headers(),
+            stream=True,
+        )
+        first_chunk_at = asyncio.get_running_loop().time()
+        first_chunk = response.raw.read()
+
+        assert first_chunk == b': keepalive\n\n'
+        assert first_chunk_at - started_at >= 0.005
+
+        release_generator.set()
+        remaining_chunks = b''.join([chunk async for chunk in response])
+
+    content = (first_chunk + remaining_chunks).decode()
+    assert parse_sse_events(content) == [
+        {
+            'type': 'json_snapshot',
+            'data': {'ready': True},
+        }
+    ]
+    assert generator_cleaned_up.is_set()
+
+
+async def test_stream_endpoint_does_not_delay_normal_events(monkeypatch: pytest.MonkeyPatch):
+    """Events available before the heartbeat deadline are delivered without comments."""
+    builder = ConfigurationBuilder()
+
+    async def immediate_stream():
+        yield StreamEvent.json_snapshot({'ready': True})
+
+    stream_var = StreamVariable(immediate_stream, variables=[])
+    builder.add_page('Test', content=MockComponent(stream=stream_var))
+    config = create_app(builder)
+
+    monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '0.1')
+    get_settings.cache_clear()
+
+    app = _start_application(config)
+    async with AsyncClient(app) as client:
+        response = await _get_stream_response(client, stream_var, [])
+
+    assert ': keepalive' not in response.text
+    assert parse_sse_events(response.text)[0]['data'] == {'ready': True}
+
+
+async def test_stream_endpoint_request_cancellation_cleans_up_generator(monkeypatch: pytest.MonkeyPatch):
+    """A browser disconnect closes a blocked stream generator and its subscription."""
+    builder = ConfigurationBuilder()
+    generator_started = asyncio.Event()
+    generator_cancelled = asyncio.Event()
+    generator_cleaned_up = asyncio.Event()
+
+    async def blocking_stream():
+        try:
+            generator_started.set()
+            yield StreamEvent.json_snapshot({'ready': True})
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                generator_cancelled.set()
+                raise
+        finally:
+            generator_cleaned_up.set()
+
+    stream_var = StreamVariable(blocking_stream, variables=[])
+    builder.add_page('Test', content=MockComponent(stream=stream_var))
+    config = create_app(builder)
+
+    monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '0.01')
+    get_settings.cache_clear()
+
+    app = _start_application(config)
+    async with AsyncClient(app) as client:
+        normalized_values, lookup = normalize_request([], stream_var.variables)
+        response = await client.post(
+            f'/api/core/stream/{str(stream_var.uid)}',
+            json={'values': {'data': normalized_values, 'lookup': lookup}},
+            headers=await _get_auth_headers(),
+            stream=True,
+        )
+        await asyncio.wait_for(generator_started.wait(), timeout=1)
+        response.send({'type': 'http.disconnect'})
+
+    await asyncio.wait_for(generator_cleaned_up.wait(), timeout=1)
+    assert generator_cancelled.is_set()
 
 
 async def test_stream_endpoint_not_found():

--- a/packages/dara-core/tests/python/test_stream_variable.py
+++ b/packages/dara-core/tests/python/test_stream_variable.py
@@ -4,6 +4,7 @@ Tests for StreamVariable functionality.
 
 import asyncio
 import json
+from contextvars import ContextVar
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -22,6 +23,14 @@ from dara.core.main import _start_application
 from tests.python.utils import _get_auth_headers, create_app, normalize_request
 
 pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    """Keep environment-backed settings isolated between stream endpoint tests."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 class MockComponent(ComponentInstance):
@@ -529,9 +538,12 @@ async def test_stream_endpoint_sends_protocol_comments_while_quiet(monkeypatch: 
     builder = ConfigurationBuilder()
     release_generator = asyncio.Event()
     generator_cleaned_up = asyncio.Event()
+    generator_started_at: float | None = None
 
     async def quiet_stream():
+        nonlocal generator_started_at
         try:
+            generator_started_at = asyncio.get_running_loop().time()
             await release_generator.wait()
             yield StreamEvent.json_snapshot({'ready': True})
         finally:
@@ -541,24 +553,27 @@ async def test_stream_endpoint_sends_protocol_comments_while_quiet(monkeypatch: 
     builder.add_page('Test', content=MockComponent(stream=stream_var))
     config = create_app(builder)
 
-    monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '0.01')
-    get_settings.cache_clear()
+    monkeypatch.setattr(
+        'dara.core.internal.routing.get_settings',
+        lambda: Mock(dara_stream_keepalive_interval_seconds=0.05),
+    )
 
     app = _start_application(config)
     async with AsyncClient(app) as client:
         normalized_values, lookup = normalize_request([], stream_var.variables)
-        started_at = asyncio.get_running_loop().time()
         response = await client.post(
             f'/api/core/stream/{str(stream_var.uid)}',
             json={'values': {'data': normalized_values, 'lookup': lookup}},
             headers=await _get_auth_headers(),
             stream=True,
         )
-        first_chunk_at = asyncio.get_running_loop().time()
         first_chunk = response.raw.read()
+        heartbeat_received_at = asyncio.get_running_loop().time()
 
         assert first_chunk == b': keepalive\n\n'
-        assert first_chunk_at - started_at >= 0.005
+        assert generator_started_at is not None
+        heartbeat_delay = heartbeat_received_at - generator_started_at
+        assert 0.04 <= heartbeat_delay < 0.2
 
         release_generator.set()
         remaining_chunks = b''.join([chunk async for chunk in response])
@@ -584,8 +599,10 @@ async def test_stream_endpoint_does_not_delay_normal_events(monkeypatch: pytest.
     builder.add_page('Test', content=MockComponent(stream=stream_var))
     config = create_app(builder)
 
-    monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '0.1')
-    get_settings.cache_clear()
+    monkeypatch.setattr(
+        'dara.core.internal.routing.get_settings',
+        lambda: Mock(dara_stream_keepalive_interval_seconds=0.1),
+    )
 
     app = _start_application(config)
     async with AsyncClient(app) as client:
@@ -618,8 +635,10 @@ async def test_stream_endpoint_request_cancellation_cleans_up_generator(monkeypa
     builder.add_page('Test', content=MockComponent(stream=stream_var))
     config = create_app(builder)
 
-    monkeypatch.setenv('DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS', '0.01')
-    get_settings.cache_clear()
+    monkeypatch.setattr(
+        'dara.core.internal.routing.get_settings',
+        lambda: Mock(dara_stream_keepalive_interval_seconds=0.01),
+    )
 
     app = _start_application(config)
     async with AsyncClient(app) as client:
@@ -781,6 +800,46 @@ async def test_stream_first_event_timer_starts_before_dependency_resolution():
     assert progress['time_to_first_event'] == 5.0
 
 
+async def test_run_stream_heartbeats_during_dependency_resolution():
+    """The browser connection stays active while a slow dependency is resolving."""
+    dependency_started = asyncio.Event()
+    release_dependency = asyncio.Event()
+
+    async def resolve_dependency(_value, _store, _task_mgr):
+        dependency_started.set()
+        await release_dependency.wait()
+        return 'resolved'
+
+    async def stream(_value):
+        yield StreamEvent.json_snapshot({'ready': True})
+
+    with patch(
+        'dara.core.internal.dependency_resolution.resolve_dependency',
+        side_effect=resolve_dependency,
+    ):
+        stream_generator = run_stream(
+            _make_entry(stream),
+            asyncio.Event(),
+            [object()],
+            Mock(),
+            Mock(),
+            keepalive_interval_seconds=0.05,
+        )
+        started_at = asyncio.get_running_loop().time()
+        first_chunk = await asyncio.wait_for(anext(stream_generator), timeout=0.3)
+        heartbeat_received_at = asyncio.get_running_loop().time()
+
+        assert dependency_started.is_set()
+        assert first_chunk == ': keepalive\n\n'
+        assert 0.04 <= heartbeat_received_at - started_at < 0.2
+
+        release_dependency.set()
+        remaining_chunks = await _collect_events(stream_generator)
+
+    assert len(remaining_chunks) == 1
+    assert '"ready":true' in remaining_chunks[0]
+
+
 async def test_run_stream_disconnect_cancels_blocked_generator():
     """
     Core scenario from the leak document: a generator blocked on an inner
@@ -853,6 +912,36 @@ async def test_run_stream_normal_exhaustion():
     assert generator_cleaned_up.is_set()
 
 
+async def test_run_stream_preserves_generator_context_between_yields():
+    """One producer task owns the generator's ContextVar lifecycle."""
+    stream_context = ContextVar('stream_context', default='outside')
+    observed_values: list[str] = []
+
+    async def context_stream():
+        token = stream_context.set('inside')
+        try:
+            observed_values.append(stream_context.get())
+            yield StreamEvent.json_snapshot({'event': 1})
+            observed_values.append(stream_context.get())
+            yield StreamEvent.json_snapshot({'event': 2})
+        finally:
+            stream_context.reset(token)
+
+    events = await _collect_events(
+        run_stream(
+            _make_entry(context_stream),
+            asyncio.Event(),
+            [],
+            Mock(),
+            Mock(),
+        )
+    )
+
+    assert len(events) == 2
+    assert observed_values == ['inside', 'inside']
+    assert stream_context.get() == 'outside'
+
+
 async def test_run_stream_disconnect_between_yields():
     """Disconnect detected between yields when generator is not blocked."""
     generator_cleaned_up = asyncio.Event()
@@ -882,6 +971,37 @@ async def test_run_stream_disconnect_between_yields():
     assert len(collected) == 1
     assert 'first' in collected[0]
     assert generator_cleaned_up.is_set()
+
+
+async def test_run_stream_disconnect_wins_over_simultaneous_failure():
+    """A disconnect suppresses an upstream failure from the same event-loop turn."""
+    generator_started = asyncio.Event()
+    release_generator = asyncio.Event()
+
+    async def failing_stream():
+        generator_started.set()
+        await release_generator.wait()
+        raise RuntimeError('upstream failure after disconnect')
+        yield  # noqa: RET503 -- unreachable, but required to make this an async generator
+
+    disconnect_event = asyncio.Event()
+    consume_task = asyncio.create_task(
+        _collect_events(
+            run_stream(
+                _make_entry(failing_stream),
+                disconnect_event,
+                [],
+                Mock(),
+                Mock(),
+            )
+        )
+    )
+    await asyncio.wait_for(generator_started.wait(), timeout=1)
+
+    release_generator.set()
+    disconnect_event.set()
+
+    assert await asyncio.wait_for(consume_task, timeout=1) == []
 
 
 async def test_run_stream_generator_exception_produces_error_event():

--- a/packages/dara-core/tests/python/test_stream_variable.py
+++ b/packages/dara-core/tests/python/test_stream_variable.py
@@ -4,7 +4,7 @@ Tests for StreamVariable functionality.
 
 import asyncio
 import json
-from contextlib import asynccontextmanager, suppress
+from contextlib import aclosing, asynccontextmanager, suppress
 from contextvars import ContextVar
 from typing import Any
 from unittest.mock import Mock, patch
@@ -761,13 +761,19 @@ async def test_stream_endpoint_browser_disconnect_closes_nested_generator(monkey
 
 
 async def test_stream_endpoint_browser_disconnect_closes_httpx_upstream(monkeypatch: pytest.MonkeyPatch):
-    """Browser disconnect waits for a blocked user generator to close its real HTTPX socket."""
+    """Disconnect after a sent event releases a real capacity-one HTTPX pool."""
     builder = ConfigurationBuilder()
     upstream_connected = asyncio.Event()
     upstream_read_started = asyncio.Event()
     upstream_socket_closed = asyncio.Event()
+    next_stream_item_requested = asyncio.Event()
+    connection_count = 0
 
     async def handle_upstream(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        nonlocal connection_count
+        connection_count += 1
+        is_first_connection = connection_count == 1
+
         try:
             await reader.readuntil(b'\r\n\r\n')
             writer.write(
@@ -779,10 +785,12 @@ async def test_stream_endpoint_browser_disconnect_closes_httpx_upstream(monkeypa
                 b'data: ready\n\n'
             )
             await writer.drain()
-            upstream_connected.set()
+            if is_first_connection:
+                upstream_connected.set()
             await reader.read()
         finally:
-            upstream_socket_closed.set()
+            if is_first_connection:
+                upstream_socket_closed.set()
             writer.close()
             with suppress(ConnectionError):
                 await writer.wait_closed()
@@ -811,7 +819,7 @@ async def test_stream_endpoint_browser_disconnect_closes_httpx_upstream(monkeypa
 
     monkeypatch.setattr(
         'dara.core.internal.routing.get_settings',
-        lambda: Mock(dara_stream_keepalive_interval_seconds=0.01),
+        lambda: Mock(dara_stream_keepalive_interval_seconds=1),
     )
 
     retained_sources = []
@@ -819,7 +827,21 @@ async def test_stream_endpoint_browser_disconnect_closes_httpx_upstream(monkeypa
     def retained_run_stream(*args, **kwargs):
         source = run_stream(*args, **kwargs)
         retained_sources.append(source)
-        return source
+
+        async def observe_next_item_request():
+            first_item = True
+            async with aclosing(source):
+                async for item in source:
+                    yield item
+                    if first_item:
+                        first_item = False
+                        # This runs only when StreamingResponse requests another
+                        # body after the ready frame's send() has returned. The
+                        # following async-for step then drives run_stream to its
+                        # quiet asyncio.wait before receive() can disconnect.
+                        next_stream_item_requested.set()
+
+        return observe_next_item_request()
 
     monkeypatch.setattr('dara.core.internal.routing.run_stream', retained_run_stream)
 
@@ -834,18 +856,18 @@ async def test_stream_endpoint_browser_disconnect_closes_httpx_upstream(monkeypa
                 body=StreamRequestBody(values={'data': normalized_values, 'lookup': lookup}),
             )
             http_stream = response.body_iterator
-            body_send_started = asyncio.Event()
+            ready_body_sent = asyncio.Event()
 
             async def receive():
-                await body_send_started.wait()
+                await ready_body_sent.wait()
+                await next_stream_item_requested.wait()
                 await upstream_connected.wait()
                 await upstream_read_started.wait()
                 return {'type': 'http.disconnect'}
 
             async def send(message):
-                if message['type'] == 'http.response.body' and message.get('body'):
-                    body_send_started.set()
-                    await asyncio.Event().wait()
+                if message['type'] == 'http.response.body' and b'"ready":true' in message.get('body', b''):
+                    ready_body_sent.set()
 
             await response(
                 {'type': 'http', 'asgi': {'spec_version': '2.3'}},
@@ -854,6 +876,19 @@ async def test_stream_endpoint_browser_disconnect_closes_httpx_upstream(monkeypa
             )
 
             await asyncio.wait_for(upstream_socket_closed.wait(), timeout=1)
+
+            # The first response must have returned its checked-out connection,
+            # not merely released a higher-level admission lease. A leaked
+            # response would make this replacement request PoolTimeout forever.
+            async def fetch_replacement_event():
+                async with upstream_client.stream(
+                    'GET',
+                    f'http://127.0.0.1:{upstream_port}/events',
+                ) as replacement:
+                    return await anext(replacement.aiter_raw())
+
+            replacement_event = await asyncio.wait_for(fetch_replacement_event(), timeout=2)
+            assert b'data: ready\n\n' in replacement_event
     finally:
         if http_stream is not None:
             await http_stream.aclose()

--- a/packages/dara-core/tests/python/test_stream_variable.py
+++ b/packages/dara-core/tests/python/test_stream_variable.py
@@ -669,8 +669,8 @@ async def test_stream_endpoint_request_cancellation_cleans_up_generator(monkeypa
     assert generator_cancelled.is_set()
 
 
-async def test_stream_endpoint_wrapper_close_cleans_up_nested_generator(monkeypatch: pytest.MonkeyPatch):
-    """Closing the HTTP-facing iterator immediately tears down the upstream stream."""
+async def test_stream_endpoint_browser_disconnect_closes_nested_generator(monkeypatch: pytest.MonkeyPatch):
+    """ASGI disconnect while sending an event immediately tears down the upstream stream."""
     builder = ConfigurationBuilder()
     producer_blocked = asyncio.Event()
     generator_cleaned_up = asyncio.Event()
@@ -708,6 +708,7 @@ async def test_stream_endpoint_wrapper_close_cleans_up_nested_generator(monkeypa
     monkeypatch.setattr('dara.core.internal.routing.run_stream', retained_run_stream)
 
     app = _start_application(config)
+    http_stream = None
     try:
         async with AsyncClient(app):
             normalized_values, lookup = normalize_request([], stream_var.variables)
@@ -717,18 +718,36 @@ async def test_stream_endpoint_wrapper_close_cleans_up_nested_generator(monkeypa
                 body=StreamRequestBody(values={'data': normalized_values, 'lookup': lookup}),
             )
             http_stream = response.body_iterator
+            body_send_started = asyncio.Event()
+            sent_bodies = []
 
-            first_chunk = await anext(http_stream)
-            assert '"ready":true' in first_chunk
-            await asyncio.wait_for(producer_blocked.wait(), timeout=1)
+            async def receive():
+                # Disconnect after StreamingResponse has pulled the first item and
+                # become suspended sending it to the browser. This is the ASGI
+                # timing where Starlette cancels its response task between pulls.
+                await body_send_started.wait()
+                await producer_blocked.wait()
+                return {'type': 'http.disconnect'}
 
-            # StreamingResponse closes this iterator while it is suspended at yield.
-            # No further iteration is available to deliver disconnect_event to run_stream.
-            await http_stream.aclose()
+            async def send(message):
+                if message['type'] == 'http.response.body' and message.get('body'):
+                    sent_bodies.append(message['body'])
+                    body_send_started.set()
+                    await asyncio.Event().wait()
 
-        await asyncio.wait_for(generator_cleaned_up.wait(), timeout=1)
-        await asyncio.wait_for(subscription_closed.wait(), timeout=1)
+            await response(
+                {'type': 'http', 'asgi': {'spec_version': '2.3'}},
+                receive,
+                send,
+            )
+
+            assert len(sent_bodies) == 1
+            assert b'"ready":true' in sent_bodies[0]
+            assert generator_cleaned_up.is_set()
+            assert subscription_closed.is_set()
     finally:
+        if http_stream is not None:
+            await http_stream.aclose()
         for source in retained_sources:
             await source.aclose()
 

--- a/packages/dara-core/tests/python/test_stream_variable.py
+++ b/packages/dara-core/tests/python/test_stream_variable.py
@@ -4,11 +4,12 @@ Tests for StreamVariable functionality.
 
 import asyncio
 import json
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from contextvars import ContextVar
 from typing import Any
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 from async_asgi_testclient import TestClient as AsyncClient
 
@@ -674,6 +675,7 @@ async def test_stream_endpoint_browser_disconnect_closes_nested_generator(monkey
     builder = ConfigurationBuilder()
     producer_blocked = asyncio.Event()
     generator_cleaned_up = asyncio.Event()
+    subscription_cleanup_started = asyncio.Event()
     subscription_closed = asyncio.Event()
 
     @asynccontextmanager
@@ -681,6 +683,11 @@ async def test_stream_endpoint_browser_disconnect_closes_nested_generator(monkey
         try:
             yield
         finally:
+            subscription_cleanup_started.set()
+            # Real transports need an event-loop checkpoint to close their
+            # response body/socket; setting an event alone cannot prove that
+            # cleanup survived cancellation.
+            await asyncio.sleep(0)
             subscription_closed.set()
 
     async def blocking_stream():
@@ -744,12 +751,117 @@ async def test_stream_endpoint_browser_disconnect_closes_nested_generator(monkey
             assert len(sent_bodies) == 1
             assert b'"ready":true' in sent_bodies[0]
             assert generator_cleaned_up.is_set()
+            assert subscription_cleanup_started.is_set()
             assert subscription_closed.is_set()
     finally:
         if http_stream is not None:
             await http_stream.aclose()
         for source in retained_sources:
             await source.aclose()
+
+
+async def test_stream_endpoint_browser_disconnect_closes_httpx_upstream(monkeypatch: pytest.MonkeyPatch):
+    """Browser disconnect waits for a blocked user generator to close its real HTTPX socket."""
+    builder = ConfigurationBuilder()
+    upstream_connected = asyncio.Event()
+    upstream_read_started = asyncio.Event()
+    upstream_socket_closed = asyncio.Event()
+
+    async def handle_upstream(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            await reader.readuntil(b'\r\n\r\n')
+            writer.write(
+                b'HTTP/1.1 200 OK\r\n'
+                b'Content-Type: text/event-stream\r\n'
+                b'Cache-Control: no-cache\r\n'
+                b'Connection: keep-alive\r\n'
+                b'\r\n'
+                b'data: ready\n\n'
+            )
+            await writer.drain()
+            upstream_connected.set()
+            await reader.read()
+        finally:
+            upstream_socket_closed.set()
+            writer.close()
+            with suppress(ConnectionError):
+                await writer.wait_closed()
+
+    upstream_server = await asyncio.start_server(handle_upstream, '127.0.0.1', 0)
+    upstream_port = upstream_server.sockets[0].getsockname()[1]
+    upstream_client = httpx.AsyncClient(
+        limits=httpx.Limits(max_connections=1, max_keepalive_connections=1),
+        timeout=None,
+    )
+
+    async def blocking_stream():
+        # The shared capacity-one client outlives this stream, matching Dara's
+        # use of an application-scoped HTTPX pool. Only closing the response
+        # can release its checked-out connection.
+        async with upstream_client.stream('GET', f'http://127.0.0.1:{upstream_port}/events') as response:
+            chunks = response.aiter_raw()
+            await anext(chunks)
+            yield StreamEvent.json_snapshot({'ready': True})
+            upstream_read_started.set()
+            await anext(chunks)
+
+    stream_var = StreamVariable(blocking_stream, variables=[])
+    builder.add_page('Test', content=MockComponent(stream=stream_var))
+    config = create_app(builder)
+
+    monkeypatch.setattr(
+        'dara.core.internal.routing.get_settings',
+        lambda: Mock(dara_stream_keepalive_interval_seconds=0.01),
+    )
+
+    retained_sources = []
+
+    def retained_run_stream(*args, **kwargs):
+        source = run_stream(*args, **kwargs)
+        retained_sources.append(source)
+        return source
+
+    monkeypatch.setattr('dara.core.internal.routing.run_stream', retained_run_stream)
+
+    app = _start_application(config)
+    http_stream = None
+    try:
+        async with AsyncClient(app):
+            normalized_values, lookup = normalize_request([], stream_var.variables)
+            response = await stream_endpoint(
+                request=Mock(),
+                stream_uid=str(stream_var.uid),
+                body=StreamRequestBody(values={'data': normalized_values, 'lookup': lookup}),
+            )
+            http_stream = response.body_iterator
+            body_send_started = asyncio.Event()
+
+            async def receive():
+                await body_send_started.wait()
+                await upstream_connected.wait()
+                await upstream_read_started.wait()
+                return {'type': 'http.disconnect'}
+
+            async def send(message):
+                if message['type'] == 'http.response.body' and message.get('body'):
+                    body_send_started.set()
+                    await asyncio.Event().wait()
+
+            await response(
+                {'type': 'http', 'asgi': {'spec_version': '2.3'}},
+                receive,
+                send,
+            )
+
+            await asyncio.wait_for(upstream_socket_closed.wait(), timeout=1)
+    finally:
+        if http_stream is not None:
+            await http_stream.aclose()
+        for source in retained_sources:
+            await source.aclose()
+        await upstream_client.aclose()
+        upstream_server.close()
+        await upstream_server.wait_closed()
 
 
 async def test_track_stream_wrapper_close_closes_retained_source():
@@ -1008,6 +1120,56 @@ async def test_run_stream_disconnect_cancels_blocked_generator():
 
     assert generator_cleaned_up.is_set(), 'Generator finally block should have run'
     assert inner_was_cancelled.is_set(), 'CancelledError should have propagated into the blocked await'
+
+
+async def test_run_stream_repeated_parent_cancellation_waits_for_generator_cleanup():
+    """Repeated response cancellation must not interrupt awaited upstream cleanup."""
+    first_event_received = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    allow_cleanup = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    @asynccontextmanager
+    async def upstream_subscription():
+        try:
+            yield
+        finally:
+            cleanup_started.set()
+            await allow_cleanup.wait()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            cleanup_finished.set()
+
+    async def blocking_stream():
+        async with upstream_subscription():
+            yield StreamEvent.json_snapshot({'ready': True})
+            await asyncio.Event().wait()
+
+    async def consume():
+        async for _event in run_stream(
+            _make_entry(blocking_stream),
+            asyncio.Event(),
+            [],
+            Mock(),
+            Mock(),
+        ):
+            first_event_received.set()
+
+    consumer_task = asyncio.create_task(consume())
+    await asyncio.wait_for(first_event_received.wait(), timeout=1)
+
+    # The first cancellation reaches run_stream and cancels its producer.
+    consumer_task.cancel()
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+
+    # ASGI/AnyIO cancellation is level-triggered and can hit the response
+    # owner again while it is awaiting the child producer's async cleanup.
+    consumer_task.cancel()
+    allow_cleanup.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(consumer_task, timeout=1)
+    assert cleanup_finished.is_set()
 
 
 async def test_run_stream_parent_close_closes_backpressured_generator():

--- a/packages/dara-core/tests/python/test_stream_variable.py
+++ b/packages/dara-core/tests/python/test_stream_variable.py
@@ -4,6 +4,7 @@ Tests for StreamVariable functionality.
 
 import asyncio
 import json
+from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from typing import Any
 from unittest.mock import Mock, patch
@@ -618,18 +619,27 @@ async def test_stream_endpoint_request_cancellation_cleans_up_generator(monkeypa
     generator_started = asyncio.Event()
     generator_cancelled = asyncio.Event()
     generator_cleaned_up = asyncio.Event()
+    subscription_closed = asyncio.Event()
+
+    @asynccontextmanager
+    async def upstream_subscription():
+        try:
+            yield
+        finally:
+            subscription_closed.set()
 
     async def blocking_stream():
-        try:
-            generator_started.set()
-            yield StreamEvent.json_snapshot({'ready': True})
+        async with upstream_subscription():
             try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                generator_cancelled.set()
-                raise
-        finally:
-            generator_cleaned_up.set()
+                generator_started.set()
+                yield StreamEvent.json_snapshot({'ready': True})
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    generator_cancelled.set()
+                    raise
+            finally:
+                generator_cleaned_up.set()
 
     stream_var = StreamVariable(blocking_stream, variables=[])
     builder.add_page('Test', content=MockComponent(stream=stream_var))
@@ -653,6 +663,7 @@ async def test_stream_endpoint_request_cancellation_cleans_up_generator(monkeypa
         response.send({'type': 'http.disconnect'})
 
     await asyncio.wait_for(generator_cleaned_up.wait(), timeout=1)
+    await asyncio.wait_for(subscription_closed.wait(), timeout=1)
     assert generator_cancelled.is_set()
 
 
@@ -885,6 +896,57 @@ async def test_run_stream_disconnect_cancels_blocked_generator():
 
     assert generator_cleaned_up.is_set(), 'Generator finally block should have run'
     assert inner_was_cancelled.is_set(), 'CancelledError should have propagated into the blocked await'
+
+
+async def test_run_stream_parent_close_closes_backpressured_generator():
+    """
+    Closing the browser-facing parent must close its nested iterator even when
+    the producer is suspended while publishing an already-produced chunk.
+    """
+    third_chunk_produced = asyncio.Event()
+    nested_iterator_closed = asyncio.Event()
+
+    class NestedStreamIterator:
+        def __init__(self):
+            self.chunks = iter(['chunk 1', 'chunk 2', 'chunk 3'])
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                chunk = next(self.chunks)
+            except StopIteration as error:
+                raise StopAsyncIteration from error
+            if chunk == 'chunk 3':
+                third_chunk_produced.set()
+            return chunk
+
+        async def aclose(self):
+            nested_iterator_closed.set()
+
+    nested_iterator = NestedStreamIterator()
+
+    with patch(
+        'dara.core.interactivity.stream_variable._generate_stream',
+        return_value=nested_iterator,
+    ):
+        stream_generator = run_stream(
+            _make_entry(Mock()),
+            asyncio.Event(),
+            [],
+            Mock(),
+            Mock(),
+        )
+
+        assert await anext(stream_generator) == 'chunk 1'
+        await asyncio.wait_for(third_chunk_produced.wait(), timeout=1)
+
+        # The parent closes while chunk 2 occupies the bounded queue and the
+        # producer is blocked trying to publish chunk 3.
+        await stream_generator.aclose()
+
+    assert nested_iterator_closed.is_set()
 
 
 async def test_run_stream_normal_exhaustion():

--- a/packages/dara-core/tests/python/test_stream_variable.py
+++ b/packages/dara-core/tests/python/test_stream_variable.py
@@ -16,8 +16,10 @@ from dara.core import DerivedVariable, Variable
 from dara.core.configuration import ConfigurationBuilder
 from dara.core.definitions import ComponentInstance
 from dara.core.interactivity.stream_event import ReconnectException, StreamEvent, StreamEventType
+from dara.core.interactivity.stream_utils import track_stream
 from dara.core.interactivity.stream_variable import StreamVariable, StreamVariableRegistryEntry, run_stream
 from dara.core.internal.dependency_resolution import ResolvedDerivedVariable
+from dara.core.internal.routing import StreamRequestBody, stream_endpoint
 from dara.core.internal.settings import get_settings
 from dara.core.main import _start_application
 
@@ -665,6 +667,97 @@ async def test_stream_endpoint_request_cancellation_cleans_up_generator(monkeypa
     await asyncio.wait_for(generator_cleaned_up.wait(), timeout=1)
     await asyncio.wait_for(subscription_closed.wait(), timeout=1)
     assert generator_cancelled.is_set()
+
+
+async def test_stream_endpoint_wrapper_close_cleans_up_nested_generator(monkeypatch: pytest.MonkeyPatch):
+    """Closing the HTTP-facing iterator immediately tears down the upstream stream."""
+    builder = ConfigurationBuilder()
+    producer_blocked = asyncio.Event()
+    generator_cleaned_up = asyncio.Event()
+    subscription_closed = asyncio.Event()
+
+    @asynccontextmanager
+    async def upstream_subscription():
+        try:
+            yield
+        finally:
+            subscription_closed.set()
+
+    async def blocking_stream():
+        async with upstream_subscription():
+            try:
+                yield StreamEvent.json_snapshot({'ready': True})
+                producer_blocked.set()
+                await asyncio.Event().wait()
+            finally:
+                generator_cleaned_up.set()
+
+    stream_var = StreamVariable(blocking_stream, variables=[])
+    builder.add_page('Test', content=MockComponent(stream=stream_var))
+    config = create_app(builder)
+
+    # Retain the source so reference-counting cannot mask a missing explicit
+    # close at the route's async-iterator ownership seam.
+    retained_sources = []
+
+    def retained_run_stream(*args, **kwargs):
+        source = run_stream(*args, **kwargs)
+        retained_sources.append(source)
+        return source
+
+    monkeypatch.setattr('dara.core.internal.routing.run_stream', retained_run_stream)
+
+    app = _start_application(config)
+    try:
+        async with AsyncClient(app):
+            normalized_values, lookup = normalize_request([], stream_var.variables)
+            response = await stream_endpoint(
+                request=Mock(),
+                stream_uid=str(stream_var.uid),
+                body=StreamRequestBody(values={'data': normalized_values, 'lookup': lookup}),
+            )
+            http_stream = response.body_iterator
+
+            first_chunk = await anext(http_stream)
+            assert '"ready":true' in first_chunk
+            await asyncio.wait_for(producer_blocked.wait(), timeout=1)
+
+            # StreamingResponse closes this iterator while it is suspended at yield.
+            # No further iteration is available to deliver disconnect_event to run_stream.
+            await http_stream.aclose()
+
+        await asyncio.wait_for(generator_cleaned_up.wait(), timeout=1)
+        await asyncio.wait_for(subscription_closed.wait(), timeout=1)
+    finally:
+        for source in retained_sources:
+            await source.aclose()
+
+
+async def test_track_stream_wrapper_close_closes_retained_source():
+    """The HTTP tracking wrapper owns its nested route iterator."""
+    source_closed = asyncio.Event()
+    retained_sources = []
+
+    async def source():
+        try:
+            yield 'first'
+            await asyncio.Event().wait()
+        finally:
+            source_closed.set()
+
+    def create_source():
+        nested_source = source()
+        retained_sources.append(nested_source)
+        return nested_source
+
+    http_stream = track_stream(create_source)()
+    try:
+        assert await anext(http_stream) == 'first'
+        await http_stream.aclose()
+        await asyncio.wait_for(source_closed.wait(), timeout=1)
+    finally:
+        for nested_source in retained_sources:
+            await nested_source.aclose()
 
 
 async def test_stream_endpoint_not_found():


### PR DESCRIPTION
## Motivation and Context

A browser-facing `StreamVariable` can sit behind two separate SSE hops:

```text
API Server --(: keepalive comments + data)--> Dara --(data)--> browser
```

The API Server already keeps its upstream connection to Dara alive with SSE protocol comments, but Dara's intermediate SSE parser consumes those comments. The independent Dara-to-browser hop can therefore remain completely silent while the upstream stream is healthy. A proxy or browser-facing intermediary may then close that idle response cleanly. Before this change, clean EOF was treated as successful completion, so the client did not reconnect and the UI could remain stale.

This follows the StreamVariable disconnect cleanup work in #645. The two protections serve different purposes: browser-facing heartbeats prevent avoidable idle-path closures, while bounded reconnect remains the safety net when a closure actually occurs.

## Implementation Description

- Treat unexpected clean StreamVariable EOF as retriable, with bounded exponential backoff.
- Surface fatal server events immediately, stop after retry exhaustion, reset the retry count only after successfully applied application data, and never retry an intentional abort.
- Ignore comment-only/empty SSE messages as transport heartbeats without logging browser errors, emitting application events, or changing reducer state.
- Emit generic SSE `: keepalive` protocol comments from Dara while the browser-facing stream is quiet, including during dependency resolution. The default interval is 15 seconds and can be configured from 1–30 seconds with `DARA_STREAM_KEEPALIVE_INTERVAL_SECONDS`.
- Run dependency resolution, async-generator iteration, and generator cleanup in one persistent producer task. This preserves task-local context and gives the browser-facing consumer a narrow, deterministic cancellation seam.
- Explicitly own the nested `_generate_stream` iterator with `contextlib.aclosing`, so cancellation while the producer is blocked publishing a buffered chunk awaits generator teardown and releases upstream HTTP subscriptions before the parent returns.
- Explicitly close forwarding iterators at the route and stream-tracking wrapper seams. A StreamVariable-specific `StreamingResponse` owner also closes its body in a shielded `finally`, covering the real ASGI disconnect race where Starlette cancels while `send()` is blocked after pulling an application item.
- Shield `run_stream` teardown at the task-ownership seam. Its queue reader, producer, and disconnect waiter are cancelled and deterministically awaited without forwarding repeated parent cancellation into a producer already awaiting a user generator's `aclose()`. Deferred parent cancellation is re-raised only after the upstream async context has finished closing its transport.
- Make browser disconnect win over a simultaneous producer result or failure, then cancel and await all pending producer/consumer tasks so generators and upstream subscriptions are not leaked.
- Keep request ownership explicit: request extras may customize headers and fetch behavior, but cannot replace the StreamVariable POST body or abort signal.
- Document the two-hop behavior and configuration, and update the Dara Core changelog.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- Dara Core JS suite: 32 files, 353 tests passed.
- Focused StreamVariable JS suite: 75 tests passed, covering clean EOF reconnect, fatal events, retry exhaustion/reset, intentional abort, heartbeat parsing and reconnect interaction, invalid events, and abort-signal ownership.
- Focused Python StreamVariable suite: 49 tests passed, covering bounded heartbeat timing, heartbeat during dependency resolution, normal delivery, generator completion/cancellation, context preservation, disconnect cleanup, and repeated parent cancellation while upstream cleanup crosses multiple checkpoints. The real HTTPX regression lets the first ready frame send normally, disconnects while `run_stream` is waiting for the next item, and proves an immediate replacement request succeeds through the same capacity-one pool.
- Complete Dara Core Python suite: 860 tests passed.
- Python lint and format checks passed.
- Full JS lint and repository-wide JS formatting checks passed.
- Dara Core JS production build completed successfully.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

N/A — protocol and client reliability changes only.