### PR TITLE
Fix: DO-12421 Prevent FastAPI telemetry cleanup errors during failed startup

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,11 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fixed FastAPI telemetry cleanup errors when application construction fails by attaching instrumentation only after
+  the application has been built successfully.
+
 ## 1.29.6
 
 - Added a development-only server handshake that reports mismatched projects and supports overriding Vite's port with `dara start --dev-port` and `dara dev --port`.

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -85,7 +85,12 @@ from dara.core.js_tooling.js_utils import (
 from dara.core.logging import LoggingMiddleware, dev_logger, eng_logger, http_logger
 from dara.core.metrics.registry import DARA_METRICS_REGISTRY
 from dara.core.router import convert_template_to_router
-from dara.core.telemetry import initialize_telemetry, observe_internal_operation, shutdown_telemetry
+from dara.core.telemetry import (
+    initialize_process_telemetry,
+    instrument_fastapi_app,
+    observe_internal_operation,
+    shutdown_telemetry,
+)
 
 
 def _callable_name(func: Callable) -> str:
@@ -121,6 +126,11 @@ def _start_application(config: Configuration):
     # Check we have a config
     if isinstance(config, Configuration) is False:
         raise ValueError('Invalid Configuration class passed to Dara Core. Did you forget to call _to_configuration()?')
+
+    # Configure process-wide providers early enough to capture application
+    # construction and lifespan startup telemetry. FastAPI middleware is
+    # attached only after the application has been built successfully.
+    initialize_process_telemetry('application')
 
     # Setup the main template to work with Vite
     os.environ['VITE_MANIFEST_PATH'] = f'{config.static_files_dir}/manifest.json'
@@ -321,7 +331,6 @@ def _start_application(config: Configuration):
         redoc_url=None if is_production else '/redoc',
         default_response_class=CustomResponse,
     )
-    initialize_telemetry(app)
 
     # Ensure session-cookie auth is reflected in Authorization header for
     # downstream handlers still expecting bearer token transport.
@@ -581,6 +590,7 @@ def _start_application(config: Configuration):
         async def not_found(rest_of_path: str):
             raise HTTPException(status_code=404, detail='API endpoint not found')
 
+    instrument_fastapi_app(app)
     return app
 
 

--- a/packages/dara-core/dara/core/telemetry.py
+++ b/packages/dara-core/dara/core/telemetry.py
@@ -1680,12 +1680,12 @@ class _TelemetryRuntime:
                 self.system_metrics_instrumented = True
         return True
 
-    def initialize(self, app: FastAPI) -> None:
-        """Configure process telemetry once and instrument a FastAPI application once."""
-        try:
-            if not self.initialize_process():
-                return
+    def instrument_fastapi_app(self, app: FastAPI) -> None:
+        """Instrument a FastAPI application once after process telemetry is configured."""
+        if not self.configured:
+            return
 
+        try:
             app_id = id(app)
             if app_id in self.fastapi_instrumentation:
                 return
@@ -1772,17 +1772,17 @@ class _TelemetryRuntime:
 _RUNTIME = _TelemetryRuntime()
 
 
-def initialize_telemetry(app: FastAPI) -> None:
+def instrument_fastapi_app(app: FastAPI) -> None:
     """
-    Initialize Dara telemetry and instrument an application when enabled.
+    Instrument a fully constructed FastAPI application when telemetry is configured.
 
-    Set ``DARA_OTEL_ENABLED=TRUE`` to opt in. Export destinations and signal
-    settings are read from standard OpenTelemetry ``OTEL_*`` environment
-    variables. Dara never sends data to Pydantic's hosted Logfire service.
+    Process telemetry must be initialized first with :func:`initialize_process_telemetry`.
+    Keeping FastAPI instrumentation separate allows Dara to capture application
+    construction telemetry without attaching middleware to a partially built app.
 
-    :param app: FastAPI application to instrument
+    :param app: fully constructed FastAPI application to instrument
     """
-    _RUNTIME.initialize(app)
+    _RUNTIME.instrument_fastapi_app(app)
 
 
 def instrument_httpx_client(client: Any) -> None:

--- a/packages/dara-core/tests/python/test_main.py
+++ b/packages/dara-core/tests/python/test_main.py
@@ -108,7 +108,8 @@ async def test_metrics_server_uses_dara_registry(monkeypatch: pytest.MonkeyPatch
     config = create_app(builder)
 
     with (
-        patch('dara.core.main.initialize_telemetry'),
+        patch('dara.core.main.initialize_process_telemetry'),
+        patch('dara.core.main.instrument_fastapi_app'),
         patch('dara.core.main.start_http_server') as start_http_server,
     ):
         _start_application(config)
@@ -127,7 +128,8 @@ async def test_prometheus_endpoint_keeps_port_10000_by_default(monkeypatch: pyte
     config = create_app(builder)
 
     with (
-        patch('dara.core.main.initialize_telemetry'),
+        patch('dara.core.main.initialize_process_telemetry'),
+        patch('dara.core.main.instrument_fastapi_app'),
         patch('dara.core.main.start_http_server') as start_http_server,
     ):
         _start_application(config)
@@ -145,12 +147,29 @@ async def test_otel_enabled_keeps_prometheus_server(monkeypatch: pytest.MonkeyPa
     config = create_app(builder)
 
     with (
-        patch('dara.core.main.initialize_telemetry'),
+        patch('dara.core.main.initialize_process_telemetry'),
+        patch('dara.core.main.instrument_fastapi_app'),
         patch('dara.core.main.start_http_server') as start_http_server,
     ):
         _start_application(config)
 
     start_http_server.assert_called_once_with(10000, registry=DARA_METRICS_REGISTRY)
+
+
+async def test_fastapi_is_instrumented_only_after_application_construction():
+    """A construction failure must not leave a partially built FastAPI app instrumented."""
+    config = create_app(ConfigurationBuilder())
+
+    with (
+        patch('dara.core.main.initialize_process_telemetry') as initialize_process_telemetry,
+        patch('dara.core.main.instrument_fastapi_app') as instrument_fastapi_app,
+        patch('dara.core.main.BuildCache.from_config', side_effect=RuntimeError('build failed')),
+        pytest.raises(SystemExit),
+    ):
+        _start_application(config)
+
+    initialize_process_telemetry.assert_called_once_with('application')
+    instrument_fastapi_app.assert_not_called()
 
 
 def assert_dict_subset(haystack: dict, needle: dict):


### PR DESCRIPTION
## Motivation and Context

Dara initialized process telemetry and instrumented the FastAPI application in one step while `_start_application` was still constructing the app. If later construction failed, Logfire's instrumentation context could be finalized with partially initialized state and emit a secondary `NoneType.uninstrument_app` error. This made the original startup failure harder to diagnose and was especially confusing because Prometheus compatibility enables telemetry initialization in the default template path.

Jira: [DO-12421](https://causalens.atlassian.net/browse/DO-12421)

## Implementation Description

Process-level telemetry is still initialized near the start of application construction, so Dara continues to capture construction and lifespan telemetry. FastAPI-specific instrumentation is now a separate final step immediately before the successfully constructed app is returned.

The internal telemetry API now exposes only those two explicit lifecycle operations; the former combined initializer has been removed. A regression test forces application construction to fail and verifies that process telemetry starts but FastAPI instrumentation is never attached to the incomplete app.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- Focused Dara Core telemetry and application-construction regression tests: 24 passed.
- `poetry anthology run lint` passed.
- `poetry anthology run format-check` passed.
- `git diff --check` passed.
- The generated-asset-dependent telemetry subprocess test could not run in this worktree because `dara/core/_assets/auto_js/dara.core.umd.cjs` is absent.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

Not applicable; backend-only telemetry lifecycle fix.

[DO-12421]: https://causalens.atlassian.net/browse/DO-12421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ