### PR TITLE
Fix: DO-12424 stabilize dynamic worker spawn test

### DIFF
--- a/packages/dara-core/tests/python/test_pool.py
+++ b/packages/dara-core/tests/python/test_pool.py
@@ -607,7 +607,7 @@ async def test_pool_cancel():
 async def test_dynamic_worker_spawn():
     """
     Test dynamic worker spawning:
-    - initial number of workers == 2
+    - initial number of workers == 1
     - number of workers scales up as number of jobs processed increases up to maximum
     - excess workers shut down after a timeout
     """
@@ -619,11 +619,19 @@ async def test_dynamic_worker_spawn():
             assert len(worker_pids) == 1
 
             # Fire off a task
-            task_1 = pool.submit('test_uid', 'add', (1, 2), {'delay': 2})
+            task_1 = pool.submit('test_uid', 'add', (1, 2), {'delay': 5})
             await wait_assert(lambda: task_1.worker_id is not None, timeout=2)
 
-            # A new worker should be started, up to 2 total
-            await wait_assert(lambda: len(pool.workers) == 2, timeout=1)
+            # Wait for the new worker to be ready while the first worker is
+            # still busy. Process creation alone does not mean it can accept work.
+            await wait_assert(
+                lambda: (
+                    len(pool.workers) == 2
+                    and sum(worker.status == WorkerStatus.WORKING for worker in pool.workers.values()) == 1
+                    and sum(worker.status == WorkerStatus.IDLE for worker in pool.workers.values()) == 1
+                ),
+                timeout=5,
+            )
 
             # Fire off a task again
             task_2 = pool.submit('test_uid2', 'add', (2, 3), {'delay': 2})


### PR DESCRIPTION
## Motivation and Context

`test_dynamic_worker_spawn` began failing intermittently after task-worker telemetry increased spawned-process startup time. The test treated a worker appearing in the pool dictionary as readiness, then included that worker's cold startup in a two-second task-acknowledgement deadline.

Jira: [DO-12424](https://causalens.atlassian.net/browse/DO-12424)

## Implementation Description

Keep the first task busy while the pool scales, then wait until the pool has exactly one working worker and one idle worker before submitting the second task. This synchronizes the test on the state it actually requires while preserving a short acknowledgement deadline once capacity is ready.

The stale test description now correctly states that the pool starts with one worker.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- `test_dynamic_worker_spawn`: 10 consecutive stress runs passed.
- Complete Dara Core pool suite: 30 passed.
- `poetry anthology run lint` passed.
- `poetry anthology run format-check` passed.
- `git diff --check` passed.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

Not applicable; test-only change.

[DO-12424]: https://causalens.atlassian.net/browse/DO-12424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ