### PR TITLE
Fix: DO-12420 add backpressure-aware polling

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,7 +4,8 @@ title: Changelog
 
 ## NEXT
 
-- Added backpressure-aware DerivedVariable and Python component polling with fixed-delay scheduling, visibility pausing, jittered error backoff, request cancellation, and stale-result protection.
+- Added one-at-a-time polling for DerivedVariable and Python components. Polling now waits after each request, pauses in hidden tabs, spreads retries with jitter and backoff, honors Retry-After, aborts work on cleanup, and drops stale results.
+- Fixed rapid navigation after early route chunks raising `Deferred already resolved` and leaving the NDJSON body open.
 - Fixed StreamVariable clean connection closures not reconnecting and fatal stream errors silently leaving stale values visible, and added configurable SSE keepalive comments with robust parsing and cleanup across the full stream lifecycle.
 - Fixed FastAPI telemetry cleanup errors when application construction fails by attaching instrumentation only after
   the application has been built successfully.

--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -4,6 +4,7 @@ title: Changelog
 
 ## NEXT
 
+- Added backpressure-aware DerivedVariable and Python component polling with fixed-delay scheduling, visibility pausing, jittered error backoff, request cancellation, and stale-result protection.
 - Fixed StreamVariable clean connection closures not reconnecting and fatal stream errors silently leaving stale values visible, and added configurable SSE keepalive comments with robust parsing and cleanup across the full stream lifecycle.
 - Fixed FastAPI telemetry cleanup errors when application construction fails by attaching instrumentation only after
   the application has been built successfully.

--- a/packages/dara-core/js/api/http.tsx
+++ b/packages/dara-core/js/api/http.tsx
@@ -3,6 +3,19 @@ import cloneDeep from 'lodash/cloneDeep';
 
 export type RequestExtras = RequestInit;
 
+const signalIds = new WeakMap<AbortSignal, number>();
+let nextSignalId = 1;
+
+function getSignalId(signal: AbortSignal): number {
+    let id = signalIds.get(signal);
+    if (id === undefined) {
+        id = nextSignalId;
+        nextSignalId += 1;
+        signalIds.set(signal, id);
+    }
+    return id;
+}
+
 /**
  * Serializable form of RequestExtras.
  * Required to use for e.g. recoil params as they need to be serializable.
@@ -46,6 +59,13 @@ export class RequestExtrasSerializable {
 
         if (!serializable) {
             return null;
+        }
+
+        if (this.extras.signal) {
+            return JSON.stringify({
+                ...serializable,
+                signal: getSignalId(this.extras.signal),
+            });
         }
 
         return JSON.stringify(serializable);

--- a/packages/dara-core/js/router/fetching.tsx
+++ b/packages/dara-core/js/router/fetching.tsx
@@ -130,35 +130,67 @@ function createCacheKey(routeId: string, params: Params<string>): string {
  * @param signal AbortSignal to abort the generator
  */
 async function* ndjson(response: Response, signal?: AbortSignal): AsyncGenerator<any, void> {
-    const reader = response.body!.getReader();
+    if (!response.body) {
+        throw new Error('Route response body is missing');
+    }
+    const reader = response.body.getReader();
     const newline = /\r?\n/;
     const decoder = new TextDecoder();
 
     let buffer = '';
+    let cancelPromise: Promise<void> | undefined;
+    const abortError = (): DOMException => new DOMException('The operation was aborted', 'AbortError');
+    const cancel = (reason: unknown): Promise<void> => {
+        cancelPromise ??= reader.cancel(reason).catch(() => undefined);
+        return cancelPromise;
+    };
+    const abort = (): void => {
+        void cancel(signal?.reason ?? abortError());
+    };
+    signal?.addEventListener('abort', abort, { once: true });
 
-    while (true) {
-        if (signal?.aborted) {
-            throw new DOMException('The operation was aborted', 'AbortError');
-        }
-
-        // eslint-disable-next-line no-await-in-loop
-        const { done, value } = await reader.read();
-        if (done) {
-            if (buffer.length > 0) {
-                yield JSON.parse(buffer);
+    try {
+        while (true) {
+            if (signal?.aborted) {
+                throw abortError();
             }
-            return;
-        }
 
-        const chunk = decoder.decode(value, { stream: true });
-        buffer += chunk;
+            // eslint-disable-next-line no-await-in-loop
+            const { done, value } = await reader.read();
+            if (signal?.aborted) {
+                throw abortError();
+            }
+            if (done) {
+                if (buffer.length > 0) {
+                    yield JSON.parse(buffer);
+                }
+                return;
+            }
 
-        const parts = buffer.split(newline);
-        buffer = parts.pop()!;
-        for (const part of parts) {
-            yield JSON.parse(part);
+            const chunk = decoder.decode(value, { stream: true });
+            buffer += chunk;
+
+            const parts = buffer.split(newline);
+            buffer = parts.pop()!;
+            for (const part of parts) {
+                yield JSON.parse(part);
+            }
         }
+    } catch (error) {
+        await cancel(error);
+        throw error;
+    } finally {
+        signal?.removeEventListener('abort', abort);
+        reader.releaseLock();
     }
+}
+
+function rejectPending<T>(handle: Deferred<T>, error: unknown): void {
+    if (handle.status !== 'pending') {
+        return;
+    }
+    void handle.getValue().catch(() => undefined);
+    handle.reject(error);
 }
 
 /**
@@ -303,9 +335,6 @@ export async function fetchRouteData(
     const template = deferred<ComponentInstance>();
     const onLoadActions = deferred<ActionImpl[]>();
 
-    const resolvedDvs = new Set<string>();
-    const resolvedPyComponents = new Set<string>();
-
     // kick off the async generator in the background
     queueMicrotask(async () => {
         try {
@@ -323,27 +352,20 @@ export async function fetchRouteData(
                 // process the other chunks, resolving the deferreds as they come in
                 if (chunk.type === 'derived_variable') {
                     dvHandlesByUid[chunk.uid]?.handle.resolve(chunk.result);
-                    resolvedDvs.add(chunk.uid);
                 }
                 if (chunk.type === 'py_component') {
                     pyHandlesByUid[chunk.uid]?.handle.resolve(chunk.result);
-                    resolvedPyComponents.add(chunk.uid);
                 }
             }
         } catch (e) {
-            template.reject(e);
-            onLoadActions.reject(e);
+            rejectPending(template, e);
+            rejectPending(onLoadActions, e);
 
-            // reject remaining unresolved promises
-            for (const [uid, handle] of Object.entries(dvHandlesByUid)) {
-                if (!resolvedDvs.has(uid)) {
-                    handle.handle.reject(e);
-                }
+            for (const handle of Object.values(dvHandlesByUid)) {
+                rejectPending(handle.handle, e);
             }
-            for (const [uid, handle] of Object.entries(pyHandlesByUid)) {
-                if (!resolvedPyComponents.has(uid)) {
-                    handle.handle.reject(e);
-                }
+            for (const handle of Object.values(pyHandlesByUid)) {
+                rejectPending(handle.handle, e);
             }
         }
     });

--- a/packages/dara-core/js/shared/context/variable-context.tsx
+++ b/packages/dara-core/js/shared/context/variable-context.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 
+import type { PollScope } from '@/shared/interactivity/polling';
+
 export interface VariableContext {
     /**
-     * Owns requests started by descendants before Suspense lets their effects commit.
+     * Collects request keys before Suspense lets descendant effects commit.
      */
-    pollingOwner?: symbol;
+    pollScope?: PollScope;
     /**
      * Set of variables subscribed to (with useVariable)
      */

--- a/packages/dara-core/js/shared/context/variable-context.tsx
+++ b/packages/dara-core/js/shared/context/variable-context.tsx
@@ -2,6 +2,10 @@ import * as React from 'react';
 
 export interface VariableContext {
     /**
+     * Owns requests started by descendants before Suspense lets their effects commit.
+     */
+    pollingOwner?: symbol;
+    /**
      * Set of variables subscribed to (with useVariable)
      */
     variables: React.MutableRefObject<Set<string>>;

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -18,7 +18,7 @@ import ProgressTracker from '@/components/progress-tracker';
 import { FallbackCtx, VariableCtx, useRequestExtras, useTaskContext } from '@/shared/context';
 import { ErrorDisplay, isSelectorError } from '@/shared/error-handling';
 import { useRefreshSelector, useVariable } from '@/shared/interactivity';
-import { usePolling } from '@/shared/interactivity/polling';
+import { beginPollOwner, keepPollOwner, releasePollOwner, usePolling } from '@/shared/interactivity/polling';
 import useServerComponent, {
     getServerComponentRequestKey,
     usePollServerComponent,
@@ -280,6 +280,14 @@ function DynamicComponent(props: DynamicComponentProps): React.ReactNode {
 
     const { hasRunningTasks, cleanupRunningTasks } = useTaskContext();
     const variables = useRef<Set<string>>(new Set());
+    const [pollingOwner] = useState(() => Symbol('dynamic-component'));
+    const variableContext = useMemo(() => ({ pollingOwner, variables }), [pollingOwner]);
+    beginPollOwner(pollingOwner);
+
+    useEffect(() => {
+        keepPollOwner(pollingOwner);
+    });
+    useEffect(() => () => releasePollOwner(pollingOwner), [pollingOwner]);
 
     /*
         When this component unmounts, then cancel any pending tasks for this component. This is required because recoil uses
@@ -322,7 +330,7 @@ function DynamicComponent(props: DynamicComponentProps): React.ReactNode {
             onReset={onResetErrorBoundary}
         >
             <FallbackCtx.Provider value={{ suspend }}>
-                <VariableCtx.Provider value={{ variables }}>
+                <VariableCtx.Provider value={variableContext}>
                     <Suspense fallback={fallback}>{component}</Suspense>
                 </VariableCtx.Provider>
             </FallbackCtx.Provider>

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -15,11 +15,15 @@ import { ErrorBoundary } from 'react-error-boundary';
 import DefaultFallback from '@/components/fallback/default';
 import { hasMarkers } from '@/components/for/templating';
 import ProgressTracker from '@/components/progress-tracker';
-import { FallbackCtx, VariableCtx, useTaskContext } from '@/shared/context';
+import { FallbackCtx, VariableCtx, useRequestExtras, useTaskContext } from '@/shared/context';
 import { ErrorDisplay, isSelectorError } from '@/shared/error-handling';
 import { useRefreshSelector, useVariable } from '@/shared/interactivity';
-import useServerComponent, { useRefreshServerComponent } from '@/shared/interactivity/use-server-component';
-import { useInterval } from '@/shared/utils';
+import { usePolling } from '@/shared/interactivity/polling';
+import useServerComponent, {
+    getServerComponentRequestKey,
+    usePollServerComponent,
+    useRefreshServerComponent,
+} from '@/shared/interactivity/use-server-component';
 import {
     type ComponentInstance,
     type DerivedVariable,
@@ -381,6 +385,8 @@ function PythonWrapper(props: PythonWrapperProps): React.ReactNode {
         props.component.loop_instance_uid
     );
     const refresh = useRefreshServerComponent(props.uid, props.component.loop_instance_uid);
+    const extras = useRequestExtras();
+    const poll = usePollServerComponent(props.uid, props.component.loop_instance_uid, extras);
     const [componentPollingInterval] = useVariable<number | null>(props.polling_interval ?? null);
     const resolvedKwargPollingIntervals = useResolveDynamicKwargPollingIntervals(props.dynamic_kwargs);
 
@@ -389,7 +395,8 @@ function PythonWrapper(props: PythonWrapperProps): React.ReactNode {
         () => computePollingInterval(resolvedKwargPollingIntervals, componentPollingInterval),
         [resolvedKwargPollingIntervals, componentPollingInterval]
     );
-    useInterval(refresh, pollingInterval);
+    const pollingKey = getServerComponentRequestKey(props.uid, props.component.loop_instance_uid, extras);
+    usePolling(pollingKey, pollingInterval, poll);
 
     if (component === null) {
         return null;

--- a/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
+++ b/packages/dara-core/js/shared/dynamic-component/dynamic-component.tsx
@@ -18,7 +18,7 @@ import ProgressTracker from '@/components/progress-tracker';
 import { FallbackCtx, VariableCtx, useRequestExtras, useTaskContext } from '@/shared/context';
 import { ErrorDisplay, isSelectorError } from '@/shared/error-handling';
 import { useRefreshSelector, useVariable } from '@/shared/interactivity';
-import { beginPollOwner, keepPollOwner, releasePollOwner, usePolling } from '@/shared/interactivity/polling';
+import { usePollScope, usePolling } from '@/shared/interactivity/polling';
 import useServerComponent, {
     getServerComponentRequestKey,
     usePollServerComponent,
@@ -280,14 +280,8 @@ function DynamicComponent(props: DynamicComponentProps): React.ReactNode {
 
     const { hasRunningTasks, cleanupRunningTasks } = useTaskContext();
     const variables = useRef<Set<string>>(new Set());
-    const [pollingOwner] = useState(() => Symbol('dynamic-component'));
-    const variableContext = useMemo(() => ({ pollingOwner, variables }), [pollingOwner]);
-    beginPollOwner(pollingOwner);
-
-    useEffect(() => {
-        keepPollOwner(pollingOwner);
-    });
-    useEffect(() => () => releasePollOwner(pollingOwner), [pollingOwner]);
+    const pollScope = usePollScope();
+    const variableContext = { pollScope, variables };
 
     /*
         When this component unmounts, then cancel any pending tasks for this component. This is required because recoil uses

--- a/packages/dara-core/js/shared/interactivity/derived-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/derived-variable.tsx
@@ -720,6 +720,7 @@ export function getOrRegisterDerivedVariableValue(
                                     wsClient,
                                 });
                             }
+                            signal?.throwIfAborted();
 
                             let variableValue: any = NOT_SET;
 

--- a/packages/dara-core/js/shared/interactivity/derived-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/derived-variable.tsx
@@ -12,7 +12,7 @@
 import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
 import { nanoid } from 'nanoid';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { Params } from 'react-router';
 import {
     type GetRecoilValue,
@@ -49,16 +49,15 @@ import { type Deferred, deferred, isDeferred } from '../utils/deferred';
 // eslint-disable-next-line import/no-cycle
 import { cleanArgs, getOrRegisterTrigger, resolveNested, resolveVariable, resolveVariableStatic } from './internal';
 import {
-    type PollingRequestOutcome,
-    assertCurrentRequest,
     createPollForceKey,
-    getRetryAfterMs,
     isAbortError,
     isPollForceKey,
-    parseRetryAfter,
-    startPollingRequest,
+    markRetryAfter,
+    ownPoll,
+    releasePoll,
+    runPoll,
     usePolling,
-    waitForAbort,
+    waitOrAbort,
 } from './polling';
 import {
     type TriggerIndexValue,
@@ -145,43 +144,39 @@ export async function fetchDerivedVariable<T>({
     try {
         await validateResponse(res, `Failed to fetch the derived variable with uid: ${variableUid}`);
     } catch (error) {
-        if (typeof error === 'object' && error !== null) {
-            Object.assign(error, { retryAfterMs: parseRetryAfter(res) });
-        }
-        throw error;
+        throw markRetryAfter(error, res);
     }
     return res.json();
 }
 
-interface DebouncedFetchBatch {
+interface PendingFetch {
     args: FetchDerivedVariableArgs;
-    timer: ReturnType<typeof setTimeout>;
+    timer?: ReturnType<typeof setTimeout>;
     waiters: Array<{
         reject: (error: unknown) => void;
         resolve: (response: DerivedVariableResponse<any>) => void;
     }>;
 }
 
-const debouncedFetchBatches = new Map<string, DebouncedFetchBatch>();
+const pendingFetches = new Map<string, PendingFetch>();
 
 /**
- * Debounce startup calls to one selector identity without sharing errors
- * between already-started and newly queued request generations.
+ * Wait 10 ms so matching selector reads share one fetch. A running fetch stays separate.
  */
-function runDebouncedFetch(selectorKey: string, batch: DebouncedFetchBatch): void {
-    if (debouncedFetchBatches.get(selectorKey) !== batch) {
+function startPendingFetch(selectorKey: string, pending: PendingFetch): void {
+    if (pendingFetches.get(selectorKey) !== pending) {
         return;
     }
-    debouncedFetchBatches.delete(selectorKey);
+    pendingFetches.delete(selectorKey);
 
-    void fetchDerivedVariable(batch.args).then(
+    void fetchDerivedVariable(pending.args).then(
         (response) => {
-            for (const waiter of batch.waiters) {
+            for (const waiter of pending.waiters) {
                 waiter.resolve(response);
             }
         },
         (error: unknown) => {
-            for (const waiter of batch.waiters) {
+            for (const waiter of pending.waiters) {
                 waiter.reject(error);
             }
         }
@@ -190,22 +185,23 @@ function runDebouncedFetch(selectorKey: string, batch: DebouncedFetchBatch): voi
 
 async function debouncedFetchDerivedVariable(args: FetchDerivedVariableArgs): Promise<DerivedVariableResponse<any>> {
     return new Promise((resolve, reject) => {
-        const pendingBatch = debouncedFetchBatches.get(args.selectorKey);
-        if (pendingBatch) {
-            clearTimeout(pendingBatch.timer);
-            pendingBatch.args = args;
-            pendingBatch.waiters.push({ reject, resolve });
-            pendingBatch.timer = setTimeout(() => runDebouncedFetch(args.selectorKey, pendingBatch), 10);
+        const pending = pendingFetches.get(args.selectorKey);
+        if (pending) {
+            if (pending.timer !== undefined) {
+                clearTimeout(pending.timer);
+            }
+            pending.args = args;
+            pending.waiters.push({ reject, resolve });
+            pending.timer = setTimeout(() => startPendingFetch(args.selectorKey, pending), 10);
             return;
         }
 
-        const batch: DebouncedFetchBatch = {
+        const next: PendingFetch = {
             args,
-            timer: undefined as unknown as ReturnType<typeof setTimeout>,
             waiters: [{ reject, resolve }],
         };
-        batch.timer = setTimeout(() => runDebouncedFetch(args.selectorKey, batch), 10);
-        debouncedFetchBatches.set(args.selectorKey, batch);
+        next.timer = setTimeout(() => startPendingFetch(args.selectorKey, next), 10);
+        pendingFetches.set(args.selectorKey, next);
     });
 }
 
@@ -378,7 +374,8 @@ export type DerivedResult = PreviousResult | CurrentResult | CachedResponse;
  * @param resolvedVariables resolved values of dependant variables - turned into primitives and Resolved forms
  * @param get getter function to resolve atoms to values
  * @param triggerList list of trigger info objects
- * @param triggers list of triggers to register as dependencies; first one is expected to be the self-trigger
+ * @param selfTriggers triggers owned by this request identity
+ * @param childTriggers triggers owned by nested variables
  */
 export function resolveDerivedValue({
     key,
@@ -387,8 +384,8 @@ export function resolveDerivedValue({
     resolvedVariables,
     resolutionStrategy,
     triggerList,
-    triggers,
-    selfTriggerCount = 1,
+    selfTriggers,
+    childTriggers,
 }: {
     key: string;
     variables: any[];
@@ -398,10 +395,10 @@ export function resolveDerivedValue({
         | { name: 'get'; get: GetRecoilValue }
         | { name: 'static'; snapshot: Snapshot; params: Params<string> };
     triggerList: Array<TriggerInfo>;
-    triggers: TriggerIndexValue[];
-    /** Number of leading triggers that directly force this request identity. */
-    selfTriggerCount?: number;
+    selfTriggers: TriggerIndexValue[];
+    childTriggers: TriggerIndexValue[];
 }): DerivedResult {
+    const triggers = [...selfTriggers, ...childTriggers];
     /**
      * Array of values:
      * - primitive values are resolved to themselves
@@ -504,13 +501,13 @@ export function resolveDerivedValue({
              *  handle the force_key appropriately
              */
             if (triggerValue.inc !== previousTriggerCounters[idx]) {
-                if (idx < selfTriggerCount) {
+                if (idx < selfTriggers.length) {
                     // This is a self-trigger (polling, manual trigger) - use global force
                     selfTriggerForceKey = triggerValue.force_key;
                 } else if (triggerValue.force_key) {
                     // This is a nested variable trigger - embed force_key in the specific variable
                     // shift index back by the number of prepended self triggers
-                    const valueIndex = idx - selfTriggerCount;
+                    const valueIndex = idx - selfTriggers.length;
                     const triggerInfo = triggerList[valueIndex]!;
 
                     // If the trigger path is empty, it means we need to force the DV itself
@@ -599,8 +596,7 @@ export function getOrRegisterDerivedVariableResult(
                         const triggerList = buildTriggerList(variable.variables);
 
                         // Register nested triggers as dependencies so triggering one of the nested derived variables will trigger a recalculation here
-                        const triggers = registerChildTriggers(triggerList, get);
-                        triggers.unshift(selfTrigger, pollingTrigger);
+                        const childTriggers = registerChildTriggers(triggerList, get);
 
                         const derivedResult = resolveDerivedValue({
                             key: selectorKey,
@@ -609,8 +605,8 @@ export function getOrRegisterDerivedVariableResult(
                             resolvedVariables,
                             resolutionStrategy: { name: 'get', get },
                             triggerList,
-                            triggers,
-                            selfTriggerCount: 2,
+                            selfTriggers: [selfTrigger, pollingTrigger],
+                            childTriggers,
                         });
                         return derivedResult;
                     },
@@ -690,26 +686,16 @@ export function getOrRegisterDerivedVariableValue(
                         const currentResult =
                             derivedResult.type === 'current' ? (derivedResult as CurrentResult) : undefined;
                         const pollRequest = isPollForceKey(currentResult?.selfTriggerForceKey);
-                        const requestFingerprint = currentResult
+                        const inputKey = currentResult
                             ? JSON.stringify({
                                   forceKey: currentResult.selfTriggerForceKey,
                                   values: currentResult.values,
                               })
                             : undefined;
-                        const requestHandle = currentResult
-                            ? startPollingRequest(
-                                  selectorKey,
-                                  pollRequest ? 'poll' : 'dependency',
-                                  extras.signal ?? undefined,
-                                  requestFingerprint
-                              )
-                            : undefined;
-                        let requestOutcome: PollingRequestOutcome = { status: 'success' };
-                        let variableResponse = null;
-                        // whether to check for an initial task
-                        let shouldFetchTask = false;
+                        const fetchValue = async (signal?: AbortSignal): Promise<any> => {
+                            let variableResponse = null;
+                            let shouldFetchTask = false;
 
-                        try {
                             // Skip fetching if we have a cached result, await it instead
                             if (derivedResult.type === 'cached') {
                                 const response = await derivedResult.response.getValue();
@@ -720,18 +706,15 @@ export function getOrRegisterDerivedVariableValue(
                                 variableResponse = response.value;
                                 derivedResult = derivedResult.currentResult;
                             } else {
-                                assertCurrentRequest(requestHandle!);
-                                requestHandle!.signal.addEventListener(
-                                    'abort',
-                                    () => taskContext.cleanupRunningTasks(variable.uid),
-                                    { once: true }
-                                );
+                                signal!.addEventListener('abort', () => taskContext.cleanupRunningTasks(variable.uid), {
+                                    once: true,
+                                });
                                 variableResponse = await debouncedFetchDerivedVariable({
                                     cache: variable.cache,
                                     extras,
                                     force_key: currentResult!.selfTriggerForceKey,
                                     selectorKey,
-                                    signal: requestHandle!.signal,
+                                    signal: signal!,
                                     values: normalizeRequest(cleanArgs(currentResult!.values), variable.variables),
                                     variableUid: variable.uid,
                                     wsClient,
@@ -751,7 +734,7 @@ export function getOrRegisterDerivedVariableValue(
                                 if (shouldFetchTask) {
                                     const taskResult = await fetchTaskResult<any>(taskId, {
                                         ...extras,
-                                        signal: requestHandle?.signal,
+                                        signal,
                                     });
                                     if (taskResult.status === 'ok') {
                                         variableValue = taskResult.result;
@@ -764,7 +747,7 @@ export function getOrRegisterDerivedVariableValue(
                                     taskContext.startTask(taskId, variable.uid, getRegistryKey(variable, 'trigger'));
 
                                     try {
-                                        await waitForAbort(wsClient.waitForTask(taskId), requestHandle?.signal);
+                                        await waitOrAbort(wsClient.waitForTask(taskId), signal);
                                     } catch (e: unknown) {
                                         if (e instanceof TaskError || isAbortError(e)) {
                                             throw e;
@@ -779,7 +762,7 @@ export function getOrRegisterDerivedVariableValue(
 
                                     const result = await fetchTaskResult<any>(taskId, {
                                         ...extras,
-                                        signal: requestHandle?.signal,
+                                        signal,
                                     });
                                     if (result.status === 'not_found') {
                                         throw new Error('Task result not found');
@@ -790,38 +773,43 @@ export function getOrRegisterDerivedVariableValue(
                                 variableValue = variableResponse.value;
                             }
 
-                            if (requestHandle) {
-                                assertCurrentRequest(requestHandle);
-                            }
-
-                            // Store the final result and arguments used
-                            depsRegistry.set(derivedResult.depsKey, {
-                                args: derivedResult.relevantValues,
-                                result: variableValue,
-                            });
-
                             return variableValue;
+                        };
+
+                        if (!currentResult) {
+                            try {
+                                const variableValue = await fetchValue();
+                                depsRegistry.set(derivedResult.depsKey, {
+                                    args: derivedResult.relevantValues,
+                                    result: variableValue,
+                                });
+                                return variableValue;
+                            } catch (error) {
+                                return throwError(error);
+                            }
+                        }
+
+                        const runResult = currentResult;
+                        try {
+                            return await runPoll({
+                                cause: pollRequest ? 'poll' : 'dependency',
+                                inputKey,
+                                key: selectorKey,
+                                read: () => {
+                                    const saved = depsRegistry.get(runResult.depsKey);
+                                    return saved ? { found: true, value: saved.result } : { found: false };
+                                },
+                                signal: extras.signal ?? undefined,
+                                work: fetchValue,
+                                write: (variableValue) => {
+                                    depsRegistry.set(runResult.depsKey, {
+                                        args: runResult.relevantValues,
+                                        result: variableValue,
+                                    });
+                                },
+                            });
                         } catch (error) {
-                            requestOutcome = isAbortError(error)
-                                ? { status: 'aborted' }
-                                : { status: 'error', retryAfterMs: getRetryAfterMs(error) };
-
-                            const previous = depsRegistry.get((derivedResult as CurrentResult).depsKey);
-                            if (isAbortError(error) && previous) {
-                                await requestHandle?.waitForSupersedingRequest();
-                                return (
-                                    depsRegistry.get((derivedResult as CurrentResult).depsKey)?.result ??
-                                    previous.result
-                                );
-                            }
-
-                            if (pollRequest && previous) {
-                                return previous.result;
-                            }
-
-                            throwError(error);
-                        } finally {
-                            requestHandle?.finish(requestOutcome);
+                            return throwError(error);
                         }
                     },
                 key: nanoid(),
@@ -925,19 +913,19 @@ export function preloadDerivedValue({
     variables,
     deps,
     triggerList,
-    triggers,
+    selfTriggers,
+    childTriggers,
     snapshot,
     params,
-    selfTriggerCount,
 }: {
     key: string;
     variables: any[];
     deps: any[];
     triggerList: Array<TriggerInfo>;
-    triggers: TriggerIndexValue[];
+    selfTriggers: TriggerIndexValue[];
+    childTriggers: TriggerIndexValue[];
     snapshot: Snapshot;
     params: Params<string>;
-    selfTriggerCount?: number;
 }): {
     handle: Deferred<any>;
     result: DerivedResult;
@@ -949,8 +937,8 @@ export function preloadDerivedValue({
         resolvedVariables: variables,
         resolutionStrategy: { name: 'static', snapshot, params },
         triggerList,
-        triggers,
-        selfTriggerCount,
+        selfTriggers,
+        childTriggers,
     });
 
     // otherwise we already have a valid entry, nothing to do here
@@ -975,21 +963,21 @@ export function preloadDerivedVariable(
 
     // prepare trigger list as usual but use static resolution
     const triggerList = buildTriggerList(variable.variables);
-    const triggers = [
+    const selfTriggers = [
         resolveTriggerStatic(getOrRegisterTrigger(variable), snapshot),
         resolveTriggerStatic(getOrRegisterPollingTrigger(requestKey), snapshot),
-        ...triggerList.map((ti) => resolveTriggerStatic(getOrRegisterTrigger(ti.variable), snapshot)),
     ];
+    const childTriggers = triggerList.map((ti) => resolveTriggerStatic(getOrRegisterTrigger(ti.variable), snapshot));
 
     return preloadDerivedValue({
         key,
         variables: variable.variables,
         deps: variable.deps,
-        triggers,
+        selfTriggers,
+        childTriggers,
         triggerList,
         snapshot,
         params,
-        selfTriggerCount: 2,
     });
 }
 
@@ -1001,17 +989,24 @@ export function preloadDerivedVariable(
  * @param taskContext global task context
  * @param search search query
  * @param extras request extras to be merged into the options
+ * @param pollingOwner Suspense-safe owner for requests started during render
  */
 export function useDerivedVariable(
     variable: DerivedVariable,
     WsClient: WebSocketClientInterface,
     taskContext: GlobalTaskContext,
     extras: RequestExtras,
-    pollingInterval?: number
+    pollingInterval?: number,
+    pollingOwner?: symbol
 ): RecoilValue<any> {
     const dvSelector = getOrRegisterDerivedVariable(variable, WsClient, taskContext, extras);
 
     const pollingKey = getRegistryKey(variable, 'derived-selector') + new RequestExtrasSerializable(extras).toJSON();
+    ownPoll(pollingOwner, pollingKey);
+    useEffect(() => {
+        ownPoll(pollingOwner, pollingKey);
+        return () => releasePoll(pollingOwner, pollingKey);
+    }, [pollingOwner, pollingKey]);
     const triggerIndex = useMemo(() => getOrRegisterPollingTrigger(pollingKey), [pollingKey]);
 
     // Creating a setter function for triggerIndex

--- a/packages/dara-core/js/shared/interactivity/derived-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/derived-variable.tsx
@@ -23,8 +23,6 @@ import {
     useRecoilValue,
     useSetRecoilState,
 } from 'recoil';
-import { BehaviorSubject, Observable, from } from 'rxjs';
-import { debounceTime, filter, share, switchMap, take } from 'rxjs/operators';
 
 import { HTTP_METHOD, validateResponse } from '@darajs/ui-utils';
 
@@ -34,7 +32,6 @@ import { TaskError } from '@/api/websocket';
 import { handleAuthErrors } from '@/auth/auth';
 import { getUniqueIdentifier } from '@/shared/utils/hashing';
 import { normalizeRequest } from '@/shared/utils/normalization';
-import useInterval from '@/shared/utils/use-interval';
 import {
     type DerivedVariable,
     type GlobalTaskContext,
@@ -52,8 +49,21 @@ import { type Deferred, deferred, isDeferred } from '../utils/deferred';
 // eslint-disable-next-line import/no-cycle
 import { cleanArgs, getOrRegisterTrigger, resolveNested, resolveVariable, resolveVariableStatic } from './internal';
 import {
+    type PollingRequestOutcome,
+    assertCurrentRequest,
+    createPollForceKey,
+    getRetryAfterMs,
+    isAbortError,
+    isPollForceKey,
+    parseRetryAfter,
+    startPollingRequest,
+    usePolling,
+    waitForAbort,
+} from './polling';
+import {
     type TriggerIndexValue,
     depsRegistry,
+    getOrRegisterPollingTrigger,
     getRegistryKey,
     selectorFamilyMembersRegistry,
     selectorFamilyRegistry,
@@ -80,6 +90,7 @@ interface FetchDerivedVariableArgs {
     cache: DerivedVariable['cache'];
     extras: RequestExtras;
     force_key?: string | null;
+    signal?: AbortSignal;
     /**
      * selector instance key  - each selector's requests should be treated separately
      */
@@ -106,6 +117,7 @@ export async function fetchDerivedVariable<T>({
     cache,
     extras,
     force_key,
+    signal,
     variableUid,
     values,
     wsClient,
@@ -126,59 +138,74 @@ export async function fetchDerivedVariable<T>({
             headers: { ...cacheControl },
             method: HTTP_METHOD.POST,
         },
-        extras
+        extras,
+        { signal }
     );
     await handleAuthErrors(res, { authenticationFailureRedirect: 'login' });
-    await validateResponse(res, `Failed to fetch the derived variable with uid: ${variableUid}`);
+    try {
+        await validateResponse(res, `Failed to fetch the derived variable with uid: ${variableUid}`);
+    } catch (error) {
+        if (typeof error === 'object' && error !== null) {
+            Object.assign(error, { retryAfterMs: parseRetryAfter(res) });
+        }
+        throw error;
+    }
     return res.json();
 }
 
+interface DebouncedFetchBatch {
+    args: FetchDerivedVariableArgs;
+    timer: ReturnType<typeof setTimeout>;
+    waiters: Array<{
+        reject: (error: unknown) => void;
+        resolve: (response: DerivedVariableResponse<any>) => void;
+    }>;
+}
+
+const debouncedFetchBatches = new Map<string, DebouncedFetchBatch>();
+
 /**
- * Add a debounced version of the fetch so as to not overload the backend on startup. This needs to be cached per uid
- * so that we only debounce calls to the same DerivedVariable. Debouncing is done with rxjs as everything here is
- * promise based and async
+ * Debounce startup calls to one selector identity without sharing errors
+ * between already-started and newly queued request generations.
  */
-const debouncedFetchSubjects: {
-    [k: string]: BehaviorSubject<FetchDerivedVariableArgs | null>;
-} = {};
-const debouncedFetchCache: {
-    [k: string]: Observable<any>;
-} = {};
-
-async function debouncedFetchDerivedVariable({
-    variableUid,
-    selectorKey,
-    values,
-    wsClient,
-    extras,
-    cache,
-    force_key,
-}: FetchDerivedVariableArgs): Promise<DerivedVariableResponse<any>> {
-    // If this is the first time this is called then set up a subject and return stream for this selector
-    if (!debouncedFetchSubjects[selectorKey]) {
-        debouncedFetchSubjects[selectorKey] = new BehaviorSubject<FetchDerivedVariableArgs | null>(null);
-        debouncedFetchCache[selectorKey] = debouncedFetchSubjects[selectorKey].pipe(
-            filter((args) => !!args),
-            debounceTime(10),
-            switchMap((args) => from(fetchDerivedVariable(args))),
-            share()
-        );
+function runDebouncedFetch(selectorKey: string, batch: DebouncedFetchBatch): void {
+    if (debouncedFetchBatches.get(selectorKey) !== batch) {
+        return;
     }
+    debouncedFetchBatches.delete(selectorKey);
 
-    // Push the next set of args to the subject
-    debouncedFetchSubjects[selectorKey].next({
-        cache,
-        extras,
-        force_key,
-        selectorKey,
-        values,
-        variableUid,
-        wsClient,
-    });
+    void fetchDerivedVariable(batch.args).then(
+        (response) => {
+            for (const waiter of batch.waiters) {
+                waiter.resolve(response);
+            }
+        },
+        (error: unknown) => {
+            for (const waiter of batch.waiters) {
+                waiter.reject(error);
+            }
+        }
+    );
+}
 
-    // Return the debounced response from the backend
+async function debouncedFetchDerivedVariable(args: FetchDerivedVariableArgs): Promise<DerivedVariableResponse<any>> {
     return new Promise((resolve, reject) => {
-        debouncedFetchCache[selectorKey]!.pipe(take(1)).subscribe(resolve, reject);
+        const pendingBatch = debouncedFetchBatches.get(args.selectorKey);
+        if (pendingBatch) {
+            clearTimeout(pendingBatch.timer);
+            pendingBatch.args = args;
+            pendingBatch.waiters.push({ reject, resolve });
+            pendingBatch.timer = setTimeout(() => runDebouncedFetch(args.selectorKey, pendingBatch), 10);
+            return;
+        }
+
+        const batch: DebouncedFetchBatch = {
+            args,
+            timer: undefined as unknown as ReturnType<typeof setTimeout>,
+            waiters: [{ reject, resolve }],
+        };
+        batch.timer = setTimeout(() => runDebouncedFetch(args.selectorKey, batch), 10);
+        debouncedFetchBatches.set(args.selectorKey, batch);
     });
 }
 
@@ -300,7 +327,7 @@ interface PreviousResult {
  * DerivedVariable resolution result meaning that the value changed since last time
  * and should be refetched.
  */
-interface CurrentResult {
+export interface CurrentResult {
     /**
      * List of new 'relevant' values which should be used to update the depsRegistry entry if refetch was successful
      */
@@ -361,6 +388,7 @@ export function resolveDerivedValue({
     resolutionStrategy,
     triggerList,
     triggers,
+    selfTriggerCount = 1,
 }: {
     key: string;
     variables: any[];
@@ -371,6 +399,8 @@ export function resolveDerivedValue({
         | { name: 'static'; snapshot: Snapshot; params: Params<string> };
     triggerList: Array<TriggerInfo>;
     triggers: TriggerIndexValue[];
+    /** Number of leading triggers that directly force this request identity. */
+    selfTriggerCount?: number;
 }): DerivedResult {
     /**
      * Array of values:
@@ -460,23 +490,27 @@ export function resolveDerivedValue({
         const previousTriggerCounters = previousEntry.args.slice(
             previousEntry.args.length - triggers.length
         ) as number[];
+        const dependenciesChanged = !isEqual(
+            previousEntry.args.slice(0, -triggers.length),
+            relevantValues.slice(0, -triggers.length)
+        );
 
         // Find which trigger changed and handle force_key appropriately
         let selfTriggerForceKey: string | null = null;
 
-        for (const [idx, triggerValue] of triggers.entries()) {
+        for (const [idx, triggerValue] of dependenciesChanged ? [] : triggers.entries()) {
             /**
              *  If any of the nested trigger value has changed (this execution was caused by a trigger)
              *  handle the force_key appropriately
              */
             if (triggerValue.inc !== previousTriggerCounters[idx]) {
-                if (idx === 0) {
+                if (idx < selfTriggerCount) {
                     // This is a self-trigger (polling, manual trigger) - use global force
                     selfTriggerForceKey = triggerValue.force_key;
                 } else if (triggerValue.force_key) {
                     // This is a nested variable trigger - embed force_key in the specific variable
-                    // shift index back by 1 because we prepended a self trigger
-                    const valueIndex = idx - 1;
+                    // shift index back by the number of prepended self triggers
+                    const valueIndex = idx - selfTriggerCount;
                     const triggerInfo = triggerList[valueIndex]!;
 
                     // If the trigger path is empty, it means we need to force the DV itself
@@ -558,13 +592,15 @@ export function getOrRegisterDerivedVariableResult(
 
                         // for deps use a different key for each selector instance rather than one per family
                         const selectorKey = key + extrasSerializable.toJSON();
+                        const requestKey = getRegistryKey(variable, 'derived-selector') + extrasSerializable.toJSON();
+                        const pollingTrigger = get(getOrRegisterPollingTrigger(requestKey));
 
                         // Build trigger map once for efficient lookups
                         const triggerList = buildTriggerList(variable.variables);
 
                         // Register nested triggers as dependencies so triggering one of the nested derived variables will trigger a recalculation here
                         const triggers = registerChildTriggers(triggerList, get);
-                        triggers.unshift(selfTrigger);
+                        triggers.unshift(selfTrigger, pollingTrigger);
 
                         const derivedResult = resolveDerivedValue({
                             key: selectorKey,
@@ -574,6 +610,7 @@ export function getOrRegisterDerivedVariableResult(
                             resolutionStrategy: { name: 'get', get },
                             triggerList,
                             triggers,
+                            selfTriggerCount: 2,
                         });
                         return derivedResult;
                     },
@@ -635,13 +672,6 @@ export function getOrRegisterDerivedVariableValue(
                             (error as any).selectorExtras = extrasSerializable.toJSON();
                             throw error;
                         };
-                        const handleError = <R,>(func: () => R): R | undefined => {
-                            try {
-                                return func();
-                            } catch (e) {
-                                throwError(e);
-                            }
-                        };
 
                         // get the result selector instance for this extras value
                         const dvResultSelector = getOrRegisterDerivedVariableResult(
@@ -657,13 +687,31 @@ export function getOrRegisterDerivedVariableValue(
                         }
 
                         const { extras } = extrasSerializable;
+                        const currentResult =
+                            derivedResult.type === 'current' ? (derivedResult as CurrentResult) : undefined;
+                        const pollRequest = isPollForceKey(currentResult?.selfTriggerForceKey);
+                        const requestFingerprint = currentResult
+                            ? JSON.stringify({
+                                  forceKey: currentResult.selfTriggerForceKey,
+                                  values: currentResult.values,
+                              })
+                            : undefined;
+                        const requestHandle = currentResult
+                            ? startPollingRequest(
+                                  selectorKey,
+                                  pollRequest ? 'poll' : 'dependency',
+                                  extras.signal ?? undefined,
+                                  requestFingerprint
+                              )
+                            : undefined;
+                        let requestOutcome: PollingRequestOutcome = { status: 'success' };
                         let variableResponse = null;
                         // whether to check for an initial task
                         let shouldFetchTask = false;
 
-                        // Skip fetching if we have a cached result, await it instead
-                        if (derivedResult.type === 'cached') {
-                            try {
+                        try {
+                            // Skip fetching if we have a cached result, await it instead
+                            if (derivedResult.type === 'cached') {
                                 const response = await derivedResult.response.getValue();
                                 shouldFetchTask = true;
                                 if (!response.ok) {
@@ -671,85 +719,110 @@ export function getOrRegisterDerivedVariableValue(
                                 }
                                 variableResponse = response.value;
                                 derivedResult = derivedResult.currentResult;
-                            } catch (e) {
-                                throwError(e);
-                            }
-                        } else {
-                            variableResponse = await handleError(() =>
-                                debouncedFetchDerivedVariable({
+                            } else {
+                                assertCurrentRequest(requestHandle!);
+                                requestHandle!.signal.addEventListener(
+                                    'abort',
+                                    () => taskContext.cleanupRunningTasks(variable.uid),
+                                    { once: true }
+                                );
+                                variableResponse = await debouncedFetchDerivedVariable({
                                     cache: variable.cache,
                                     extras,
-                                    force_key: (derivedResult as CurrentResult).selfTriggerForceKey,
+                                    force_key: currentResult!.selfTriggerForceKey,
                                     selectorKey,
-                                    values: normalizeRequest(
-                                        cleanArgs((derivedResult as CurrentResult).values),
-                                        variable.variables
-                                    ),
+                                    signal: requestHandle!.signal,
+                                    values: normalizeRequest(cleanArgs(currentResult!.values), variable.variables),
                                     variableUid: variable.uid,
                                     wsClient,
-                                })
-                            );
-                        }
+                                });
+                            }
 
-                        let variableValue: any = NOT_SET;
+                            let variableValue: any = NOT_SET;
 
-                        // If there is a task running related to the current variable then something has changed, so cancel them
-                        taskContext.cleanupRunningTasks(variable.uid);
+                            // If there is a task running related to the current variable then something has changed, so cancel them
+                            taskContext.cleanupRunningTasks(variable.uid);
 
-                        // If the variable is computed as a task then wait for it to finish and fetch the result
-                        if (isTaskResponse(variableResponse)) {
-                            const taskId = variableResponse.task_id;
+                            // If the variable is computed as a task then wait for it to finish and fetch the result
+                            if (isTaskResponse(variableResponse)) {
+                                const taskId = variableResponse.task_id;
 
-                            // pre-fetch task result since it could already be available without us receiving the notif
-                            if (shouldFetchTask) {
-                                try {
-                                    const taskResult = await fetchTaskResult<any>(taskId, extras);
+                                // pre-fetch task result since it could already be available without us receiving the notif
+                                if (shouldFetchTask) {
+                                    const taskResult = await fetchTaskResult<any>(taskId, {
+                                        ...extras,
+                                        signal: requestHandle?.signal,
+                                    });
                                     if (taskResult.status === 'ok') {
                                         variableValue = taskResult.result;
                                     }
-                                } catch (e) {
-                                    throwError(e);
                                 }
-                            }
 
-                            // continue waiting for the task if it's not available yet
-                            if (variableValue === NOT_SET) {
-                                // register task being started
-                                taskContext.startTask(taskId, variable.uid, getRegistryKey(variable, 'trigger'));
+                                // continue waiting for the task if it's not available yet
+                                if (variableValue === NOT_SET) {
+                                    // register task being started
+                                    taskContext.startTask(taskId, variable.uid, getRegistryKey(variable, 'trigger'));
 
-                                try {
-                                    await wsClient.waitForTask(taskId);
-                                } catch (e: unknown) {
-                                    if (e instanceof TaskError) {
-                                        throwError(e);
+                                    try {
+                                        await waitForAbort(wsClient.waitForTask(taskId), requestHandle?.signal);
+                                    } catch (e: unknown) {
+                                        if (e instanceof TaskError || isAbortError(e)) {
+                                            throw e;
+                                        }
+
+                                        // should be a TaskCancelledError
+                                        // It should be safe to return `null` here as the selector will re-run and throw suspense again
+                                        return null;
+                                    } finally {
+                                        taskContext.endTask(taskId);
                                     }
 
-                                    // should be a TaskCancelledError
-                                    // It should be safe to return `null` here as the selector will re-run and throw suspense again
-                                    return null;
-                                } finally {
-                                    taskContext.endTask(taskId);
-                                }
-
-                                variableValue = await handleError(async () => {
-                                    const result = await fetchTaskResult<any>(taskId, extras);
+                                    const result = await fetchTaskResult<any>(taskId, {
+                                        ...extras,
+                                        signal: requestHandle?.signal,
+                                    });
                                     if (result.status === 'not_found') {
                                         throw new Error('Task result not found');
                                     }
-                                    return result.result;
-                                });
+                                    variableValue = result.result;
+                                }
+                            } else {
+                                variableValue = variableResponse.value;
                             }
-                        } else {
-                            variableValue = variableResponse.value;
+
+                            if (requestHandle) {
+                                assertCurrentRequest(requestHandle);
+                            }
+
+                            // Store the final result and arguments used
+                            depsRegistry.set(derivedResult.depsKey, {
+                                args: derivedResult.relevantValues,
+                                result: variableValue,
+                            });
+
+                            return variableValue;
+                        } catch (error) {
+                            requestOutcome = isAbortError(error)
+                                ? { status: 'aborted' }
+                                : { status: 'error', retryAfterMs: getRetryAfterMs(error) };
+
+                            const previous = depsRegistry.get((derivedResult as CurrentResult).depsKey);
+                            if (isAbortError(error) && previous) {
+                                await requestHandle?.waitForSupersedingRequest();
+                                return (
+                                    depsRegistry.get((derivedResult as CurrentResult).depsKey)?.result ??
+                                    previous.result
+                                );
+                            }
+
+                            if (pollRequest && previous) {
+                                return previous.result;
+                            }
+
+                            throwError(error);
+                        } finally {
+                            requestHandle?.finish(requestOutcome);
                         }
-
-                        // Store the final result and arguments used
-                        depsRegistry.set(derivedResult.depsKey, {
-                            args: derivedResult.relevantValues,
-                            result: variableValue,
-                        });
-
-                        return variableValue;
                     },
                 key: nanoid(),
             })
@@ -855,6 +928,7 @@ export function preloadDerivedValue({
     triggers,
     snapshot,
     params,
+    selfTriggerCount,
 }: {
     key: string;
     variables: any[];
@@ -863,6 +937,7 @@ export function preloadDerivedValue({
     triggers: TriggerIndexValue[];
     snapshot: Snapshot;
     params: Params<string>;
+    selfTriggerCount?: number;
 }): {
     handle: Deferred<any>;
     result: DerivedResult;
@@ -875,6 +950,7 @@ export function preloadDerivedValue({
         resolutionStrategy: { name: 'static', snapshot, params },
         triggerList,
         triggers,
+        selfTriggerCount,
     });
 
     // otherwise we already have a valid entry, nothing to do here
@@ -895,10 +971,15 @@ export function preloadDerivedVariable(
 ): ReturnType<typeof preloadDerivedValue> {
     // assume no extras in top-level variables
     const key = getRegistryKey(variable, 'result-selector') + new RequestExtrasSerializable({}).toJSON();
+    const requestKey = getRegistryKey(variable, 'derived-selector') + new RequestExtrasSerializable({}).toJSON();
 
     // prepare trigger list as usual but use static resolution
-    const triggerList = [...buildTriggerList(variable.variables), { path: [], variable }];
-    const triggers = triggerList.map((ti) => resolveTriggerStatic(getOrRegisterTrigger(ti.variable), snapshot));
+    const triggerList = buildTriggerList(variable.variables);
+    const triggers = [
+        resolveTriggerStatic(getOrRegisterTrigger(variable), snapshot),
+        resolveTriggerStatic(getOrRegisterPollingTrigger(requestKey), snapshot),
+        ...triggerList.map((ti) => resolveTriggerStatic(getOrRegisterTrigger(ti.variable), snapshot)),
+    ];
 
     return preloadDerivedValue({
         key,
@@ -908,6 +989,7 @@ export function preloadDerivedVariable(
         triggerList,
         snapshot,
         params,
+        selfTriggerCount: 2,
     });
 }
 
@@ -929,26 +1011,21 @@ export function useDerivedVariable(
 ): RecoilValue<any> {
     const dvSelector = getOrRegisterDerivedVariable(variable, WsClient, taskContext, extras);
 
-    /**
-     * Workaround for forcing a re-calculation for derived variables by creating a triggerIndex atom and making it a dependency of
-     * the recoil selector. This way the selector can be re-run and derived variable can be re-fetched from the
-     * backend by just updating this atom.
-     */
-    const triggerIndex = useMemo(() => getOrRegisterTrigger(variable), []);
+    const pollingKey = getRegistryKey(variable, 'derived-selector') + new RequestExtrasSerializable(extras).toJSON();
+    const triggerIndex = useMemo(() => getOrRegisterPollingTrigger(pollingKey), [pollingKey]);
 
     // Creating a setter function for triggerIndex
     const triggerUpdates = useSetRecoilState(triggerIndex);
     const trigger = useCallback(
-        (force = true) =>
+        () =>
             triggerUpdates((val) => ({
-                force_key: force ? nanoid() : null,
+                force_key: createPollForceKey(),
                 inc: val.inc + 1,
             })),
         [triggerUpdates]
     );
 
-    // Using useInterval to poll, forcing recalculation everytime
-    useInterval(trigger, pollingInterval);
+    usePolling(pollingKey, pollingInterval, trigger);
 
     return dvSelector;
 }

--- a/packages/dara-core/js/shared/interactivity/derived-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/derived-variable.tsx
@@ -12,7 +12,7 @@
 import isEqual from 'lodash/isEqual';
 import set from 'lodash/set';
 import { nanoid } from 'nanoid';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { Params } from 'react-router';
 import {
     type GetRecoilValue,
@@ -53,9 +53,9 @@ import {
     isAbortError,
     isPollForceKey,
     markRetryAfter,
-    ownPoll,
-    releasePoll,
+    type PollScope,
     runPoll,
+    usePollKey,
     usePolling,
     waitOrAbort,
 } from './polling';
@@ -989,7 +989,7 @@ export function preloadDerivedVariable(
  * @param taskContext global task context
  * @param search search query
  * @param extras request extras to be merged into the options
- * @param pollingOwner Suspense-safe owner for requests started during render
+ * @param pollScope render-local scope for requests started before commit
  */
 export function useDerivedVariable(
     variable: DerivedVariable,
@@ -997,16 +997,12 @@ export function useDerivedVariable(
     taskContext: GlobalTaskContext,
     extras: RequestExtras,
     pollingInterval?: number,
-    pollingOwner?: symbol
+    pollScope?: PollScope
 ): RecoilValue<any> {
     const dvSelector = getOrRegisterDerivedVariable(variable, WsClient, taskContext, extras);
 
     const pollingKey = getRegistryKey(variable, 'derived-selector') + new RequestExtrasSerializable(extras).toJSON();
-    ownPoll(pollingOwner, pollingKey);
-    useEffect(() => {
-        ownPoll(pollingOwner, pollingKey);
-        return () => releasePoll(pollingOwner, pollingKey);
-    }, [pollingOwner, pollingKey]);
+    usePollKey(pollScope, pollingKey);
     const triggerIndex = useMemo(() => getOrRegisterPollingTrigger(pollingKey), [pollingKey]);
 
     // Creating a setter function for triggerIndex

--- a/packages/dara-core/js/shared/interactivity/polling.tsx
+++ b/packages/dara-core/js/shared/interactivity/polling.tsx
@@ -3,39 +3,43 @@ import { useEffect, useRef } from 'react';
 const DEFAULT_JITTER_RATIO = 0.1;
 const MAX_BACKOFF_MS = 60_000;
 const POLL_FORCE_KEY_PREFIX = '__dara_poll__:';
+const retryAfterByError = new WeakMap<object, number>();
 
 type TimerHandle = ReturnType<typeof setTimeout>;
-type RequestSource = 'dependency' | 'poll';
+type RunCause = 'dependency' | 'poll';
 
 interface PollingSubscriber {
     intervalMs: number;
     refresh: () => void;
 }
 
-interface ActiveRequest {
-    completion: Promise<void>;
-    consumers: number;
+interface ActiveRun {
+    done: Promise<void>;
     controller: AbortController;
     detachExternalSignal?: () => void;
-    fingerprint?: string;
+    inputKey?: string;
     generation: number;
-    resolveCompletion: () => void;
-    source: RequestSource;
+    end: () => void;
+    result?: Promise<unknown>;
+    cause: RunCause;
 }
 
+type RunState = { kind: 'idle' } | { kind: 'running'; run: ActiveRun } | { kind: 'starting' };
+
 interface PollingEntry {
-    activeRequest?: ActiveRequest;
-    awaitingRequest: boolean;
     disposeTimer?: TimerHandle;
     failureCount: number;
     generation: number;
-    resumePending: boolean;
+    nextRunAt?: number;
+    owners: Set<symbol>;
+    runAgain: boolean;
+    runOnShow: boolean;
+    state: RunState;
     subscribers: Map<symbol, PollingSubscriber>;
     timer?: TimerHandle;
-    trailingRefresh: boolean;
 }
 
-interface PollingCoordinatorOptions {
+interface PollerOptions {
     clearTimeout?: (timer: TimerHandle) => void;
     getVisibilityState?: () => DocumentVisibilityState;
     jitterRatio?: number;
@@ -45,7 +49,15 @@ interface PollingCoordinatorOptions {
     visibilityTarget?: Pick<Document, 'addEventListener' | 'removeEventListener'>;
 }
 
-export type PollingRequestOutcome =
+interface PollOwner {
+    disposeTimer?: TimerHandle;
+    keyDisposeTimers: Map<string, TimerHandle>;
+    keys: Set<string>;
+    mounted: boolean;
+    seenKeys: Set<string>;
+}
+
+type RunOutcome =
     | {
           status: 'aborted';
       }
@@ -57,15 +69,47 @@ export type PollingRequestOutcome =
           status: 'error';
       };
 
-export interface PollingRequestHandle {
-    /** AbortSignal owned by the polling coordinator for this request generation. */
+interface RunHandle {
+    /** AbortSignal owned by the poller for this request generation. */
     signal: AbortSignal;
     /** Complete this request and update polling cadence if it is still current. */
-    finish: (outcome: PollingRequestOutcome) => void;
+    finish: (outcome: RunOutcome) => void;
     /** Whether this request is still the newest request for its polling identity. */
     isCurrent: () => boolean;
     /** Wait for a newer request, if any, to finish publishing its result. */
-    waitForSupersedingRequest: () => Promise<void>;
+    waitForNewer: () => Promise<void>;
+}
+
+export type SavedValue<T> = { found: false } | { found: true; value: T };
+
+export interface PollRun<T> {
+    cause: RunCause;
+    inputKey?: string;
+    key: string;
+    read?: () => SavedValue<T>;
+    signal?: AbortSignal;
+    work: (signal: AbortSignal) => Promise<T>;
+    write: (value: T) => void;
+}
+
+/** Throw an AbortError when an old run attempts to publish a result. */
+function assertCurrentRun(handle: RunHandle): void {
+    if (!handle.isCurrent() || handle.signal.aborted) {
+        throw new DOMException('The request was superseded', 'AbortError');
+    }
+}
+
+/** Check whether an error represents intentional request cancellation. */
+export function isAbortError(error: unknown): boolean {
+    return (
+        (error instanceof DOMException && error.name === 'AbortError') ||
+        (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
+    );
+}
+
+/** Read Retry-After saved at the HTTP response seam. */
+function getRetryAfterMs(error: unknown): number | undefined {
+    return typeof error === 'object' && error !== null ? retryAfterByError.get(error) : undefined;
 }
 
 /**
@@ -75,7 +119,7 @@ export interface PollingRequestHandle {
  * serialized request extras. Multiple React consumers of the same identity
  * share one timer and one active request generation.
  */
-export class PollingCoordinator {
+export class Poller {
     readonly #clearTimeout: (timer: TimerHandle) => void;
     readonly #entries = new Map<string, PollingEntry>();
     readonly #getVisibilityState: () => DocumentVisibilityState;
@@ -84,10 +128,11 @@ export class PollingCoordinator {
     readonly #random: () => number;
     readonly #setTimeout: (callback: () => void, delay: number) => TimerHandle;
     readonly #visibilityTarget?: Pick<Document, 'addEventListener' | 'removeEventListener'>;
+    readonly #owners = new Map<symbol, PollOwner>();
 
     #listeningForVisibility = false;
 
-    constructor(options: PollingCoordinatorOptions = {}) {
+    constructor(options: PollerOptions = {}) {
         this.#clearTimeout = options.clearTimeout ?? ((timer) => clearTimeout(timer));
         this.#getVisibilityState =
             options.getVisibilityState ??
@@ -113,6 +158,7 @@ export class PollingCoordinator {
         }
 
         const entry = this.#getOrCreateEntry(key);
+        const oldIntervalMs = entry.subscribers.size > 0 ? this.#getIntervalMs(entry) : undefined;
         if (entry.disposeTimer !== undefined) {
             this.#clearTimeout(entry.disposeTimer);
             entry.disposeTimer = undefined;
@@ -122,13 +168,16 @@ export class PollingCoordinator {
         entry.subscribers.set(subscriberId, { intervalMs, refresh });
         this.#startVisibilityListener();
 
-        if (
-            entry.subscribers.size === 1 &&
-            !entry.activeRequest &&
-            !entry.awaitingRequest &&
-            entry.timer === undefined
-        ) {
+        if (entry.subscribers.size === 1 && entry.state.kind === 'idle' && entry.timer === undefined) {
             this.#scheduleOrdinaryPoll(key, entry);
+        } else if (
+            entry.timer !== undefined &&
+            entry.failureCount === 0 &&
+            oldIntervalMs !== undefined &&
+            intervalMs < oldIntervalMs
+        ) {
+            const remaining = Math.max(0, (entry.nextRunAt ?? this.#now()) - this.#now());
+            this.#schedule(key, entry, Math.min(remaining, this.#withJitter(intervalMs)));
         }
 
         return () => {
@@ -143,76 +192,147 @@ export class PollingCoordinator {
                 if (entry.subscribers.size > 0) {
                     return;
                 }
+                if (entry.owners.size > 0) {
+                    return;
+                }
+                if (this.#entries.get(key) !== entry) {
+                    return;
+                }
 
-                entry.activeRequest?.controller.abort();
-                entry.activeRequest?.detachExternalSignal?.();
-                entry.activeRequest?.resolveCompletion();
+                if (entry.state.kind === 'running') {
+                    entry.state.run.controller.abort();
+                    entry.state.run.detachExternalSignal?.();
+                    entry.state.run.end();
+                }
                 this.#entries.delete(key);
                 this.#stopVisibilityListenerIfIdle();
             }, 0);
         };
     }
 
+    /** Start one render pass for a Suspense-safe owner. */
+    beginOwner(ownerId: symbol): void {
+        const owner = this.#getOrCreateOwner(ownerId);
+        owner.seenKeys.clear();
+    }
+
+    /** Keep a request alive while a rendered owner may still suspend. */
+    own(ownerId: symbol, key: string): void {
+        const owner = this.#getOrCreateOwner(ownerId);
+        owner.seenKeys.add(key);
+        const disposeTimer = owner.keyDisposeTimers.get(key);
+        if (disposeTimer !== undefined) {
+            this.#clearTimeout(disposeTimer);
+            owner.keyDisposeTimers.delete(key);
+        }
+        if (owner.keys.has(key)) {
+            return;
+        }
+        owner.keys.add(key);
+        this.#getOrCreateEntry(key).owners.add(ownerId);
+    }
+
+    /** Drop one key after the StrictMode remount window. */
+    release(ownerId: symbol, key: string): void {
+        const owner = this.#owners.get(ownerId);
+        if (!owner || owner.keyDisposeTimers.has(key)) {
+            return;
+        }
+        const timer = this.#setTimeout(() => {
+            owner.keyDisposeTimers.delete(key);
+            this.#dropOwnedKey(ownerId, owner, key);
+            this.#stopVisibilityListenerIfIdle();
+        }, 0);
+        owner.keyDisposeTimers.set(key, timer);
+    }
+
+    /** Mark a rendered owner as committed and cancel provisional cleanup. */
+    keepOwner(ownerId: symbol): void {
+        const owner = this.#owners.get(ownerId);
+        if (!owner) {
+            return;
+        }
+        for (const key of Array.from(owner.keys)) {
+            if (!owner.seenKeys.has(key)) {
+                this.#dropOwnedKey(ownerId, owner, key);
+            }
+        }
+        owner.mounted = true;
+        if (owner.disposeTimer !== undefined) {
+            this.#clearTimeout(owner.disposeTimer);
+            owner.disposeTimer = undefined;
+        }
+    }
+
+    /** Release an owner after the StrictMode remount window. */
+    releaseOwner(ownerId: symbol): void {
+        const owner = this.#owners.get(ownerId);
+        if (!owner || owner.disposeTimer !== undefined) {
+            return;
+        }
+        owner.mounted = false;
+        owner.disposeTimer = this.#setTimeout(() => this.#dropOwner(ownerId, owner), 0);
+    }
+
     /**
-     * Start a request associated with a polling identity.
+     * Run one request for a polling identity.
      *
-     * Dependency requests supersede and abort older work. Poll requests are
-     * expected to originate from the coordinator; if a racing poll arrives
-     * while another request is active, it is born aborted and cannot overwrite
-     * the current generation.
+     * Matching callers share one promise. Dependency runs replace older work,
+     * while a poll that arrives during a run leaves one follow-up refresh.
      */
-    startRequest(
-        key: string,
-        source: RequestSource,
-        externalSignal?: AbortSignal,
-        fingerprint?: string
-    ): PollingRequestHandle {
+    run<T>({ cause, inputKey, key, read, signal, work, write }: PollRun<T>): Promise<T> {
+        const entry = this.#entries.get(key);
+        const running = entry?.state.kind === 'running' ? entry.state.run : undefined;
+        if (running?.cause === cause && running.inputKey === inputKey && running.result) {
+            return running.result as Promise<T>;
+        }
+
+        const handle = this.#start(key, cause, signal, inputKey);
+        const result = this.#runWork({ cause, handle, read, work, write });
+        const state = this.#entries.get(key)?.state;
+        if (state?.kind === 'running' && handle.isCurrent()) {
+            state.run.result = result;
+        }
+        return result;
+    }
+
+    #start(key: string, cause: RunCause, externalSignal?: AbortSignal, inputKey?: string): RunHandle {
         const entry = this.#getOrCreateEntry(key);
 
-        if (entry.activeRequest) {
-            if (
-                fingerprint !== undefined &&
-                entry.activeRequest.fingerprint === fingerprint &&
-                entry.activeRequest.source === source
-            ) {
-                entry.activeRequest.consumers++;
-                return this.#createRequestHandle(key, entry.activeRequest);
-            }
-
-            if (source === 'poll') {
-                entry.trailingRefresh = true;
+        if (entry.state.kind === 'running') {
+            const running = entry.state.run;
+            if (cause === 'poll') {
+                entry.runAgain = true;
                 const abortedController = new AbortController();
                 abortedController.abort();
                 return {
                     signal: abortedController.signal,
                     finish: () => {},
                     isCurrent: () => false,
-                    waitForSupersedingRequest: () => this.#waitForSupersedingRequest(key, entry.generation),
+                    waitForNewer: () => this.#waitForNewer(key, entry.generation),
                 };
             }
-            entry.activeRequest.controller.abort();
-            entry.activeRequest.detachExternalSignal?.();
-            entry.activeRequest.resolveCompletion();
+            running.controller.abort();
+            running.detachExternalSignal?.();
+            running.end();
         }
 
         this.#clearTimer(entry);
-        entry.awaitingRequest = false;
         const generation = ++entry.generation;
         const controller = new AbortController();
-        let resolveCompletion = (): void => {};
-        const completion = new Promise<void>((resolve) => {
-            resolveCompletion = resolve;
+        let end = (): void => {};
+        const done = new Promise<void>((resolve) => {
+            end = resolve;
         });
-        const activeRequest: ActiveRequest = {
-            completion,
-            consumers: 1,
+        const activeRun: ActiveRun = {
+            cause,
             controller,
-            fingerprint,
+            done,
+            end,
             generation,
-            resolveCompletion,
-            source,
+            inputKey,
         };
-        entry.activeRequest = activeRequest;
+        entry.state = { kind: 'running', run: activeRun };
 
         if (externalSignal && typeof externalSignal.addEventListener === 'function') {
             if (externalSignal.aborted) {
@@ -220,49 +340,92 @@ export class PollingCoordinator {
             } else {
                 const abortFromExternalSignal = (): void => controller.abort(externalSignal.reason);
                 externalSignal.addEventListener('abort', abortFromExternalSignal, { once: true });
-                activeRequest.detachExternalSignal = () =>
+                activeRun.detachExternalSignal = () =>
                     externalSignal.removeEventListener('abort', abortFromExternalSignal);
             }
         }
 
-        return this.#createRequestHandle(key, activeRequest);
+        return this.#createRunHandle(key, activeRun);
     }
 
-    #createRequestHandle(key: string, activeRequest: ActiveRequest): PollingRequestHandle {
+    #createRunHandle(key: string, activeRun: ActiveRun): RunHandle {
         let finished = false;
         return {
-            signal: activeRequest.controller.signal,
+            signal: activeRun.controller.signal,
             finish: (outcome) => {
                 if (finished) {
                     return;
                 }
                 finished = true;
-                this.#finishRequest(key, activeRequest.generation, outcome);
+                this.#finishRequest(key, activeRun.generation, outcome);
             },
-            isCurrent: () => this.#entries.get(key)?.activeRequest?.generation === activeRequest.generation,
-            waitForSupersedingRequest: () => this.#waitForSupersedingRequest(key, activeRequest.generation),
+            isCurrent: () => {
+                const state = this.#entries.get(key)?.state;
+                return state?.kind === 'running' && state.run.generation === activeRun.generation;
+            },
+            waitForNewer: () => this.#waitForNewer(key, activeRun.generation),
         };
     }
 
-    /** Request an immediate refresh, coalescing it while the identity is busy. */
-    requestRefresh(key: string): void {
+    async #runWork<T>({
+        cause,
+        handle,
+        read,
+        work,
+        write,
+    }: {
+        cause: RunCause;
+        handle: RunHandle;
+        read?: () => SavedValue<T>;
+        work: (signal: AbortSignal) => Promise<T>;
+        write: (value: T) => void;
+    }): Promise<T> {
+        let outcome: RunOutcome = { status: 'success' };
+        try {
+            assertCurrentRun(handle);
+            const value = await work(handle.signal);
+            assertCurrentRun(handle);
+            write(value);
+            return value;
+        } catch (error) {
+            outcome = isAbortError(error)
+                ? { status: 'aborted' }
+                : { status: 'error', retryAfterMs: getRetryAfterMs(error) };
+
+            const previous = read?.();
+            if (isAbortError(error) && previous?.found) {
+                await handle.waitForNewer();
+                const latest = read?.();
+                return latest?.found ? latest.value : previous.value;
+            }
+            if (cause === 'poll' && previous?.found) {
+                return previous.value;
+            }
+            throw error;
+        } finally {
+            handle.finish(outcome);
+        }
+    }
+
+    /** Refresh now, or keep one refresh while busy. */
+    runNow(key: string): void {
         const entry = this.#entries.get(key);
         if (!entry || entry.subscribers.size === 0) {
             return;
         }
 
         if (this.#getVisibilityState() === 'hidden') {
-            entry.resumePending = true;
+            entry.runOnShow = true;
             return;
         }
 
-        if (entry.activeRequest || entry.awaitingRequest) {
-            entry.trailingRefresh = true;
+        if (entry.state.kind !== 'idle') {
+            entry.runAgain = true;
             return;
         }
 
         this.#clearTimer(entry);
-        entry.awaitingRequest = true;
+        entry.state = { kind: 'starting' };
         this.#getSubscriber(entry)?.refresh();
     }
 
@@ -273,10 +436,21 @@ export class PollingCoordinator {
             if (entry.disposeTimer !== undefined) {
                 this.#clearTimeout(entry.disposeTimer);
             }
-            entry.activeRequest?.controller.abort();
-            entry.activeRequest?.detachExternalSignal?.();
-            entry.activeRequest?.resolveCompletion();
+            if (entry.state.kind === 'running') {
+                entry.state.run.controller.abort();
+                entry.state.run.detachExternalSignal?.();
+                entry.state.run.end();
+            }
         }
+        for (const owner of this.#owners.values()) {
+            if (owner.disposeTimer !== undefined) {
+                this.#clearTimeout(owner.disposeTimer);
+            }
+            for (const timer of owner.keyDisposeTimers.values()) {
+                this.#clearTimeout(timer);
+            }
+        }
+        this.#owners.clear();
         this.#entries.clear();
         this.#stopVisibilityListenerIfIdle();
     }
@@ -286,61 +460,73 @@ export class PollingCoordinator {
         return this.#now();
     }
 
-    #finishRequest(key: string, generation: number, outcome: PollingRequestOutcome): void {
+    #finishRequest(key: string, generation: number, outcome: RunOutcome): void {
         const entry = this.#entries.get(key);
-        if (!entry || entry.activeRequest?.generation !== generation) {
+        if (!entry || entry.state.kind !== 'running' || entry.state.run.generation !== generation) {
             return;
         }
 
-        entry.activeRequest.consumers--;
-        if (entry.activeRequest.consumers > 0) {
-            return;
-        }
-
-        entry.activeRequest.detachExternalSignal?.();
-        entry.activeRequest.resolveCompletion();
-        entry.activeRequest = undefined;
+        entry.state.run.detachExternalSignal?.();
+        entry.state.run.end();
+        entry.state = { kind: 'idle' };
         if (entry.subscribers.size === 0) {
-            this.#entries.delete(key);
-            this.#stopVisibilityListenerIfIdle();
-            return;
-        }
-
-        if (outcome.status === 'aborted') {
-            return;
-        }
-
-        if (this.#getVisibilityState() === 'hidden') {
-            entry.resumePending = true;
+            if (entry.owners.size === 0) {
+                this.#entries.delete(key);
+                this.#stopVisibilityListenerIfIdle();
+            }
             return;
         }
 
         if (outcome.status === 'success') {
             entry.failureCount = 0;
-            if (entry.trailingRefresh || entry.resumePending) {
-                entry.trailingRefresh = false;
-                entry.resumePending = false;
-                this.requestRefresh(key);
+            entry.nextRunAt = undefined;
+        } else if (outcome.status === 'error') {
+            entry.failureCount += 1;
+            entry.runAgain = false;
+            const baseDelay = this.#getIntervalMs(entry);
+            const exponentialDelay = Math.min(baseDelay * 2 ** (entry.failureCount - 1), MAX_BACKOFF_MS);
+            const jitteredDelay = Math.min(this.#withJitter(exponentialDelay), MAX_BACKOFF_MS);
+            const backoffDelay = Math.max(jitteredDelay, outcome.retryAfterMs ?? 0);
+            this.#schedule(key, entry, backoffDelay);
+        }
+
+        if (this.#getVisibilityState() === 'hidden') {
+            entry.runOnShow = true;
+            return;
+        }
+
+        if (outcome.status === 'success') {
+            if (entry.runAgain || entry.runOnShow) {
+                entry.runAgain = false;
+                entry.runOnShow = false;
+                this.runNow(key);
                 return;
             }
             this.#scheduleOrdinaryPoll(key, entry);
             return;
         }
 
-        entry.failureCount += 1;
-        entry.trailingRefresh = false;
-        const baseDelay = this.#getIntervalMs(entry);
-        const exponentialDelay = Math.min(baseDelay * 2 ** (entry.failureCount - 1), MAX_BACKOFF_MS);
-        const backoffDelay = Math.max(this.#withJitter(exponentialDelay), outcome.retryAfterMs ?? 0);
-        this.#schedule(key, entry, backoffDelay);
+        if (outcome.status === 'aborted') {
+            if (entry.runAgain) {
+                entry.runAgain = false;
+                this.runNow(key);
+            } else {
+                this.#scheduleOrdinaryPoll(key, entry);
+            }
+        }
     }
 
-    async #waitForSupersedingRequest(key: string, generation: number): Promise<void> {
-        const activeRequest = this.#entries.get(key)?.activeRequest;
-        if (!activeRequest || activeRequest.generation === generation) {
-            return;
+    async #waitForNewer(key: string, generation: number): Promise<void> {
+        let seenGeneration = generation;
+        while (true) {
+            const state = this.#entries.get(key)?.state;
+            const activeRun = state?.kind === 'running' ? state.run : undefined;
+            if (!activeRun || activeRun.generation <= seenGeneration) {
+                return;
+            }
+            seenGeneration = activeRun.generation;
+            await activeRun.done;
         }
-        await activeRequest.completion;
     }
 
     #getIntervalMs(entry: PollingEntry): number {
@@ -351,12 +537,13 @@ export class PollingCoordinator {
         let entry = this.#entries.get(key);
         if (!entry) {
             entry = {
-                awaitingRequest: false,
                 failureCount: 0,
                 generation: 0,
-                resumePending: false,
+                owners: new Set(),
+                runAgain: false,
+                runOnShow: false,
+                state: { kind: 'idle' },
                 subscribers: new Map(),
-                trailingRefresh: false,
             };
             this.#entries.set(key, entry);
         }
@@ -367,26 +554,80 @@ export class PollingCoordinator {
         return Array.from(entry.subscribers.values()).sort((a, b) => a.intervalMs - b.intervalMs)[0];
     }
 
+    #getOrCreateOwner(ownerId: symbol): PollOwner {
+        let owner = this.#owners.get(ownerId);
+        if (!owner) {
+            const newOwner: PollOwner = {
+                keyDisposeTimers: new Map(),
+                keys: new Set(),
+                mounted: false,
+                seenKeys: new Set(),
+            };
+            owner = newOwner;
+            this.#owners.set(ownerId, newOwner);
+            newOwner.disposeTimer = this.#setTimeout(() => this.#dropOwner(ownerId, newOwner), 0);
+        }
+        return owner;
+    }
+
+    #dropOwnedKey(ownerId: symbol, owner: PollOwner, key: string): void {
+        owner.keys.delete(key);
+        const entry = this.#entries.get(key);
+        if (!entry) {
+            return;
+        }
+        entry.owners.delete(ownerId);
+        if (entry.owners.size > 0 || entry.subscribers.size > 0) {
+            return;
+        }
+        this.#clearTimer(entry);
+        if (entry.state.kind === 'running') {
+            entry.state.run.controller.abort();
+            entry.state.run.detachExternalSignal?.();
+            entry.state.run.end();
+        }
+        this.#entries.delete(key);
+    }
+
+    #dropOwner(ownerId: symbol, owner: PollOwner): void {
+        if (this.#owners.get(ownerId) !== owner || owner.mounted) {
+            return;
+        }
+        this.#owners.delete(ownerId);
+        for (const timer of owner.keyDisposeTimers.values()) {
+            this.#clearTimeout(timer);
+        }
+        for (const key of Array.from(owner.keys)) {
+            this.#dropOwnedKey(ownerId, owner, key);
+        }
+        this.#stopVisibilityListenerIfIdle();
+    }
+
     #scheduleOrdinaryPoll(key: string, entry: PollingEntry): void {
         this.#schedule(key, entry, this.#withJitter(this.#getIntervalMs(entry)));
     }
 
     #schedule(key: string, entry: PollingEntry, delay: number): void {
         this.#clearTimer(entry);
+        entry.nextRunAt = this.#now() + delay;
         if (this.#getVisibilityState() === 'hidden') {
-            entry.resumePending = true;
+            entry.runOnShow = true;
             return;
         }
         entry.timer = this.#setTimeout(() => {
             entry.timer = undefined;
-            this.requestRefresh(key);
+            entry.nextRunAt = undefined;
+            this.runNow(key);
         }, delay);
     }
 
-    #clearTimer(entry: PollingEntry): void {
+    #clearTimer(entry: PollingEntry, clearNextRun = true): void {
         if (entry.timer !== undefined) {
             this.#clearTimeout(entry.timer);
             entry.timer = undefined;
+        }
+        if (clearNextRun) {
+            entry.nextRunAt = undefined;
         }
     }
 
@@ -399,18 +640,23 @@ export class PollingCoordinator {
         const hidden = this.#getVisibilityState() === 'hidden';
         for (const [key, entry] of this.#entries) {
             if (hidden) {
-                entry.resumePending = entry.subscribers.size > 0;
+                entry.runOnShow = entry.subscribers.size > 0;
                 if (entry.timer !== undefined) {
-                    this.#clearTimer(entry);
+                    this.#clearTimer(entry, entry.failureCount === 0);
                 }
                 continue;
             }
 
-            if (!entry.resumePending || entry.subscribers.size === 0) {
+            if (!entry.runOnShow || entry.subscribers.size === 0) {
                 continue;
             }
-            entry.resumePending = false;
-            this.requestRefresh(key);
+            entry.runOnShow = false;
+            const delay = Math.max(0, (entry.nextRunAt ?? this.#now()) - this.#now());
+            if (delay > 0) {
+                this.#schedule(key, entry, delay);
+            } else {
+                this.runNow(key);
+            }
         }
     };
 
@@ -431,46 +677,67 @@ export class PollingCoordinator {
     }
 }
 
-const pollingCoordinator = new PollingCoordinator();
+const poller = new Poller();
 
 /**
  * Register fixed-delay polling for a request identity.
  *
  * `refresh` only invalidates the corresponding selector. Request lifecycle,
- * backpressure, retries, and cancellation remain owned by the coordinator.
+ * backpressure, retries, and cancellation remain owned by the poller.
  */
 export function usePolling(key: string, intervalSeconds: number | undefined, refresh: () => void): void {
     const refreshRef = useRef(refresh);
     refreshRef.current = refresh;
 
-    useEffect(
-        () => pollingCoordinator.subscribe(key, intervalSeconds, () => refreshRef.current()),
-        [key, intervalSeconds]
-    );
+    useEffect(() => poller.subscribe(key, intervalSeconds, () => refreshRef.current()), [key, intervalSeconds]);
 }
 
-/** Start a request using the production polling coordinator. */
-export function startPollingRequest(
-    key: string,
-    source: RequestSource,
-    externalSignal?: AbortSignal,
-    fingerprint?: string
-): PollingRequestHandle {
-    return pollingCoordinator.startRequest(key, source, externalSignal, fingerprint);
+/** Link a polling key to a Suspense-safe rendered owner. */
+export function ownPoll(ownerId: symbol | undefined, key: string): void {
+    if (ownerId) {
+        poller.own(ownerId, key);
+    }
 }
 
-/** Create a force key that identifies a coordinator-owned poll refresh. */
+/** Release one polling key after its hook unmounts or changes identity. */
+export function releasePoll(ownerId: symbol | undefined, key: string): void {
+    if (ownerId) {
+        poller.release(ownerId, key);
+    }
+}
+
+/** Start one render pass for a polling owner. */
+export function beginPollOwner(ownerId: symbol): void {
+    poller.beginOwner(ownerId);
+}
+
+/** Keep a polling owner after its render commits. */
+export function keepPollOwner(ownerId: symbol): void {
+    poller.keepOwner(ownerId);
+}
+
+/** Release a polling owner after its rendered tree unmounts. */
+export function releasePollOwner(ownerId: symbol): void {
+    poller.releaseOwner(ownerId);
+}
+
+/** Run one request using the production poller. */
+export function runPoll<T>(run: PollRun<T>): Promise<T> {
+    return poller.run(run);
+}
+
+/** Create a force key that identifies a poller-owned refresh. */
 export function createPollForceKey(): string {
     return `${POLL_FORCE_KEY_PREFIX}${globalThis.crypto?.randomUUID?.() ?? String(Math.random())}`;
 }
 
-/** Check whether a selector force key originated from the polling coordinator. */
+/** Check whether a selector force key originated from the poller. */
 export function isPollForceKey(forceKey: string | null | undefined): boolean {
     return forceKey?.startsWith(POLL_FORCE_KEY_PREFIX) ?? false;
 }
 
 /** Extract Retry-After as a non-negative delay in milliseconds. */
-export function parseRetryAfter(response: Response, now = pollingCoordinator.now()): number | undefined {
+export function parseRetryAfter(response: Response, now = poller.now()): number | undefined {
     const value = response.headers.get('Retry-After');
     if (!value) {
         return undefined;
@@ -488,30 +755,17 @@ export function parseRetryAfter(response: Response, now = pollingCoordinator.now
     return Math.max(0, retryAt - now);
 }
 
-/** Read Retry-After metadata attached at the HTTP response seam. */
-export function getRetryAfterMs(error: unknown): number | undefined {
-    return typeof error === 'object' && error !== null && 'retryAfterMs' in error
-        ? (error as { retryAfterMs?: number }).retryAfterMs
-        : undefined;
-}
-
-/** Throw an AbortError when a superseded request attempts to publish a result. */
-export function assertCurrentRequest(handle: PollingRequestHandle): void {
-    if (!handle.isCurrent() || handle.signal.aborted) {
-        throw new DOMException('The request was superseded', 'AbortError');
+/** Keep Retry-After beside an error without changing the error object. */
+export function markRetryAfter(error: unknown, response: Response): unknown {
+    const delay = parseRetryAfter(response);
+    if (delay !== undefined && typeof error === 'object' && error !== null) {
+        retryAfterByError.set(error, delay);
     }
-}
-
-/** Check whether an error represents intentional request cancellation. */
-export function isAbortError(error: unknown): boolean {
-    return (
-        (error instanceof DOMException && error.name === 'AbortError') ||
-        (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
-    );
+    return error;
 }
 
 /** Await a promise while preserving ownership of request cancellation. */
-export async function waitForAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+export async function waitOrAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
     if (!signal) {
         return promise;
     }
@@ -540,5 +794,5 @@ export async function waitForAbort<T>(promise: Promise<T>, signal?: AbortSignal)
 
 /** Clear production polling state. Intended for test isolation. */
 export function clearPolling_TEST(): void {
-    pollingCoordinator.clear();
+    poller.clear();
 }

--- a/packages/dara-core/js/shared/interactivity/polling.tsx
+++ b/packages/dara-core/js/shared/interactivity/polling.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useId, useLayoutEffect } from 'react';
+
+import { useLatestRef } from '@darajs/ui-utils';
 
 const DEFAULT_JITTER_RATIO = 0.1;
 const MAX_BACKOFF_MS = 60_000;
@@ -31,7 +33,7 @@ interface PollingEntry {
     failureCount: number;
     generation: number;
     nextRunAt?: number;
-    owners: Set<symbol>;
+    owners: Set<string>;
     runAgain: boolean;
     runOnShow: boolean;
     state: RunState;
@@ -51,10 +53,14 @@ interface PollerOptions {
 
 interface PollOwner {
     disposeTimer?: TimerHandle;
-    keyDisposeTimers: Map<string, TimerHandle>;
+    hooks: Map<string, string>;
+    renderKeys: Set<string>;
+    timers: Map<string, TimerHandle>;
+}
+
+export interface PollScope {
+    id: string;
     keys: Set<string>;
-    mounted: boolean;
-    seenKeys: Set<string>;
 }
 
 type RunOutcome =
@@ -128,7 +134,7 @@ export class Poller {
     readonly #random: () => number;
     readonly #setTimeout: (callback: () => void, delay: number) => TimerHandle;
     readonly #visibilityTarget?: Pick<Document, 'addEventListener' | 'removeEventListener'>;
-    readonly #owners = new Map<symbol, PollOwner>();
+    readonly #owners = new Map<string, PollOwner>();
 
     #listeningForVisibility = false;
 
@@ -210,67 +216,81 @@ export class Poller {
         };
     }
 
-    /** Start one render pass for a Suspense-safe owner. */
-    beginOwner(ownerId: symbol): void {
+    /** Apply the polling keys collected by one committed owner render. */
+    commitOwner(ownerId: string, keys: ReadonlySet<string>): void {
         const owner = this.#getOrCreateOwner(ownerId);
-        owner.seenKeys.clear();
-    }
-
-    /** Keep a request alive while a rendered owner may still suspend. */
-    own(ownerId: symbol, key: string): void {
-        const owner = this.#getOrCreateOwner(ownerId);
-        owner.seenKeys.add(key);
-        const disposeTimer = owner.keyDisposeTimers.get(key);
-        if (disposeTimer !== undefined) {
-            this.#clearTimeout(disposeTimer);
-            owner.keyDisposeTimers.delete(key);
-        }
-        if (owner.keys.has(key)) {
-            return;
-        }
-        owner.keys.add(key);
-        this.#getOrCreateEntry(key).owners.add(ownerId);
-    }
-
-    /** Drop one key after the StrictMode remount window. */
-    release(ownerId: symbol, key: string): void {
-        const owner = this.#owners.get(ownerId);
-        if (!owner || owner.keyDisposeTimers.has(key)) {
-            return;
-        }
-        const timer = this.#setTimeout(() => {
-            owner.keyDisposeTimers.delete(key);
-            this.#dropOwnedKey(ownerId, owner, key);
-            this.#stopVisibilityListenerIfIdle();
-        }, 0);
-        owner.keyDisposeTimers.set(key, timer);
-    }
-
-    /** Mark a rendered owner as committed and cancel provisional cleanup. */
-    keepOwner(ownerId: symbol): void {
-        const owner = this.#owners.get(ownerId);
-        if (!owner) {
-            return;
-        }
-        for (const key of Array.from(owner.keys)) {
-            if (!owner.seenKeys.has(key)) {
-                this.#dropOwnedKey(ownerId, owner, key);
-            }
-        }
-        owner.mounted = true;
         if (owner.disposeTimer !== undefined) {
             this.#clearTimeout(owner.disposeTimer);
             owner.disposeTimer = undefined;
         }
+
+        // Add the new render before dropping the old one. A rerender must not
+        // leave a live request without an owner between layout effects.
+        const nextRenderKeys = new Set<string>();
+        for (const key of keys) {
+            this.#getOrCreateEntry(key).owners.add(ownerId);
+            if (!this.#hasHookForKey(owner, key)) {
+                nextRenderKeys.add(key);
+            }
+        }
+
+        const oldRenderKeys = owner.renderKeys;
+        owner.renderKeys = nextRenderKeys;
+        for (const key of oldRenderKeys) {
+            if (!nextRenderKeys.has(key) && !this.#hasHookForKey(owner, key)) {
+                this.#dropOwnedKey(ownerId, key);
+            }
+        }
     }
 
-    /** Release an owner after the StrictMode remount window. */
-    releaseOwner(ownerId: symbol): void {
+    /** Keep one key after its hook commits. */
+    mountKey(ownerId: string, hookId: string, key: string): void {
+        const owner = this.#getOrCreateOwner(ownerId);
+        if (owner.disposeTimer !== undefined) {
+            this.#clearTimeout(owner.disposeTimer);
+            owner.disposeTimer = undefined;
+        }
+        const timer = owner.timers.get(hookId);
+        if (timer !== undefined) {
+            this.#clearTimeout(timer);
+            owner.timers.delete(hookId);
+        }
+
+        const oldKey = owner.hooks.get(hookId);
+        owner.hooks.set(hookId, key);
+        owner.renderKeys.delete(key);
+        this.#getOrCreateEntry(key).owners.add(ownerId);
+        if (oldKey !== undefined && oldKey !== key && !this.#ownerHasKey(owner, oldKey)) {
+            this.#dropOwnedKey(ownerId, oldKey);
+        }
+    }
+
+    /** Drop a committed hook key after the StrictMode remount window. */
+    unmountKey(ownerId: string, hookId: string, key: string): void {
+        const owner = this.#owners.get(ownerId);
+        if (!owner || owner.timers.has(hookId)) {
+            return;
+        }
+        const timer = this.#setTimeout(() => {
+            owner.timers.delete(hookId);
+            if (owner.hooks.get(hookId) !== key) {
+                return;
+            }
+            owner.hooks.delete(hookId);
+            if (!this.#ownerHasKey(owner, key)) {
+                this.#dropOwnedKey(ownerId, key);
+            }
+            this.#stopVisibilityListenerIfIdle();
+        }, 0);
+        owner.timers.set(hookId, timer);
+    }
+
+    /** Release a rendered owner after the StrictMode remount window. */
+    releaseOwner(ownerId: string): void {
         const owner = this.#owners.get(ownerId);
         if (!owner || owner.disposeTimer !== undefined) {
             return;
         }
-        owner.mounted = false;
         owner.disposeTimer = this.#setTimeout(() => this.#dropOwner(ownerId, owner), 0);
     }
 
@@ -302,6 +322,8 @@ export class Poller {
         if (entry.state.kind === 'running') {
             const running = entry.state.run;
             if (cause === 'poll') {
+                // A slow poll must finish. Keep one later run instead of
+                // stopping work on every tick.
                 entry.runAgain = true;
                 const abortedController = new AbortController();
                 abortedController.abort();
@@ -394,6 +416,8 @@ export class Poller {
 
             const previous = read?.();
             if (isAbortError(error) && previous?.found) {
+                // A replaced selector still owns a Recoil promise. Wait until
+                // every newer run publishes before returning its value.
                 await handle.waitForNewer();
                 const latest = read?.();
                 return latest?.found ? latest.value : previous.value;
@@ -446,7 +470,7 @@ export class Poller {
             if (owner.disposeTimer !== undefined) {
                 this.#clearTimeout(owner.disposeTimer);
             }
-            for (const timer of owner.keyDisposeTimers.values()) {
+            for (const timer of owner.timers.values()) {
                 this.#clearTimeout(timer);
             }
         }
@@ -491,6 +515,8 @@ export class Poller {
         }
 
         if (this.#getVisibilityState() === 'hidden') {
+            // Keep the due time so Retry-After and backoff still hold when the
+            // tab becomes visible.
             entry.runOnShow = true;
             return;
         }
@@ -554,24 +580,21 @@ export class Poller {
         return Array.from(entry.subscribers.values()).sort((a, b) => a.intervalMs - b.intervalMs)[0];
     }
 
-    #getOrCreateOwner(ownerId: symbol): PollOwner {
+    #getOrCreateOwner(ownerId: string): PollOwner {
         let owner = this.#owners.get(ownerId);
         if (!owner) {
             const newOwner: PollOwner = {
-                keyDisposeTimers: new Map(),
-                keys: new Set(),
-                mounted: false,
-                seenKeys: new Set(),
+                hooks: new Map(),
+                renderKeys: new Set(),
+                timers: new Map(),
             };
             owner = newOwner;
             this.#owners.set(ownerId, newOwner);
-            newOwner.disposeTimer = this.#setTimeout(() => this.#dropOwner(ownerId, newOwner), 0);
         }
         return owner;
     }
 
-    #dropOwnedKey(ownerId: symbol, owner: PollOwner, key: string): void {
-        owner.keys.delete(key);
+    #dropOwnedKey(ownerId: string, key: string): void {
         const entry = this.#entries.get(key);
         if (!entry) {
             return;
@@ -589,18 +612,27 @@ export class Poller {
         this.#entries.delete(key);
     }
 
-    #dropOwner(ownerId: symbol, owner: PollOwner): void {
-        if (this.#owners.get(ownerId) !== owner || owner.mounted) {
+    #dropOwner(ownerId: string, owner: PollOwner): void {
+        if (this.#owners.get(ownerId) !== owner) {
             return;
         }
         this.#owners.delete(ownerId);
-        for (const timer of owner.keyDisposeTimers.values()) {
+        for (const timer of owner.timers.values()) {
             this.#clearTimeout(timer);
         }
-        for (const key of Array.from(owner.keys)) {
-            this.#dropOwnedKey(ownerId, owner, key);
+        const keys = new Set([...owner.renderKeys, ...owner.hooks.values()]);
+        for (const key of keys) {
+            this.#dropOwnedKey(ownerId, key);
         }
         this.#stopVisibilityListenerIfIdle();
+    }
+
+    #hasHookForKey(owner: PollOwner, key: string): boolean {
+        return Array.from(owner.hooks.values()).some((hookKey) => hookKey === key);
+    }
+
+    #ownerHasKey(owner: PollOwner, key: string): boolean {
+        return owner.renderKeys.has(key) || this.#hasHookForKey(owner, key);
     }
 
     #scheduleOrdinaryPoll(key: string, entry: PollingEntry): void {
@@ -686,39 +718,51 @@ const poller = new Poller();
  * backpressure, retries, and cancellation remain owned by the poller.
  */
 export function usePolling(key: string, intervalSeconds: number | undefined, refresh: () => void): void {
-    const refreshRef = useRef(refresh);
-    refreshRef.current = refresh;
+    const refreshRef = useLatestRef(refresh);
 
-    useEffect(() => poller.subscribe(key, intervalSeconds, () => refreshRef.current()), [key, intervalSeconds]);
+    useEffect(
+        () => poller.subscribe(key, intervalSeconds, () => refreshRef.current()),
+        [intervalSeconds, key, refreshRef]
+    );
 }
 
-/** Link a polling key to a Suspense-safe rendered owner. */
-export function ownPoll(ownerId: symbol | undefined, key: string): void {
-    if (ownerId) {
-        poller.own(ownerId, key);
-    }
+/**
+ * Create a render-local list of polling keys and apply it after commit.
+ *
+ * Descendants may suspend before their own effects run. They add keys to this
+ * detached set during render; only the owner's layout effect changes Poller.
+ */
+export function usePollScope(): PollScope {
+    const id = useId();
+    const keys = new Set<string>();
+
+    useLayoutEffect(() => {
+        poller.commitOwner(id, keys);
+    });
+    useLayoutEffect(() => () => poller.releaseOwner(id), [id]);
+
+    return { id, keys };
 }
 
-/** Release one polling key after its hook unmounts or changes identity. */
-export function releasePoll(ownerId: symbol | undefined, key: string): void {
-    if (ownerId) {
-        poller.release(ownerId, key);
-    }
-}
+/**
+ * Keep one request key for a rendered hook.
+ *
+ * The render-local key lets a committed parent own work while this hook is
+ * suspended. Its passive effect stays mounted when Suspense hides an existing
+ * tree, so a dependency refresh does not lose ownership of the active request.
+ */
+export function usePollKey(scope: PollScope | undefined, key: string): void {
+    const hookId = useId();
+    scope?.keys.add(key);
+    const ownerId = scope?.id;
 
-/** Start one render pass for a polling owner. */
-export function beginPollOwner(ownerId: symbol): void {
-    poller.beginOwner(ownerId);
-}
-
-/** Keep a polling owner after its render commits. */
-export function keepPollOwner(ownerId: symbol): void {
-    poller.keepOwner(ownerId);
-}
-
-/** Release a polling owner after its rendered tree unmounts. */
-export function releasePollOwner(ownerId: symbol): void {
-    poller.releaseOwner(ownerId);
+    useEffect(() => {
+        if (!ownerId) {
+            return;
+        }
+        poller.mountKey(ownerId, hookId, key);
+        return () => poller.unmountKey(ownerId, hookId, key);
+    }, [hookId, key, ownerId]);
 }
 
 /** Run one request using the production poller. */

--- a/packages/dara-core/js/shared/interactivity/polling.tsx
+++ b/packages/dara-core/js/shared/interactivity/polling.tsx
@@ -1,0 +1,544 @@
+import { useEffect, useRef } from 'react';
+
+const DEFAULT_JITTER_RATIO = 0.1;
+const MAX_BACKOFF_MS = 60_000;
+const POLL_FORCE_KEY_PREFIX = '__dara_poll__:';
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+type RequestSource = 'dependency' | 'poll';
+
+interface PollingSubscriber {
+    intervalMs: number;
+    refresh: () => void;
+}
+
+interface ActiveRequest {
+    completion: Promise<void>;
+    consumers: number;
+    controller: AbortController;
+    detachExternalSignal?: () => void;
+    fingerprint?: string;
+    generation: number;
+    resolveCompletion: () => void;
+    source: RequestSource;
+}
+
+interface PollingEntry {
+    activeRequest?: ActiveRequest;
+    awaitingRequest: boolean;
+    disposeTimer?: TimerHandle;
+    failureCount: number;
+    generation: number;
+    resumePending: boolean;
+    subscribers: Map<symbol, PollingSubscriber>;
+    timer?: TimerHandle;
+    trailingRefresh: boolean;
+}
+
+interface PollingCoordinatorOptions {
+    clearTimeout?: (timer: TimerHandle) => void;
+    getVisibilityState?: () => DocumentVisibilityState;
+    jitterRatio?: number;
+    now?: () => number;
+    random?: () => number;
+    setTimeout?: (callback: () => void, delay: number) => TimerHandle;
+    visibilityTarget?: Pick<Document, 'addEventListener' | 'removeEventListener'>;
+}
+
+export type PollingRequestOutcome =
+    | {
+          status: 'aborted';
+      }
+    | {
+          status: 'success';
+      }
+    | {
+          retryAfterMs?: number;
+          status: 'error';
+      };
+
+export interface PollingRequestHandle {
+    /** AbortSignal owned by the polling coordinator for this request generation. */
+    signal: AbortSignal;
+    /** Complete this request and update polling cadence if it is still current. */
+    finish: (outcome: PollingRequestOutcome) => void;
+    /** Whether this request is still the newest request for its polling identity. */
+    isCurrent: () => boolean;
+    /** Wait for a newer request, if any, to finish publishing its result. */
+    waitForSupersedingRequest: () => Promise<void>;
+}
+
+/**
+ * Coordinates non-overlapping, fixed-delay polling for request identities.
+ *
+ * A request identity includes the rendered variable/component identity and its
+ * serialized request extras. Multiple React consumers of the same identity
+ * share one timer and one active request generation.
+ */
+export class PollingCoordinator {
+    readonly #clearTimeout: (timer: TimerHandle) => void;
+    readonly #entries = new Map<string, PollingEntry>();
+    readonly #getVisibilityState: () => DocumentVisibilityState;
+    readonly #jitterRatio: number;
+    readonly #now: () => number;
+    readonly #random: () => number;
+    readonly #setTimeout: (callback: () => void, delay: number) => TimerHandle;
+    readonly #visibilityTarget?: Pick<Document, 'addEventListener' | 'removeEventListener'>;
+
+    #listeningForVisibility = false;
+
+    constructor(options: PollingCoordinatorOptions = {}) {
+        this.#clearTimeout = options.clearTimeout ?? ((timer) => clearTimeout(timer));
+        this.#getVisibilityState =
+            options.getVisibilityState ??
+            (() => (typeof document === 'undefined' ? 'visible' : document.visibilityState));
+        this.#jitterRatio = options.jitterRatio ?? DEFAULT_JITTER_RATIO;
+        this.#now = options.now ?? (() => Date.now());
+        this.#random = options.random ?? (() => Math.random());
+        this.#setTimeout = options.setTimeout ?? ((callback, delay) => setTimeout(callback, delay));
+        this.#visibilityTarget = options.visibilityTarget ?? (typeof document === 'undefined' ? undefined : document);
+    }
+
+    /**
+     * Register one rendered polling consumer.
+     *
+     * The returned cleanup releases the consumer. The final cleanup aborts the
+     * owned request on the next macrotask so React StrictMode can immediately
+     * reacquire the same identity without cancelling useful work.
+     */
+    subscribe(key: string, intervalSeconds: number | undefined, refresh: () => void): () => void {
+        const intervalMs = (intervalSeconds ?? 0) * 1000;
+        if (!Number.isFinite(intervalMs) || !(intervalMs > 0)) {
+            return () => {};
+        }
+
+        const entry = this.#getOrCreateEntry(key);
+        if (entry.disposeTimer !== undefined) {
+            this.#clearTimeout(entry.disposeTimer);
+            entry.disposeTimer = undefined;
+        }
+
+        const subscriberId = Symbol(key);
+        entry.subscribers.set(subscriberId, { intervalMs, refresh });
+        this.#startVisibilityListener();
+
+        if (
+            entry.subscribers.size === 1 &&
+            !entry.activeRequest &&
+            !entry.awaitingRequest &&
+            entry.timer === undefined
+        ) {
+            this.#scheduleOrdinaryPoll(key, entry);
+        }
+
+        return () => {
+            entry.subscribers.delete(subscriberId);
+            if (entry.subscribers.size > 0) {
+                return;
+            }
+
+            this.#clearTimer(entry);
+            entry.disposeTimer = this.#setTimeout(() => {
+                entry.disposeTimer = undefined;
+                if (entry.subscribers.size > 0) {
+                    return;
+                }
+
+                entry.activeRequest?.controller.abort();
+                entry.activeRequest?.detachExternalSignal?.();
+                entry.activeRequest?.resolveCompletion();
+                this.#entries.delete(key);
+                this.#stopVisibilityListenerIfIdle();
+            }, 0);
+        };
+    }
+
+    /**
+     * Start a request associated with a polling identity.
+     *
+     * Dependency requests supersede and abort older work. Poll requests are
+     * expected to originate from the coordinator; if a racing poll arrives
+     * while another request is active, it is born aborted and cannot overwrite
+     * the current generation.
+     */
+    startRequest(
+        key: string,
+        source: RequestSource,
+        externalSignal?: AbortSignal,
+        fingerprint?: string
+    ): PollingRequestHandle {
+        const entry = this.#getOrCreateEntry(key);
+
+        if (entry.activeRequest) {
+            if (
+                fingerprint !== undefined &&
+                entry.activeRequest.fingerprint === fingerprint &&
+                entry.activeRequest.source === source
+            ) {
+                entry.activeRequest.consumers++;
+                return this.#createRequestHandle(key, entry.activeRequest);
+            }
+
+            if (source === 'poll') {
+                entry.trailingRefresh = true;
+                const abortedController = new AbortController();
+                abortedController.abort();
+                return {
+                    signal: abortedController.signal,
+                    finish: () => {},
+                    isCurrent: () => false,
+                    waitForSupersedingRequest: () => this.#waitForSupersedingRequest(key, entry.generation),
+                };
+            }
+            entry.activeRequest.controller.abort();
+            entry.activeRequest.detachExternalSignal?.();
+            entry.activeRequest.resolveCompletion();
+        }
+
+        this.#clearTimer(entry);
+        entry.awaitingRequest = false;
+        const generation = ++entry.generation;
+        const controller = new AbortController();
+        let resolveCompletion = (): void => {};
+        const completion = new Promise<void>((resolve) => {
+            resolveCompletion = resolve;
+        });
+        const activeRequest: ActiveRequest = {
+            completion,
+            consumers: 1,
+            controller,
+            fingerprint,
+            generation,
+            resolveCompletion,
+            source,
+        };
+        entry.activeRequest = activeRequest;
+
+        if (externalSignal && typeof externalSignal.addEventListener === 'function') {
+            if (externalSignal.aborted) {
+                controller.abort(externalSignal.reason);
+            } else {
+                const abortFromExternalSignal = (): void => controller.abort(externalSignal.reason);
+                externalSignal.addEventListener('abort', abortFromExternalSignal, { once: true });
+                activeRequest.detachExternalSignal = () =>
+                    externalSignal.removeEventListener('abort', abortFromExternalSignal);
+            }
+        }
+
+        return this.#createRequestHandle(key, activeRequest);
+    }
+
+    #createRequestHandle(key: string, activeRequest: ActiveRequest): PollingRequestHandle {
+        let finished = false;
+        return {
+            signal: activeRequest.controller.signal,
+            finish: (outcome) => {
+                if (finished) {
+                    return;
+                }
+                finished = true;
+                this.#finishRequest(key, activeRequest.generation, outcome);
+            },
+            isCurrent: () => this.#entries.get(key)?.activeRequest?.generation === activeRequest.generation,
+            waitForSupersedingRequest: () => this.#waitForSupersedingRequest(key, activeRequest.generation),
+        };
+    }
+
+    /** Request an immediate refresh, coalescing it while the identity is busy. */
+    requestRefresh(key: string): void {
+        const entry = this.#entries.get(key);
+        if (!entry || entry.subscribers.size === 0) {
+            return;
+        }
+
+        if (this.#getVisibilityState() === 'hidden') {
+            entry.resumePending = true;
+            return;
+        }
+
+        if (entry.activeRequest || entry.awaitingRequest) {
+            entry.trailingRefresh = true;
+            return;
+        }
+
+        this.#clearTimer(entry);
+        entry.awaitingRequest = true;
+        this.#getSubscriber(entry)?.refresh();
+    }
+
+    /** Abort and remove every polling identity. Intended for test isolation. */
+    clear(): void {
+        for (const entry of this.#entries.values()) {
+            this.#clearTimer(entry);
+            if (entry.disposeTimer !== undefined) {
+                this.#clearTimeout(entry.disposeTimer);
+            }
+            entry.activeRequest?.controller.abort();
+            entry.activeRequest?.detachExternalSignal?.();
+            entry.activeRequest?.resolveCompletion();
+        }
+        this.#entries.clear();
+        this.#stopVisibilityListenerIfIdle();
+    }
+
+    /** Current time according to the injected clock. */
+    now(): number {
+        return this.#now();
+    }
+
+    #finishRequest(key: string, generation: number, outcome: PollingRequestOutcome): void {
+        const entry = this.#entries.get(key);
+        if (!entry || entry.activeRequest?.generation !== generation) {
+            return;
+        }
+
+        entry.activeRequest.consumers--;
+        if (entry.activeRequest.consumers > 0) {
+            return;
+        }
+
+        entry.activeRequest.detachExternalSignal?.();
+        entry.activeRequest.resolveCompletion();
+        entry.activeRequest = undefined;
+        if (entry.subscribers.size === 0) {
+            this.#entries.delete(key);
+            this.#stopVisibilityListenerIfIdle();
+            return;
+        }
+
+        if (outcome.status === 'aborted') {
+            return;
+        }
+
+        if (this.#getVisibilityState() === 'hidden') {
+            entry.resumePending = true;
+            return;
+        }
+
+        if (outcome.status === 'success') {
+            entry.failureCount = 0;
+            if (entry.trailingRefresh || entry.resumePending) {
+                entry.trailingRefresh = false;
+                entry.resumePending = false;
+                this.requestRefresh(key);
+                return;
+            }
+            this.#scheduleOrdinaryPoll(key, entry);
+            return;
+        }
+
+        entry.failureCount += 1;
+        entry.trailingRefresh = false;
+        const baseDelay = this.#getIntervalMs(entry);
+        const exponentialDelay = Math.min(baseDelay * 2 ** (entry.failureCount - 1), MAX_BACKOFF_MS);
+        const backoffDelay = Math.max(this.#withJitter(exponentialDelay), outcome.retryAfterMs ?? 0);
+        this.#schedule(key, entry, backoffDelay);
+    }
+
+    async #waitForSupersedingRequest(key: string, generation: number): Promise<void> {
+        const activeRequest = this.#entries.get(key)?.activeRequest;
+        if (!activeRequest || activeRequest.generation === generation) {
+            return;
+        }
+        await activeRequest.completion;
+    }
+
+    #getIntervalMs(entry: PollingEntry): number {
+        return Math.min(...Array.from(entry.subscribers.values(), (subscriber) => subscriber.intervalMs));
+    }
+
+    #getOrCreateEntry(key: string): PollingEntry {
+        let entry = this.#entries.get(key);
+        if (!entry) {
+            entry = {
+                awaitingRequest: false,
+                failureCount: 0,
+                generation: 0,
+                resumePending: false,
+                subscribers: new Map(),
+                trailingRefresh: false,
+            };
+            this.#entries.set(key, entry);
+        }
+        return entry;
+    }
+
+    #getSubscriber(entry: PollingEntry): PollingSubscriber | undefined {
+        return Array.from(entry.subscribers.values()).sort((a, b) => a.intervalMs - b.intervalMs)[0];
+    }
+
+    #scheduleOrdinaryPoll(key: string, entry: PollingEntry): void {
+        this.#schedule(key, entry, this.#withJitter(this.#getIntervalMs(entry)));
+    }
+
+    #schedule(key: string, entry: PollingEntry, delay: number): void {
+        this.#clearTimer(entry);
+        if (this.#getVisibilityState() === 'hidden') {
+            entry.resumePending = true;
+            return;
+        }
+        entry.timer = this.#setTimeout(() => {
+            entry.timer = undefined;
+            this.requestRefresh(key);
+        }, delay);
+    }
+
+    #clearTimer(entry: PollingEntry): void {
+        if (entry.timer !== undefined) {
+            this.#clearTimeout(entry.timer);
+            entry.timer = undefined;
+        }
+    }
+
+    #withJitter(delay: number): number {
+        const multiplier = 1 - this.#jitterRatio + this.#random() * this.#jitterRatio * 2;
+        return Math.max(0, delay * multiplier);
+    }
+
+    readonly #handleVisibilityChange = (): void => {
+        const hidden = this.#getVisibilityState() === 'hidden';
+        for (const [key, entry] of this.#entries) {
+            if (hidden) {
+                entry.resumePending = entry.subscribers.size > 0;
+                if (entry.timer !== undefined) {
+                    this.#clearTimer(entry);
+                }
+                continue;
+            }
+
+            if (!entry.resumePending || entry.subscribers.size === 0) {
+                continue;
+            }
+            entry.resumePending = false;
+            this.requestRefresh(key);
+        }
+    };
+
+    #startVisibilityListener(): void {
+        if (this.#listeningForVisibility || !this.#visibilityTarget) {
+            return;
+        }
+        this.#visibilityTarget.addEventListener('visibilitychange', this.#handleVisibilityChange);
+        this.#listeningForVisibility = true;
+    }
+
+    #stopVisibilityListenerIfIdle(): void {
+        if (!this.#listeningForVisibility || this.#entries.size > 0 || !this.#visibilityTarget) {
+            return;
+        }
+        this.#visibilityTarget.removeEventListener('visibilitychange', this.#handleVisibilityChange);
+        this.#listeningForVisibility = false;
+    }
+}
+
+const pollingCoordinator = new PollingCoordinator();
+
+/**
+ * Register fixed-delay polling for a request identity.
+ *
+ * `refresh` only invalidates the corresponding selector. Request lifecycle,
+ * backpressure, retries, and cancellation remain owned by the coordinator.
+ */
+export function usePolling(key: string, intervalSeconds: number | undefined, refresh: () => void): void {
+    const refreshRef = useRef(refresh);
+    refreshRef.current = refresh;
+
+    useEffect(
+        () => pollingCoordinator.subscribe(key, intervalSeconds, () => refreshRef.current()),
+        [key, intervalSeconds]
+    );
+}
+
+/** Start a request using the production polling coordinator. */
+export function startPollingRequest(
+    key: string,
+    source: RequestSource,
+    externalSignal?: AbortSignal,
+    fingerprint?: string
+): PollingRequestHandle {
+    return pollingCoordinator.startRequest(key, source, externalSignal, fingerprint);
+}
+
+/** Create a force key that identifies a coordinator-owned poll refresh. */
+export function createPollForceKey(): string {
+    return `${POLL_FORCE_KEY_PREFIX}${globalThis.crypto?.randomUUID?.() ?? String(Math.random())}`;
+}
+
+/** Check whether a selector force key originated from the polling coordinator. */
+export function isPollForceKey(forceKey: string | null | undefined): boolean {
+    return forceKey?.startsWith(POLL_FORCE_KEY_PREFIX) ?? false;
+}
+
+/** Extract Retry-After as a non-negative delay in milliseconds. */
+export function parseRetryAfter(response: Response, now = pollingCoordinator.now()): number | undefined {
+    const value = response.headers.get('Retry-After');
+    if (!value) {
+        return undefined;
+    }
+
+    const seconds = Number(value);
+    if (Number.isFinite(seconds) && seconds >= 0) {
+        return seconds * 1000;
+    }
+
+    const retryAt = Date.parse(value);
+    if (Number.isNaN(retryAt)) {
+        return undefined;
+    }
+    return Math.max(0, retryAt - now);
+}
+
+/** Read Retry-After metadata attached at the HTTP response seam. */
+export function getRetryAfterMs(error: unknown): number | undefined {
+    return typeof error === 'object' && error !== null && 'retryAfterMs' in error
+        ? (error as { retryAfterMs?: number }).retryAfterMs
+        : undefined;
+}
+
+/** Throw an AbortError when a superseded request attempts to publish a result. */
+export function assertCurrentRequest(handle: PollingRequestHandle): void {
+    if (!handle.isCurrent() || handle.signal.aborted) {
+        throw new DOMException('The request was superseded', 'AbortError');
+    }
+}
+
+/** Check whether an error represents intentional request cancellation. */
+export function isAbortError(error: unknown): boolean {
+    return (
+        (error instanceof DOMException && error.name === 'AbortError') ||
+        (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
+    );
+}
+
+/** Await a promise while preserving ownership of request cancellation. */
+export async function waitForAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+    if (!signal) {
+        return promise;
+    }
+    if (signal.aborted) {
+        throw new DOMException('The request was aborted', 'AbortError');
+    }
+
+    return new Promise<T>((resolve, reject) => {
+        const abort = (): void => {
+            signal.removeEventListener('abort', abort);
+            reject(new DOMException('The request was aborted', 'AbortError'));
+        };
+        signal.addEventListener('abort', abort, { once: true });
+        promise.then(
+            (value) => {
+                signal.removeEventListener('abort', abort);
+                resolve(value);
+            },
+            (error: unknown) => {
+                signal.removeEventListener('abort', abort);
+                reject(error);
+            }
+        );
+    });
+}
+
+/** Clear production polling state. Intended for test isolation. */
+export function clearPolling_TEST(): void {
+    pollingCoordinator.clear();
+}

--- a/packages/dara-core/js/shared/interactivity/polling.tsx
+++ b/packages/dara-core/js/shared/interactivity/polling.tsx
@@ -10,7 +10,7 @@ const retryAfterByError = new WeakMap<object, number>();
 type TimerHandle = ReturnType<typeof setTimeout>;
 type RunCause = 'dependency' | 'poll';
 
-interface PollingSubscriber {
+interface Subscriber {
     intervalMs: number;
     refresh: () => void;
 }
@@ -28,7 +28,7 @@ interface ActiveRun {
 
 type RunState = { kind: 'idle' } | { kind: 'running'; run: ActiveRun } | { kind: 'starting' };
 
-interface PollingEntry {
+interface Entry {
     disposeTimer?: TimerHandle;
     failureCount: number;
     generation: number;
@@ -37,7 +37,7 @@ interface PollingEntry {
     runAgain: boolean;
     runOnShow: boolean;
     state: RunState;
-    subscribers: Map<symbol, PollingSubscriber>;
+    subscribers: Map<symbol, Subscriber>;
     timer?: TimerHandle;
 }
 
@@ -52,6 +52,7 @@ interface PollerOptions {
 }
 
 interface PollOwner {
+    claims: Map<string, string>;
     disposeTimer?: TimerHandle;
     hooks: Map<string, string>;
     renderKeys: Set<string>;
@@ -59,8 +60,8 @@ interface PollOwner {
 }
 
 export interface PollScope {
+    claims: Map<string, string>;
     id: string;
-    keys: Set<string>;
 }
 
 type RunOutcome =
@@ -127,7 +128,7 @@ function getRetryAfterMs(error: unknown): number | undefined {
  */
 export class Poller {
     readonly #clearTimeout: (timer: TimerHandle) => void;
-    readonly #entries = new Map<string, PollingEntry>();
+    readonly #entries = new Map<string, Entry>();
     readonly #getVisibilityState: () => DocumentVisibilityState;
     readonly #jitterRatio: number;
     readonly #now: () => number;
@@ -175,7 +176,7 @@ export class Poller {
         this.#startVisibilityListener();
 
         if (entry.subscribers.size === 1 && entry.state.kind === 'idle' && entry.timer === undefined) {
-            this.#scheduleOrdinaryPoll(key, entry);
+            this.#schedulePoll(key, entry);
         } else if (
             entry.timer !== undefined &&
             entry.failureCount === 0 &&
@@ -187,8 +188,16 @@ export class Poller {
         }
 
         return () => {
+            const removedIntervalMs = this.#getIntervalMs(entry);
             entry.subscribers.delete(subscriberId);
             if (entry.subscribers.size > 0) {
+                if (
+                    entry.timer !== undefined &&
+                    entry.failureCount === 0 &&
+                    this.#getIntervalMs(entry) > removedIntervalMs
+                ) {
+                    this.#schedulePoll(key, entry);
+                }
                 return;
             }
 
@@ -216,20 +225,46 @@ export class Poller {
         };
     }
 
-    /** Apply the polling keys collected by one committed owner render. */
-    commitOwner(ownerId: string, keys: ReadonlySet<string>): void {
+    /**
+     * Claim a key during render so Suspense cannot skip its ownership effect.
+     *
+     * A later owner commit prunes claims left by an abandoned render.
+     */
+    claimKey(ownerId: string, hookId: string, key: string): void {
+        const owner = this.#getOrCreateOwner(ownerId);
+        if (owner.hooks.get(hookId) === key) {
+            return;
+        }
+        const oldKey = owner.claims.get(hookId);
+        owner.claims.set(hookId, key);
+        this.#getOrCreateEntry(key).owners.add(ownerId);
+        if (oldKey !== undefined && oldKey !== key && !this.#ownerHasKey(owner, oldKey)) {
+            this.#dropOwnedKey(ownerId, oldKey);
+        }
+    }
+
+    /** Apply the hook claims collected by one committed owner render. */
+    commitOwner(ownerId: string, claims: ReadonlyMap<string, string>): void {
         const owner = this.#getOrCreateOwner(ownerId);
         if (owner.disposeTimer !== undefined) {
             this.#clearTimeout(owner.disposeTimer);
             owner.disposeTimer = undefined;
         }
 
+        const droppedClaims = new Set<string>();
+        for (const [hookId, key] of owner.claims) {
+            if (claims.get(hookId) !== key) {
+                owner.claims.delete(hookId);
+                droppedClaims.add(key);
+            }
+        }
+
         // Add the new render before dropping the old one. A rerender must not
         // leave a live request without an owner between layout effects.
         const nextRenderKeys = new Set<string>();
-        for (const key of keys) {
+        for (const key of new Set(claims.values())) {
             this.#getOrCreateEntry(key).owners.add(ownerId);
-            if (!this.#hasHookForKey(owner, key)) {
+            if (!this.#hasHookForKey(owner, key) && !this.#hasClaimForKey(owner, key)) {
                 nextRenderKeys.add(key);
             }
         }
@@ -238,6 +273,11 @@ export class Poller {
         owner.renderKeys = nextRenderKeys;
         for (const key of oldRenderKeys) {
             if (!nextRenderKeys.has(key) && !this.#hasHookForKey(owner, key)) {
+                this.#dropOwnedKey(ownerId, key);
+            }
+        }
+        for (const key of droppedClaims) {
+            if (!this.#ownerHasKey(owner, key)) {
                 this.#dropOwnedKey(ownerId, key);
             }
         }
@@ -258,6 +298,7 @@ export class Poller {
 
         const oldKey = owner.hooks.get(hookId);
         owner.hooks.set(hookId, key);
+        owner.claims.delete(hookId);
         owner.renderKeys.delete(key);
         this.#getOrCreateEntry(key).owners.add(ownerId);
         if (oldKey !== undefined && oldKey !== key && !this.#ownerHasKey(owner, oldKey)) {
@@ -379,7 +420,7 @@ export class Poller {
                     return;
                 }
                 finished = true;
-                this.#finishRequest(key, activeRun.generation, outcome);
+                this.#finishRun(key, activeRun.generation, outcome);
             },
             isCurrent: () => {
                 const state = this.#entries.get(key)?.state;
@@ -484,7 +525,7 @@ export class Poller {
         return this.#now();
     }
 
-    #finishRequest(key: string, generation: number, outcome: RunOutcome): void {
+    #finishRun(key: string, generation: number, outcome: RunOutcome): void {
         const entry = this.#entries.get(key);
         if (!entry || entry.state.kind !== 'running' || entry.state.run.generation !== generation) {
             return;
@@ -528,7 +569,7 @@ export class Poller {
                 this.runNow(key);
                 return;
             }
-            this.#scheduleOrdinaryPoll(key, entry);
+            this.#schedulePoll(key, entry);
             return;
         }
 
@@ -537,7 +578,7 @@ export class Poller {
                 entry.runAgain = false;
                 this.runNow(key);
             } else {
-                this.#scheduleOrdinaryPoll(key, entry);
+                this.#schedulePoll(key, entry);
             }
         }
     }
@@ -555,11 +596,11 @@ export class Poller {
         }
     }
 
-    #getIntervalMs(entry: PollingEntry): number {
+    #getIntervalMs(entry: Entry): number {
         return Math.min(...Array.from(entry.subscribers.values(), (subscriber) => subscriber.intervalMs));
     }
 
-    #getOrCreateEntry(key: string): PollingEntry {
+    #getOrCreateEntry(key: string): Entry {
         let entry = this.#entries.get(key);
         if (!entry) {
             entry = {
@@ -576,7 +617,7 @@ export class Poller {
         return entry;
     }
 
-    #getSubscriber(entry: PollingEntry): PollingSubscriber | undefined {
+    #getSubscriber(entry: Entry): Subscriber | undefined {
         return Array.from(entry.subscribers.values()).sort((a, b) => a.intervalMs - b.intervalMs)[0];
     }
 
@@ -584,6 +625,7 @@ export class Poller {
         let owner = this.#owners.get(ownerId);
         if (!owner) {
             const newOwner: PollOwner = {
+                claims: new Map(),
                 hooks: new Map(),
                 renderKeys: new Set(),
                 timers: new Map(),
@@ -620,11 +662,15 @@ export class Poller {
         for (const timer of owner.timers.values()) {
             this.#clearTimeout(timer);
         }
-        const keys = new Set([...owner.renderKeys, ...owner.hooks.values()]);
+        const keys = new Set([...owner.claims.values(), ...owner.renderKeys, ...owner.hooks.values()]);
         for (const key of keys) {
             this.#dropOwnedKey(ownerId, key);
         }
         this.#stopVisibilityListenerIfIdle();
+    }
+
+    #hasClaimForKey(owner: PollOwner, key: string): boolean {
+        return Array.from(owner.claims.values()).some((claimKey) => claimKey === key);
     }
 
     #hasHookForKey(owner: PollOwner, key: string): boolean {
@@ -632,14 +678,14 @@ export class Poller {
     }
 
     #ownerHasKey(owner: PollOwner, key: string): boolean {
-        return owner.renderKeys.has(key) || this.#hasHookForKey(owner, key);
+        return owner.renderKeys.has(key) || this.#hasHookForKey(owner, key) || this.#hasClaimForKey(owner, key);
     }
 
-    #scheduleOrdinaryPoll(key: string, entry: PollingEntry): void {
+    #schedulePoll(key: string, entry: Entry): void {
         this.#schedule(key, entry, this.#withJitter(this.#getIntervalMs(entry)));
     }
 
-    #schedule(key: string, entry: PollingEntry, delay: number): void {
+    #schedule(key: string, entry: Entry, delay: number): void {
         this.#clearTimer(entry);
         entry.nextRunAt = this.#now() + delay;
         if (this.#getVisibilityState() === 'hidden') {
@@ -653,7 +699,7 @@ export class Poller {
         }, delay);
     }
 
-    #clearTimer(entry: PollingEntry, clearNextRun = true): void {
+    #clearTimer(entry: Entry, clearNextRun = true): void {
         if (entry.timer !== undefined) {
             this.#clearTimeout(entry.timer);
             entry.timer = undefined;
@@ -727,34 +773,37 @@ export function usePolling(key: string, intervalSeconds: number | undefined, ref
 }
 
 /**
- * Create a render-local list of polling keys and apply it after commit.
+ * Create a render-local map of hooks to polling keys.
  *
- * Descendants may suspend before their own effects run. They add keys to this
- * detached set during render; only the owner's layout effect changes Poller.
+ * The commit drops claims left by hooks that did not render.
  */
 export function usePollScope(): PollScope {
     const id = useId();
-    const keys = new Set<string>();
+    const claims = new Map<string, string>();
 
     useLayoutEffect(() => {
-        poller.commitOwner(id, keys);
+        poller.commitOwner(id, claims);
     });
     useLayoutEffect(() => () => poller.releaseOwner(id), [id]);
 
-    return { id, keys };
+    return { claims, id };
 }
 
 /**
  * Keep one request key for a rendered hook.
  *
- * The render-local key lets a committed parent own work while this hook is
- * suspended. Its passive effect stays mounted when Suspense hides an existing
- * tree, so a dependency refresh does not lose ownership of the active request.
+ * The hook must claim the key during render because an initial suspended render
+ * runs no effect. The claim only marks ownership; it starts no work. The passive
+ * effect keeps the claim after commit and stays mounted when Suspense hides an
+ * existing tree.
  */
 export function usePollKey(scope: PollScope | undefined, key: string): void {
     const hookId = useId();
-    scope?.keys.add(key);
+    scope?.claims.set(hookId, key);
     const ownerId = scope?.id;
+    if (ownerId) {
+        poller.claimKey(ownerId, hookId, key);
+    }
 
     useEffect(() => {
         if (!ownerId) {

--- a/packages/dara-core/js/shared/interactivity/store.tsx
+++ b/packages/dara-core/js/shared/interactivity/store.tsx
@@ -1,8 +1,10 @@
-import { type RecoilState, type RecoilValue } from 'recoil';
+import { type RecoilState, type RecoilValue, atom } from 'recoil';
 
 import { RequestExtrasSerializable } from '@/api/http';
 import { getUniqueIdentifier } from '@/shared/utils/hashing';
 import { type AnyVariable, isDerivedVariable, isVariable } from '@/types';
+
+import { clearPolling_TEST } from './polling';
 
 /**
  * Selector family type which constructs a selector from a given set of extras.
@@ -18,6 +20,8 @@ export type AtomFamily = (P: RequestExtrasSerializable) => RecoilState<any>;
  * Key -> atom
  */
 export const atomRegistry = new Map<string, RecoilState<any>>();
+/** Request identity -> polling-only trigger atom. */
+export const pollingTriggerRegistry = new Map<string, RecoilState<TriggerIndexValue>>();
 /**
  * Key -> atom family
  */
@@ -65,6 +69,25 @@ export type TriggerIndexValue = {
     inc: number;
 };
 
+/**
+ * Get the trigger used to refresh exactly one selector/request-extras identity.
+ */
+export function getOrRegisterPollingTrigger(requestKey: string): RecoilState<TriggerIndexValue> {
+    if (!pollingTriggerRegistry.has(requestKey)) {
+        pollingTriggerRegistry.set(
+            requestKey,
+            atom<TriggerIndexValue>({
+                default: {
+                    force_key: null,
+                    inc: 0,
+                } satisfies TriggerIndexValue,
+                key: `_POLLING_TRIGGER_${requestKey}`,
+            })
+        );
+    }
+    return pollingTriggerRegistry.get(requestKey)!;
+}
+
 type RegistryKeyType = 'result-selector' | 'derived-selector' | 'selector-nested' | 'trigger' | 'filters';
 
 /**
@@ -94,8 +117,11 @@ export function getRegistryKey<T>(variable: AnyVariable<T>, type: RegistryKeyTyp
  * Clear registries - to be used in tests only.
  */
 export function clearRegistries_TEST(): void {
+    clearPolling_TEST();
+
     for (const registry of [
         atomRegistry,
+        pollingTriggerRegistry,
         atomFamilyRegistry,
         atomFamilyMembersRegistry,
         selectorRegistry,

--- a/packages/dara-core/js/shared/interactivity/use-server-component.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-server-component.tsx
@@ -36,15 +36,13 @@ import { type CurrentResult, preloadDerivedValue, resolveDerivedValue } from './
 import { findStreamVariablesInArray } from './find-stream-variables';
 import { buildTriggerList, getOrRegisterTrigger, registerChildTriggers, resolveTriggerStatic } from './internal';
 import {
-    type PollingRequestOutcome,
-    assertCurrentRequest,
     createPollForceKey,
-    getRetryAfterMs,
-    isAbortError,
     isPollForceKey,
-    parseRetryAfter,
-    startPollingRequest,
-    waitForAbort,
+    markRetryAfter,
+    ownPoll,
+    releasePoll,
+    runPoll,
+    waitOrAbort,
 } from './polling';
 import { cleanKwargs, resolveVariable } from './resolve-variable';
 import {
@@ -125,10 +123,7 @@ async function fetchFunctionComponent(
     try {
         await validateResponse(res, `Failed to fetch the component: ${component}`);
     } catch (error) {
-        if (typeof error === 'object' && error !== null) {
-            Object.assign(error, { retryAfterMs: parseRetryAfter(res) });
-        }
-        throw error;
+        throw markRetryAfter(error, res);
     }
     const result: TaskResponse | NormalizedPayload<ComponentInstance> | null = await res.json();
     return result;
@@ -225,8 +220,7 @@ function getOrRegisterServerComponent({
                         const triggerList = buildTriggerList(kwargsList);
 
                         // Register nested triggers as dependencies so triggering one of the nested derived variables will trigger a recalculation here
-                        const triggers = registerChildTriggers(triggerList, get);
-                        triggers.unshift(selfTrigger, pollingTrigger);
+                        const childTriggers = registerChildTriggers(triggerList, get);
 
                         const { extras } = extrasSerializable;
 
@@ -237,8 +231,8 @@ function getOrRegisterServerComponent({
                             resolvedVariables: resolvedKwargsList,
                             resolutionStrategy: { name: 'get', get },
                             triggerList,
-                            triggers,
-                            selfTriggerCount: 2,
+                            selfTriggers: [selfTrigger, pollingTrigger],
+                            childTriggers,
                         });
 
                         // returning previous result as no change in dependant values
@@ -249,25 +243,14 @@ function getOrRegisterServerComponent({
                         const currentResult =
                             derivedResult.type === 'current' ? (derivedResult as CurrentResult) : undefined;
                         const pollRequest = isPollForceKey(currentResult?.selfTriggerForceKey);
-                        const requestFingerprint = currentResult
+                        const inputKey = currentResult
                             ? JSON.stringify({
                                   forceKey: currentResult.selfTriggerForceKey,
                                   values: currentResult.values,
                               })
                             : undefined;
-                        const requestHandle = currentResult
-                            ? startPollingRequest(
-                                  selectorKey,
-                                  pollRequest ? 'poll' : 'dependency',
-                                  extras.signal ?? undefined,
-                                  requestFingerprint
-                              )
-                            : undefined;
-                        let requestOutcome: PollingRequestOutcome = { status: 'success' };
-
-                        try {
+                        const fetchComponent = async (signal?: AbortSignal): Promise<any> => {
                             let result: any = NOT_SET;
-                            // whether to check for an initial task
                             let shouldFetchTask = false;
 
                             if (derivedResult.type === 'cached') {
@@ -280,11 +263,9 @@ function getOrRegisterServerComponent({
                                 result = response.value;
                                 derivedResult = derivedResult.currentResult;
                             } else {
-                                requestHandle!.signal.addEventListener(
-                                    'abort',
-                                    () => taskContext.cleanupRunningTasks(key),
-                                    { once: true }
-                                );
+                                signal!.addEventListener('abort', () => taskContext.cleanupRunningTasks(key), {
+                                    once: true,
+                                });
 
                                 // Otherwise fetch new component
                                 // turn the resolved values back into an object and clean them up
@@ -304,7 +285,7 @@ function getOrRegisterServerComponent({
                                     uid,
                                     extras,
                                     wsClient,
-                                    requestHandle!.signal
+                                    signal!
                                 );
                             }
 
@@ -319,7 +300,7 @@ function getOrRegisterServerComponent({
                                 if (shouldFetchTask) {
                                     const taskResult = await fetchTaskResult<any>(taskId, {
                                         ...extras,
-                                        signal: requestHandle?.signal,
+                                        signal,
                                     });
                                     if (taskResult.status === 'ok') {
                                         result = taskResult.result;
@@ -332,7 +313,7 @@ function getOrRegisterServerComponent({
                                     taskContext.startTask(taskId, key, getComponentRegistryKey(uid, true));
 
                                     try {
-                                        await waitForAbort(wsClient.waitForTask(taskId), requestHandle?.signal);
+                                        await waitOrAbort(wsClient.waitForTask(taskId), signal);
                                     } finally {
                                         taskContext.endTask(taskId);
                                     }
@@ -341,7 +322,7 @@ function getOrRegisterServerComponent({
                                         taskId,
                                         {
                                             ...extras,
-                                            signal: requestHandle?.signal,
+                                            signal,
                                         }
                                     );
                                     if (response.status === 'not_found') {
@@ -356,37 +337,43 @@ function getOrRegisterServerComponent({
                                 result = denormalize(result.data, result.lookup);
                             }
 
-                            if (requestHandle) {
-                                assertCurrentRequest(requestHandle);
-                            }
-
-                            depsRegistry.set(derivedResult.depsKey, {
-                                args: derivedResult.relevantValues,
-                                result,
-                            });
-
                             return result;
+                        };
+
+                        if (!currentResult) {
+                            try {
+                                const result = await fetchComponent();
+                                depsRegistry.set(derivedResult.depsKey, {
+                                    args: derivedResult.relevantValues,
+                                    result,
+                                });
+                                return result;
+                            } catch (error) {
+                                return throwError(error);
+                            }
+                        }
+
+                        const runResult = currentResult;
+                        try {
+                            return await runPoll({
+                                cause: pollRequest ? 'poll' : 'dependency',
+                                inputKey,
+                                key: selectorKey,
+                                read: () => {
+                                    const saved = depsRegistry.get(runResult.depsKey);
+                                    return saved ? { found: true, value: saved.result } : { found: false };
+                                },
+                                signal: extras.signal ?? undefined,
+                                work: fetchComponent,
+                                write: (result) => {
+                                    depsRegistry.set(runResult.depsKey, {
+                                        args: runResult.relevantValues,
+                                        result,
+                                    });
+                                },
+                            });
                         } catch (error) {
-                            requestOutcome = isAbortError(error)
-                                ? { status: 'aborted' }
-                                : { status: 'error', retryAfterMs: getRetryAfterMs(error) };
-
-                            const previous = depsRegistry.get((derivedResult as CurrentResult).depsKey);
-                            if (isAbortError(error) && previous) {
-                                await requestHandle?.waitForSupersedingRequest();
-                                return (
-                                    depsRegistry.get((derivedResult as CurrentResult).depsKey)?.result ??
-                                    previous.result
-                                );
-                            }
-
-                            if (pollRequest && previous) {
-                                return previous.result;
-                            }
-
-                            throwError(error);
-                        } finally {
-                            requestHandle?.finish(requestOutcome);
+                            return throwError(error);
                         }
                     },
                 key,
@@ -424,21 +411,21 @@ export function preloadServerComponent(
     const triggerList = buildTriggerList(kwargsList);
 
     // prepare trigger list as usual but use static resolution
-    const triggers = [
+    const selfTriggers = [
         resolveTriggerStatic(getOrRegisterComponentTrigger(component.uid, component.loop_instance_uid), snapshot),
         resolveTriggerStatic(getOrRegisterPollingTrigger(key), snapshot),
-        ...triggerList.map((ti) => resolveTriggerStatic(getOrRegisterTrigger(ti.variable), snapshot)),
     ];
+    const childTriggers = triggerList.map((ti) => resolveTriggerStatic(getOrRegisterTrigger(ti.variable), snapshot));
 
     return preloadDerivedValue({
         key,
         variables: kwargsList,
         deps: kwargsList,
         triggerList,
-        triggers,
+        selfTriggers,
+        childTriggers,
         snapshot,
         params,
-        selfTriggerCount: 2,
     });
 }
 
@@ -460,6 +447,12 @@ export default function useServerComponent(
     const { client: wsClient } = useContext(WebSocketCtx);
     const taskContext = useTaskContext();
     const variablesContext = useContext(VariableCtx);
+    const requestKey = getServerComponentRequestKey(uid, loop_instance_uid, extras);
+    ownPoll(variablesContext?.pollingOwner, requestKey);
+    useEffect(() => {
+        ownPoll(variablesContext?.pollingOwner, requestKey);
+        return () => releasePoll(variablesContext?.pollingOwner, requestKey);
+    }, [variablesContext?.pollingOwner, requestKey]);
 
     const bus = useEventBus();
 

--- a/packages/dara-core/js/shared/interactivity/use-server-component.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-server-component.tsx
@@ -281,6 +281,7 @@ function getOrRegisterServerComponent({
                                 );
                             }
 
+                            signal?.throwIfAborted();
                             taskContext.cleanupRunningTasks(key);
 
                             // Metatask returned

--- a/packages/dara-core/js/shared/interactivity/use-server-component.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-server-component.tsx
@@ -32,14 +32,26 @@ import {
 import { VariableCtx, WebSocketCtx, useRequestExtras } from '../context';
 import { useTaskContext } from '../context/global-task-context';
 import { useEventBus } from '../event-bus/event-bus';
-import { preloadDerivedValue, resolveDerivedValue } from './derived-variable';
+import { type CurrentResult, preloadDerivedValue, resolveDerivedValue } from './derived-variable';
 import { findStreamVariablesInArray } from './find-stream-variables';
 import { buildTriggerList, getOrRegisterTrigger, registerChildTriggers, resolveTriggerStatic } from './internal';
+import {
+    type PollingRequestOutcome,
+    assertCurrentRequest,
+    createPollForceKey,
+    getRetryAfterMs,
+    isAbortError,
+    isPollForceKey,
+    parseRetryAfter,
+    startPollingRequest,
+    waitForAbort,
+} from './polling';
 import { cleanKwargs, resolveVariable } from './resolve-variable';
 import {
     type TriggerIndexValue,
     atomRegistry,
     depsRegistry,
+    getOrRegisterPollingTrigger,
     selectorFamilyMembersRegistry,
     selectorFamilyRegistry,
 } from './store';
@@ -70,6 +82,17 @@ export function getComponentRegistryKey(uid: string, trigger?: boolean, loopInst
 }
 
 /**
+ * Generate the request identity used for polling and cancellation.
+ */
+export function getServerComponentRequestKey(
+    uid: string,
+    loopInstanceUid: string | undefined,
+    extras: RequestExtras
+): string {
+    return getComponentRegistryKey(uid, false, loopInstanceUid) + new RequestExtrasSerializable(extras).toJSON();
+}
+
+/**
  * Fetch a component from the backend, expects a component instance to be returned.
  *
  * @param component the component to fetch
@@ -85,7 +108,8 @@ async function fetchFunctionComponent(
     },
     uid: string,
     extras: RequestExtras,
-    wsClient: WebSocketClientInterface
+    wsClient: WebSocketClientInterface,
+    signal?: AbortSignal
 ): Promise<TaskResponse | NormalizedPayload<ComponentInstance> | null> {
     const ws_channel = await wsClient.getChannel();
     const res = await request(
@@ -94,10 +118,18 @@ async function fetchFunctionComponent(
             body: JSON.stringify({ uid, values, ws_channel }),
             method: HTTP_METHOD.POST,
         },
-        extras
+        extras,
+        { signal }
     );
     await handleAuthErrors(res, { authenticationFailureRedirect: 'login' });
-    await validateResponse(res, `Failed to fetch the component: ${component}`);
+    try {
+        await validateResponse(res, `Failed to fetch the component: ${component}`);
+    } catch (error) {
+        if (typeof error === 'object' && error !== null) {
+            Object.assign(error, { retryAfterMs: parseRetryAfter(res) });
+        }
+        throw error;
+    }
     const result: TaskResponse | NormalizedPayload<ComponentInstance> | null = await res.json();
     return result;
 }
@@ -169,13 +201,7 @@ function getOrRegisterServerComponent({
                             (error as any).selectorExtras = extrasSerializable.toJSON();
                             throw error;
                         };
-                        const handleError = <R,>(func: () => R): R | undefined => {
-                            try {
-                                return func();
-                            } catch (e) {
-                                throwError(e);
-                            }
-                        };
+                        const selectorKey = key + extrasSerializable.toJSON();
 
                         // Kwargs resolved to their simple values
                         const resolvedKwargs = await Promise.all(
@@ -193,24 +219,26 @@ function getOrRegisterServerComponent({
 
                         const triggerAtom = getOrRegisterComponentTrigger(uid, loop_instance_uid);
                         const selfTrigger = get(triggerAtom);
+                        const pollingTrigger = get(getOrRegisterPollingTrigger(selectorKey));
 
                         // Build trigger map once for efficient lookups
                         const triggerList = buildTriggerList(kwargsList);
 
                         // Register nested triggers as dependencies so triggering one of the nested derived variables will trigger a recalculation here
                         const triggers = registerChildTriggers(triggerList, get);
-                        triggers.unshift(selfTrigger);
+                        triggers.unshift(selfTrigger, pollingTrigger);
 
                         const { extras } = extrasSerializable;
 
                         let derivedResult = resolveDerivedValue({
-                            key,
+                            key: selectorKey,
                             variables: kwargsList,
                             deps: kwargsList,
                             resolvedVariables: resolvedKwargsList,
                             resolutionStrategy: { name: 'get', get },
                             triggerList,
                             triggers,
+                            selfTriggerCount: 2,
                         });
 
                         // returning previous result as no change in dependant values
@@ -218,12 +246,31 @@ function getOrRegisterServerComponent({
                             return derivedResult.entry.result;
                         }
 
-                        let result: any = NOT_SET;
-                        // whether to check for an initial task
-                        let shouldFetchTask = false;
+                        const currentResult =
+                            derivedResult.type === 'current' ? (derivedResult as CurrentResult) : undefined;
+                        const pollRequest = isPollForceKey(currentResult?.selfTriggerForceKey);
+                        const requestFingerprint = currentResult
+                            ? JSON.stringify({
+                                  forceKey: currentResult.selfTriggerForceKey,
+                                  values: currentResult.values,
+                              })
+                            : undefined;
+                        const requestHandle = currentResult
+                            ? startPollingRequest(
+                                  selectorKey,
+                                  pollRequest ? 'poll' : 'dependency',
+                                  extras.signal ?? undefined,
+                                  requestFingerprint
+                              )
+                            : undefined;
+                        let requestOutcome: PollingRequestOutcome = { status: 'success' };
 
-                        if (derivedResult.type === 'cached') {
-                            try {
+                        try {
+                            let result: any = NOT_SET;
+                            // whether to check for an initial task
+                            let shouldFetchTask = false;
+
+                            if (derivedResult.type === 'cached') {
                                 const response = await derivedResult.response.getValue();
                                 shouldFetchTask = true;
                                 if (!response.ok) {
@@ -232,89 +279,115 @@ function getOrRegisterServerComponent({
 
                                 result = response.value;
                                 derivedResult = derivedResult.currentResult;
-                            } catch (e) {
-                                throwError(e);
-                            }
-                        } else {
-                            // Otherwise fetch new component
-                            // turn the resolved values back into an object and clean them up
-                            const kwargValues = cleanKwargs(
-                                Object.keys(dynamicKwargs).reduce(
-                                    (acc, k, idx) => {
-                                        acc[k] = (derivedResult as any).values[idx];
-                                        return acc;
-                                    },
-                                    {} as Record<string, any>
-                                )
-                            );
+                            } else {
+                                requestHandle!.signal.addEventListener(
+                                    'abort',
+                                    () => taskContext.cleanupRunningTasks(key),
+                                    { once: true }
+                                );
 
-                            result = await handleError(() =>
-                                fetchFunctionComponent(
+                                // Otherwise fetch new component
+                                // turn the resolved values back into an object and clean them up
+                                const kwargValues = cleanKwargs(
+                                    Object.keys(dynamicKwargs).reduce(
+                                        (acc, k, idx) => {
+                                            acc[k] = currentResult!.values[idx];
+                                            return acc;
+                                        },
+                                        {} as Record<string, any>
+                                    )
+                                );
+
+                                result = await fetchFunctionComponent(
                                     name,
                                     normalizeRequest(kwargValues, dynamicKwargs),
                                     uid,
                                     extras,
-                                    wsClient
-                                )
-                            );
-                        }
+                                    wsClient,
+                                    requestHandle!.signal
+                                );
+                            }
 
-                        taskContext.cleanupRunningTasks(key);
+                            taskContext.cleanupRunningTasks(key);
 
-                        // Metatask returned
-                        if (isTaskResponse(result)) {
-                            const taskId = result.task_id;
-                            result = NOT_SET;
+                            // Metatask returned
+                            if (isTaskResponse(result)) {
+                                const taskId = result.task_id;
+                                result = NOT_SET;
 
-                            // pre-fetch task result since it could already be available without us receiving the notif
-                            if (shouldFetchTask) {
-                                try {
-                                    const taskResult = await fetchTaskResult<any>(taskId, extras);
+                                // pre-fetch task result since it could already be available without us receiving the notif
+                                if (shouldFetchTask) {
+                                    const taskResult = await fetchTaskResult<any>(taskId, {
+                                        ...extras,
+                                        signal: requestHandle?.signal,
+                                    });
                                     if (taskResult.status === 'ok') {
                                         result = taskResult.result;
                                     }
-                                } catch (e) {
-                                    throwError(e);
-                                }
-                            }
-
-                            // no value yet, need to wait for the task
-                            if (result === NOT_SET) {
-                                // Register the task under the component's instance key
-                                taskContext.startTask(taskId, key, getComponentRegistryKey(uid, true));
-
-                                try {
-                                    await wsClient.waitForTask(taskId);
-                                } catch (e: unknown) {
-                                    throwError(e);
-                                } finally {
-                                    taskContext.endTask(taskId);
                                 }
 
-                                result = await handleError(async () => {
-                                    const res = await fetchTaskResult<NormalizedPayload<ComponentInstance>>(
+                                // no value yet, need to wait for the task
+                                if (result === NOT_SET) {
+                                    // Register the task under the component's instance key
+                                    taskContext.startTask(taskId, key, getComponentRegistryKey(uid, true));
+
+                                    try {
+                                        await waitForAbort(wsClient.waitForTask(taskId), requestHandle?.signal);
+                                    } finally {
+                                        taskContext.endTask(taskId);
+                                    }
+
+                                    const response = await fetchTaskResult<NormalizedPayload<ComponentInstance>>(
                                         taskId,
-                                        extras
+                                        {
+                                            ...extras,
+                                            signal: requestHandle?.signal,
+                                        }
                                     );
-                                    if (res.status === 'not_found') {
+                                    if (response.status === 'not_found') {
                                         throw new Error('Task result not found');
                                     }
-                                    return res.result;
-                                });
+                                    result = response.result;
+                                }
                             }
+
+                            if (result !== NOT_SET && result !== null) {
+                                // Denormalize
+                                result = denormalize(result.data, result.lookup);
+                            }
+
+                            if (requestHandle) {
+                                assertCurrentRequest(requestHandle);
+                            }
+
+                            depsRegistry.set(derivedResult.depsKey, {
+                                args: derivedResult.relevantValues,
+                                result,
+                            });
+
+                            return result;
+                        } catch (error) {
+                            requestOutcome = isAbortError(error)
+                                ? { status: 'aborted' }
+                                : { status: 'error', retryAfterMs: getRetryAfterMs(error) };
+
+                            const previous = depsRegistry.get((derivedResult as CurrentResult).depsKey);
+                            if (isAbortError(error) && previous) {
+                                await requestHandle?.waitForSupersedingRequest();
+                                return (
+                                    depsRegistry.get((derivedResult as CurrentResult).depsKey)?.result ??
+                                    previous.result
+                                );
+                            }
+
+                            if (pollRequest && previous) {
+                                return previous.result;
+                            }
+
+                            throwError(error);
+                        } finally {
+                            requestHandle?.finish(requestOutcome);
                         }
-
-                        if (result !== NOT_SET && result !== null) {
-                            // Denormalize
-                            result = denormalize(result.data, result.lookup);
-                        }
-
-                        depsRegistry.set(key, {
-                            args: derivedResult.relevantValues,
-                            result,
-                        });
-
-                        return result;
                     },
                 key,
             })
@@ -344,7 +417,7 @@ export function preloadServerComponent(
     snapshot: Snapshot,
     params: Params<string>
 ): ReturnType<typeof preloadDerivedValue> {
-    const key = getComponentRegistryKey(component.uid, false, component.loop_instance_uid);
+    const key = getServerComponentRequestKey(component.uid, component.loop_instance_uid, {});
 
     const kwargsList = Object.values(component.props.dynamic_kwargs);
 
@@ -352,8 +425,9 @@ export function preloadServerComponent(
 
     // prepare trigger list as usual but use static resolution
     const triggers = [
+        resolveTriggerStatic(getOrRegisterComponentTrigger(component.uid, component.loop_instance_uid), snapshot),
+        resolveTriggerStatic(getOrRegisterPollingTrigger(key), snapshot),
         ...triggerList.map((ti) => resolveTriggerStatic(getOrRegisterTrigger(ti.variable), snapshot)),
-        resolveTriggerStatic(getOrRegisterComponentTrigger(component.uid), snapshot),
     ];
 
     return preloadDerivedValue({
@@ -364,6 +438,7 @@ export function preloadServerComponent(
         triggers,
         snapshot,
         params,
+        selfTriggerCount: 2,
     });
 }
 
@@ -444,5 +519,26 @@ export function useRefreshServerComponent(uid: string, loop_instance_uid?: strin
                 }));
             },
         [uid]
+    );
+}
+
+/**
+ * Refresh one server-component/request-extras identity for polling.
+ */
+export function usePollServerComponent(
+    uid: string,
+    loopInstanceUid: string | undefined,
+    extras: RequestExtras
+): () => void {
+    const requestKey = getServerComponentRequestKey(uid, loopInstanceUid, extras);
+    return useRecoilCallback(
+        ({ set }) =>
+            () => {
+                set(getOrRegisterPollingTrigger(requestKey), (triggerIndexValue) => ({
+                    force_key: createPollForceKey(),
+                    inc: triggerIndexValue.inc + 1,
+                }));
+            },
+        [requestKey]
     );
 }

--- a/packages/dara-core/js/shared/interactivity/use-server-component.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-server-component.tsx
@@ -35,15 +35,7 @@ import { useEventBus } from '../event-bus/event-bus';
 import { type CurrentResult, preloadDerivedValue, resolveDerivedValue } from './derived-variable';
 import { findStreamVariablesInArray } from './find-stream-variables';
 import { buildTriggerList, getOrRegisterTrigger, registerChildTriggers, resolveTriggerStatic } from './internal';
-import {
-    createPollForceKey,
-    isPollForceKey,
-    markRetryAfter,
-    ownPoll,
-    releasePoll,
-    runPoll,
-    waitOrAbort,
-} from './polling';
+import { createPollForceKey, isPollForceKey, markRetryAfter, runPoll, usePollKey, waitOrAbort } from './polling';
 import { cleanKwargs, resolveVariable } from './resolve-variable';
 import {
     type TriggerIndexValue,
@@ -448,11 +440,7 @@ export default function useServerComponent(
     const taskContext = useTaskContext();
     const variablesContext = useContext(VariableCtx);
     const requestKey = getServerComponentRequestKey(uid, loop_instance_uid, extras);
-    ownPoll(variablesContext?.pollingOwner, requestKey);
-    useEffect(() => {
-        ownPoll(variablesContext?.pollingOwner, requestKey);
-        return () => releasePoll(variablesContext?.pollingOwner, requestKey);
-    }, [variablesContext?.pollingOwner, requestKey]);
+    usePollKey(variablesContext?.pollScope, requestKey);
 
     const bus = useEventBus();
 

--- a/packages/dara-core/js/shared/interactivity/use-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable.tsx
@@ -113,7 +113,14 @@ export function useVariable<T>(
 
     if (isDerivedVariable(variable)) {
         const [pollingInterval] = useVariable<number | null>(variable.polling_interval ?? null, { suspend: false });
-        const selector = useDerivedVariable(variable, wsClient, taskContext, extras, pollingInterval ?? undefined);
+        const selector = useDerivedVariable(
+            variable,
+            wsClient,
+            taskContext,
+            extras,
+            pollingInterval ?? undefined,
+            variablesContext?.pollingOwner
+        );
         const selectorLoadable = useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE(selector);
 
         useEffect(() => {
@@ -132,7 +139,14 @@ export function useVariable<T>(
     }
 
     if (isStateVariable(variable)) {
-        const parentSelector = useDerivedVariable(variable.parent_variable, wsClient, taskContext, extras);
+        const parentSelector = useDerivedVariable(
+            variable.parent_variable,
+            wsClient,
+            taskContext,
+            extras,
+            undefined,
+            variablesContext?.pollingOwner
+        );
         const parentLoadable = useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE(parentSelector);
 
         // Map the loadable state to the specific property

--- a/packages/dara-core/js/shared/interactivity/use-variable.tsx
+++ b/packages/dara-core/js/shared/interactivity/use-variable.tsx
@@ -119,7 +119,7 @@ export function useVariable<T>(
             taskContext,
             extras,
             pollingInterval ?? undefined,
-            variablesContext?.pollingOwner
+            variablesContext?.pollScope
         );
         const selectorLoadable = useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE(selector);
 
@@ -145,7 +145,7 @@ export function useVariable<T>(
             taskContext,
             extras,
             undefined,
-            variablesContext?.pollingOwner
+            variablesContext?.pollScope
         );
         const parentLoadable = useRecoilValueLoadable_TRANSITION_SUPPORT_UNSTABLE(parentSelector);
 

--- a/packages/dara-core/tests/js/dynamic-component.spec.tsx
+++ b/packages/dara-core/tests/js/dynamic-component.spec.tsx
@@ -296,8 +296,8 @@ describe('DynamicComponent', () => {
 
         server.use(
             http.post('/api/core/components/FreshPythonComponent', async ({ request }) => {
-                requestCount++;
-                if (requestCount === 2) {
+                const currentRequest = ++requestCount;
+                if (currentRequest === 2) {
                     staleSignal = request.signal;
                     await new Promise<void>((resolve) => {
                         request.signal.addEventListener('abort', () => resolve(), { once: true });
@@ -307,7 +307,8 @@ describe('DynamicComponent', () => {
                     data: {
                         name: 'RawString',
                         props: {
-                            content: requestCount === 1 ? 'initial' : requestCount === 2 ? 'stale-poll' : 'fresh-input',
+                            content:
+                                currentRequest === 1 ? 'initial' : currentRequest === 2 ? 'stale-poll' : 'fresh-input',
                         },
                     },
                     lookup: {},

--- a/packages/dara-core/tests/js/dynamic-component.spec.tsx
+++ b/packages/dara-core/tests/js/dynamic-component.spec.tsx
@@ -30,7 +30,11 @@ describe('DynamicComponent', () => {
         await preloadActions(importers, Object.values(mockActions));
         await preloadComponents(importers, Object.values(mockComponents));
     });
-    afterEach(() => server.resetHandlers());
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        server.resetHandlers();
+    });
     afterAll(() => server.close());
 
     it("should load the component from the registry and render it if it's a JS one", async () => {
@@ -159,6 +163,67 @@ describe('DynamicComponent', () => {
                 )
             ).toBeInstanceOf(HTMLDivElement);
         });
+    });
+
+    it('keeps slow Python component polling at one request in flight and aborts on unmount', async () => {
+        vi.useFakeTimers();
+        let requestCount = 0;
+        let activeRequests = 0;
+        let peakRequests = 0;
+        let slowPollSignal: AbortSignal | undefined;
+
+        server.use(
+            http.post('/api/core/components/SlowPollingComponent', async ({ request }) => {
+                requestCount++;
+                activeRequests++;
+                peakRequests = Math.max(peakRequests, activeRequests);
+
+                if (requestCount > 1) {
+                    slowPollSignal = request.signal;
+                    await new Promise<void>((resolve) => {
+                        request.signal.addEventListener('abort', () => resolve(), { once: true });
+                    });
+                }
+
+                activeRequests--;
+                return HttpResponse.json({
+                    data: {
+                        name: 'RawString',
+                        props: { content: `request-${requestCount}` },
+                    },
+                    lookup: {},
+                });
+            })
+        );
+
+        const rendered = wrappedRender(
+            <DynamicComponent
+                component={
+                    {
+                        name: 'SlowPollingComponent',
+                        props: {
+                            dynamic_kwargs: {},
+                            polling_interval: 1,
+                            js_module: 'test',
+                            func_name: 'slow_poll',
+                        },
+                        uid: 'slow-polling-component',
+                    } satisfies PyComponentInstance
+                }
+            />
+        );
+
+        await waitFor(() => expect(rendered.getByText('request-1')).toBeInTheDocument());
+        act(() => vi.advanceTimersByTime(1200));
+        await vi.waitFor(() => expect(requestCount).toBe(2));
+
+        act(() => vi.advanceTimersByTime(10_000));
+        expect(requestCount).toBe(2);
+        expect(peakRequests).toBe(1);
+
+        rendered.unmount();
+        act(() => vi.advanceTimersByTime(0));
+        expect(slowPollSignal?.aborted).toBe(true);
     });
 
     it('should publish EventBus notification on server component render', async () => {

--- a/packages/dara-core/tests/js/dynamic-component.spec.tsx
+++ b/packages/dara-core/tests/js/dynamic-component.spec.tsx
@@ -226,6 +226,118 @@ describe('DynamicComponent', () => {
         expect(slowPollSignal?.aborted).toBe(true);
     });
 
+    it('aborts the first Python component request when its suspended owner unmounts', async () => {
+        vi.useFakeTimers();
+        let firstSignal: AbortSignal | undefined;
+        server.use(
+            http.post('/api/core/components/SuspendedComponent', async ({ request }) => {
+                firstSignal = request.signal;
+                await new Promise<void>((resolve) => {
+                    if (request.signal.aborted) {
+                        resolve();
+                    } else {
+                        request.signal.addEventListener('abort', () => resolve(), { once: true });
+                    }
+                });
+                return HttpResponse.json({
+                    data: {
+                        name: 'RawString',
+                        props: { content: 'old' },
+                    },
+                    lookup: {},
+                });
+            })
+        );
+
+        const rendered = wrappedRender(
+            <DynamicComponent
+                component={
+                    {
+                        name: 'SuspendedComponent',
+                        props: {
+                            dynamic_kwargs: {},
+                            polling_interval: 1,
+                            js_module: 'test',
+                            func_name: 'suspended',
+                        },
+                        uid: 'suspended-component',
+                    } satisfies PyComponentInstance
+                }
+            />
+        );
+
+        await vi.waitFor(() => expect(firstSignal).toBeDefined());
+        rendered.unmount();
+        act(() => vi.advanceTimersByTime(0));
+
+        expect(firstSignal?.aborted).toBe(true);
+    });
+
+    it('aborts a slow Python poll when an input changes and drops its stale result', async () => {
+        vi.useFakeTimers();
+        const dependency: Variable<number> = {
+            __typename: 'Variable',
+            default: 1,
+            nested: [],
+            uid: 'python-poll-dependency',
+        };
+        const component = {
+            name: 'FreshPythonComponent',
+            props: {
+                dynamic_kwargs: { value: dependency },
+                polling_interval: 1,
+                js_module: 'test',
+                func_name: 'fresh_python',
+            },
+            uid: 'fresh-python-component',
+        } satisfies PyComponentInstance;
+        let requestCount = 0;
+        let staleSignal: AbortSignal | undefined;
+
+        server.use(
+            http.post('/api/core/components/FreshPythonComponent', async ({ request }) => {
+                requestCount++;
+                if (requestCount === 2) {
+                    staleSignal = request.signal;
+                    await new Promise<void>((resolve) => {
+                        request.signal.addEventListener('abort', () => resolve(), { once: true });
+                    });
+                }
+                return HttpResponse.json({
+                    data: {
+                        name: 'RawString',
+                        props: {
+                            content: requestCount === 1 ? 'initial' : requestCount === 2 ? 'stale-poll' : 'fresh-input',
+                        },
+                    },
+                    lookup: {},
+                });
+            })
+        );
+
+        function TestHost(): JSX.Element {
+            const [, setDependency] = useVariable(dependency);
+            return (
+                <>
+                    <button onClick={() => setDependency(2)} type="button">
+                        update
+                    </button>
+                    <DynamicComponent component={component} />
+                </>
+            );
+        }
+
+        const rendered = wrappedRender(<TestHost />);
+        await vi.waitFor(() => expect(rendered.getByText('initial')).toBeInTheDocument());
+        act(() => vi.advanceTimersByTime(1200));
+        await vi.waitFor(() => expect(requestCount).toBe(2));
+        fireEvent.click(rendered.getByText('update'));
+
+        await vi.waitFor(() => expect(rendered.getByText('fresh-input')).toBeInTheDocument());
+        expect(staleSignal?.aborted).toBe(true);
+        expect(rendered.queryByText('stale-poll')).not.toBeInTheDocument();
+    });
+
     it('should publish EventBus notification on server component render', async () => {
         const receivedData: Array<DaraEventMap['SERVER_COMPONENT_LOADED']> = [];
 

--- a/packages/dara-core/tests/js/http.spec.tsx
+++ b/packages/dara-core/tests/js/http.spec.tsx
@@ -2,6 +2,7 @@ import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 
 import { request } from '@/api';
+import { RequestExtrasSerializable } from '@/api/http';
 
 const requested401 = vi.fn();
 const requested403 = vi.fn();
@@ -63,5 +64,17 @@ describe('HTTP Utils', () => {
             accept: 'application/json',
             contentType: 'application/json',
         });
+    });
+
+    it('keeps AbortSignal identity in serialized request extras', () => {
+        const firstSignal = new AbortController().signal;
+        const secondSignal = new AbortController().signal;
+
+        const first = new RequestExtrasSerializable({ signal: firstSignal }).toJSON();
+        const firstAgain = new RequestExtrasSerializable({ signal: firstSignal }).toJSON();
+        const second = new RequestExtrasSerializable({ signal: secondSignal }).toJSON();
+
+        expect(firstAgain).toBe(first);
+        expect(second).not.toBe(first);
     });
 });

--- a/packages/dara-core/tests/js/polling.spec.tsx
+++ b/packages/dara-core/tests/js/polling.spec.tsx
@@ -1,0 +1,280 @@
+import {
+    PollingCoordinator,
+    assertCurrentRequest,
+    parseRetryAfter,
+} from '@/shared/interactivity/polling';
+
+class VisibilityTarget extends EventTarget {
+    state: DocumentVisibilityState = 'visible';
+
+    setState(state: DocumentVisibilityState): void {
+        this.state = state;
+        this.dispatchEvent(new Event('visibilitychange'));
+    }
+}
+
+describe('PollingCoordinator', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+    });
+
+    function createCoordinator(
+        visibility = new VisibilityTarget(),
+        options: { jitterRatio?: number; random?: () => number } = {}
+    ): { coordinator: PollingCoordinator; visibility: VisibilityTarget } {
+        return {
+            coordinator: new PollingCoordinator({
+                getVisibilityState: () => visibility.state,
+                jitterRatio: options.jitterRatio ?? 0,
+                random: options.random,
+                visibilityTarget: visibility,
+            }),
+            visibility,
+        };
+    }
+
+    it('allows one active poll and coalesces busy refreshes into one trailing request', () => {
+        const { coordinator } = createCoordinator();
+        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
+        let active = 0;
+        let peak = 0;
+
+        coordinator.subscribe('derived:one', 1, () => {
+            const handle = coordinator.startRequest('derived:one', 'poll');
+            handles.push(handle);
+            active++;
+            peak = Math.max(peak, active);
+        });
+
+        vi.advanceTimersByTime(1000);
+        expect(handles).toHaveLength(1);
+
+        coordinator.requestRefresh('derived:one');
+        coordinator.requestRefresh('derived:one');
+        coordinator.requestRefresh('derived:one');
+        expect(handles).toHaveLength(1);
+
+        active--;
+        handles[0]!.finish({ status: 'success' });
+        expect(handles).toHaveLength(2);
+
+        active--;
+        handles[1]!.finish({ status: 'success' });
+        expect(peak).toBe(1);
+    });
+
+    it('uses fixed delay measured from request completion', () => {
+        const { coordinator } = createCoordinator();
+        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
+
+        coordinator.subscribe('derived:fixed-delay', 1, () => {
+            handles.push(coordinator.startRequest('derived:fixed-delay', 'poll'));
+        });
+
+        vi.advanceTimersByTime(1000);
+        expect(handles).toHaveLength(1);
+
+        vi.advanceTimersByTime(5000);
+        expect(handles).toHaveLength(1);
+
+        handles[0]!.finish({ status: 'success' });
+        vi.advanceTimersByTime(999);
+        expect(handles).toHaveLength(1);
+        vi.advanceTimersByTime(1);
+        expect(handles).toHaveLength(2);
+    });
+
+    it('pauses while hidden and performs exactly one prompt refresh on resume', () => {
+        const { coordinator, visibility } = createCoordinator();
+        const refresh = vi.fn(() => coordinator.startRequest('component:hidden', 'poll'));
+
+        coordinator.subscribe('component:hidden', 1, refresh);
+        visibility.setState('hidden');
+        vi.advanceTimersByTime(10_000);
+        expect(refresh).not.toHaveBeenCalled();
+
+        visibility.setState('visible');
+        expect(refresh).toHaveBeenCalledTimes(1);
+        visibility.setState('visible');
+        expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('coalesces a visibility resume that occurs while a request is active', () => {
+        const { coordinator, visibility } = createCoordinator();
+        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
+        coordinator.subscribe('component:resume-busy', 1, () => {
+            handles.push(coordinator.startRequest('component:resume-busy', 'poll'));
+        });
+
+        vi.advanceTimersByTime(1000);
+        visibility.setState('hidden');
+        visibility.setState('visible');
+        visibility.setState('hidden');
+        visibility.setState('visible');
+        expect(handles).toHaveLength(1);
+
+        handles[0]!.finish({ status: 'success' });
+        expect(handles).toHaveLength(2);
+    });
+
+    it('backs off exponentially after errors and resets after success', () => {
+        const { coordinator } = createCoordinator();
+        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
+        coordinator.subscribe('derived:backoff', 1, () => {
+            handles.push(coordinator.startRequest('derived:backoff', 'poll'));
+        });
+
+        vi.advanceTimersByTime(1000);
+        handles[0]!.finish({ status: 'error' });
+        vi.advanceTimersByTime(999);
+        expect(handles).toHaveLength(1);
+        vi.advanceTimersByTime(1);
+        expect(handles).toHaveLength(2);
+
+        handles[1]!.finish({ status: 'error' });
+        vi.advanceTimersByTime(1999);
+        expect(handles).toHaveLength(2);
+        vi.advanceTimersByTime(1);
+        expect(handles).toHaveLength(3);
+
+        handles[2]!.finish({ status: 'success' });
+        vi.advanceTimersByTime(999);
+        expect(handles).toHaveLength(3);
+        vi.advanceTimersByTime(1);
+        expect(handles).toHaveLength(4);
+    });
+
+    it('respects Retry-After when it exceeds exponential backoff', () => {
+        const { coordinator } = createCoordinator();
+        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
+        coordinator.subscribe('derived:retry-after', 1, () => {
+            handles.push(coordinator.startRequest('derived:retry-after', 'poll'));
+        });
+
+        vi.advanceTimersByTime(1000);
+        handles[0]!.finish({ status: 'error', retryAfterMs: 5000 });
+        vi.advanceTimersByTime(4999);
+        expect(handles).toHaveLength(1);
+        vi.advanceTimersByTime(1);
+        expect(handles).toHaveLength(2);
+    });
+
+    it('keeps ordinary jitter inside the configured bound', () => {
+        const early = createCoordinator(undefined, { jitterRatio: 0.1, random: () => 0 }).coordinator;
+        const late = createCoordinator(undefined, { jitterRatio: 0.1, random: () => 1 }).coordinator;
+        const earlyRefresh = vi.fn();
+        const lateRefresh = vi.fn();
+
+        early.subscribe('early', 1, earlyRefresh);
+        late.subscribe('late', 1, lateRefresh);
+
+        vi.advanceTimersByTime(899);
+        expect(earlyRefresh).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(earlyRefresh).toHaveBeenCalledTimes(1);
+        expect(lateRefresh).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(199);
+        expect(lateRefresh).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(lateRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts the owned request when its final rendered consumer unmounts', () => {
+        const { coordinator } = createCoordinator();
+        let request: ReturnType<PollingCoordinator['startRequest']> | undefined;
+        const unsubscribe = coordinator.subscribe('component:unmount', 1, () => {
+            request = coordinator.startRequest('component:unmount', 'poll');
+        });
+
+        vi.advanceTimersByTime(1000);
+        unsubscribe();
+        vi.advanceTimersByTime(0);
+
+        expect(request?.signal.aborted).toBe(true);
+    });
+
+    it('does not abort an immediately reacquired StrictMode subscription', () => {
+        const { coordinator } = createCoordinator();
+        let request: ReturnType<PollingCoordinator['startRequest']> | undefined;
+        const subscribe = (): (() => void) =>
+            coordinator.subscribe('component:strict-mode', 1, () => {
+                request = coordinator.startRequest('component:strict-mode', 'poll');
+            });
+
+        const firstCleanup = subscribe();
+        vi.advanceTimersByTime(1000);
+        firstCleanup();
+        const secondCleanup = subscribe();
+        vi.advanceTimersByTime(0);
+        expect(request?.signal.aborted).toBe(false);
+
+        secondCleanup();
+        vi.advanceTimersByTime(0);
+        expect(request?.signal.aborted).toBe(true);
+    });
+
+    it('aborts and makes a slow poll stale when a dependency request supersedes it', () => {
+        const { coordinator } = createCoordinator();
+        coordinator.subscribe('derived:freshness', 1, () => {});
+
+        const poll = coordinator.startRequest('derived:freshness', 'poll');
+        const dependency = coordinator.startRequest('derived:freshness', 'dependency');
+
+        expect(poll.signal.aborted).toBe(true);
+        expect(() => assertCurrentRequest(poll)).toThrowError(/superseded/);
+        expect(dependency.signal.aborted).toBe(false);
+
+        poll.finish({ status: 'aborted' });
+        dependency.finish({ status: 'success' });
+    });
+
+    it('deduplicates shared consumers while keeping request-extras identities independent', () => {
+        const { coordinator } = createCoordinator();
+        const sharedRefresh = vi.fn(() => coordinator.startRequest('dv:headers-a', 'poll'));
+        const otherExtrasRefresh = vi.fn(() => coordinator.startRequest('dv:headers-b', 'poll'));
+
+        coordinator.subscribe('dv:headers-a', 1, sharedRefresh);
+        coordinator.subscribe('dv:headers-a', 1, sharedRefresh);
+        coordinator.subscribe('dv:headers-b', 1, otherExtrasRefresh);
+        vi.advanceTimersByTime(1000);
+
+        expect(sharedRefresh).toHaveBeenCalledTimes(1);
+        expect(otherExtrasRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates external cancellation into the coordinator-owned signal', () => {
+        const { coordinator } = createCoordinator();
+        const navigation = new AbortController();
+        const request = coordinator.startRequest('derived:navigation', 'dependency', navigation.signal);
+
+        navigation.abort();
+
+        expect(request.signal.aborted).toBe(true);
+    });
+});
+
+describe('parseRetryAfter', () => {
+    it('parses delay seconds and HTTP dates', () => {
+        expect(
+            parseRetryAfter(
+                new Response(null, {
+                    headers: { 'Retry-After': '3' },
+                })
+            )
+        ).toBe(3000);
+
+        expect(
+            parseRetryAfter(
+                new Response(null, {
+                    headers: { 'Retry-After': 'Mon, 03 Aug 2026 12:00:05 GMT' },
+                }),
+                Date.parse('Mon, 03 Aug 2026 12:00:00 GMT')
+            )
+        ).toBe(5000);
+    });
+});

--- a/packages/dara-core/tests/js/polling.spec.tsx
+++ b/packages/dara-core/tests/js/polling.spec.tsx
@@ -1,8 +1,4 @@
-import {
-    PollingCoordinator,
-    assertCurrentRequest,
-    parseRetryAfter,
-} from '@/shared/interactivity/polling';
+import { Poller, markRetryAfter, parseRetryAfter, waitOrAbort } from '@/shared/interactivity/polling';
 
 class VisibilityTarget extends EventTarget {
     state: DocumentVisibilityState = 'visible';
@@ -13,7 +9,23 @@ class VisibilityTarget extends EventTarget {
     }
 }
 
-describe('PollingCoordinator', () => {
+interface Deferred<T> {
+    promise: Promise<T>;
+    reject: (error: unknown) => void;
+    resolve: (value: T) => void;
+}
+
+function defer<T>(): Deferred<T> {
+    let reject!: (error: unknown) => void;
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        reject = rejectPromise;
+        resolve = resolvePromise;
+    });
+    return { promise, reject, resolve };
+}
+
+describe('Poller', () => {
     beforeEach(() => {
         vi.useFakeTimers();
     });
@@ -23,12 +35,12 @@ describe('PollingCoordinator', () => {
         vi.useRealTimers();
     });
 
-    function createCoordinator(
+    function createPoller(
         visibility = new VisibilityTarget(),
         options: { jitterRatio?: number; random?: () => number } = {}
-    ): { coordinator: PollingCoordinator; visibility: VisibilityTarget } {
+    ): { poller: Poller; visibility: VisibilityTarget } {
         return {
-            coordinator: new PollingCoordinator({
+            poller: new Poller({
                 getVisibilityState: () => visibility.state,
                 jitterRatio: options.jitterRatio ?? 0,
                 random: options.random,
@@ -38,135 +50,162 @@ describe('PollingCoordinator', () => {
         };
     }
 
-    it('allows one active poll and coalesces busy refreshes into one trailing request', () => {
-        const { coordinator } = createCoordinator();
-        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
-        let active = 0;
-        let peak = 0;
-
-        coordinator.subscribe('derived:one', 1, () => {
-            const handle = coordinator.startRequest('derived:one', 'poll');
-            handles.push(handle);
-            active++;
-            peak = Math.max(peak, active);
+    function watchPolls(
+        poller: Poller,
+        key: string,
+        interval = 1
+    ): Array<Deferred<number> & { result?: Promise<number>; signal?: AbortSignal }> {
+        const runs: Array<Deferred<number> & { result?: Promise<number>; signal?: AbortSignal }> = [];
+        let saved = 0;
+        poller.subscribe(key, interval, () => {
+            const next: Deferred<number> & { result?: Promise<number>; signal?: AbortSignal } = defer<number>();
+            runs.push(next);
+            next.result = poller.run({
+                cause: 'poll',
+                key,
+                read: () => ({ found: true, value: saved }),
+                work: (signal) => {
+                    next.signal = signal;
+                    return waitOrAbort(next.promise, signal);
+                },
+                write: (value) => {
+                    saved = value;
+                },
+            });
         });
+        return runs;
+    }
+
+    it('runs one poll at a time and keeps one refresh while busy', async () => {
+        const { poller } = createPoller();
+        const runs = watchPolls(poller, 'derived:one');
 
         vi.advanceTimersByTime(1000);
-        expect(handles).toHaveLength(1);
+        poller.runNow('derived:one');
+        poller.runNow('derived:one');
+        poller.runNow('derived:one');
+        expect(runs).toHaveLength(1);
 
-        coordinator.requestRefresh('derived:one');
-        coordinator.requestRefresh('derived:one');
-        coordinator.requestRefresh('derived:one');
-        expect(handles).toHaveLength(1);
-
-        active--;
-        handles[0]!.finish({ status: 'success' });
-        expect(handles).toHaveLength(2);
-
-        active--;
-        handles[1]!.finish({ status: 'success' });
-        expect(peak).toBe(1);
+        runs[0]!.resolve(1);
+        await vi.waitFor(() => expect(runs).toHaveLength(2));
+        runs[1]!.resolve(2);
+        await expect(runs[1]!.result).resolves.toBe(2);
+        expect(runs).toHaveLength(2);
     });
 
-    it('uses fixed delay measured from request completion', () => {
-        const { coordinator } = createCoordinator();
-        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
-
-        coordinator.subscribe('derived:fixed-delay', 1, () => {
-            handles.push(coordinator.startRequest('derived:fixed-delay', 'poll'));
-        });
+    it('uses fixed delay measured from request completion', async () => {
+        const { poller } = createPoller();
+        const runs = watchPolls(poller, 'derived:fixed-delay');
 
         vi.advanceTimersByTime(1000);
-        expect(handles).toHaveLength(1);
-
         vi.advanceTimersByTime(5000);
-        expect(handles).toHaveLength(1);
+        expect(runs).toHaveLength(1);
 
-        handles[0]!.finish({ status: 'success' });
-        vi.advanceTimersByTime(999);
-        expect(handles).toHaveLength(1);
-        vi.advanceTimersByTime(1);
-        expect(handles).toHaveLength(2);
+        runs[0]!.resolve(1);
+        await vi.advanceTimersByTimeAsync(999);
+        expect(runs).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runs).toHaveLength(2);
     });
 
-    it('pauses while hidden and performs exactly one prompt refresh on resume', () => {
-        const { coordinator, visibility } = createCoordinator();
-        const refresh = vi.fn(() => coordinator.startRequest('component:hidden', 'poll'));
+    it('pauses while hidden and refreshes once when shown', () => {
+        const { poller, visibility } = createPoller();
+        const refresh = vi.fn();
+        poller.subscribe('component:hidden', 1, refresh);
 
-        coordinator.subscribe('component:hidden', 1, refresh);
         visibility.setState('hidden');
         vi.advanceTimersByTime(10_000);
         expect(refresh).not.toHaveBeenCalled();
 
         visibility.setState('visible');
-        expect(refresh).toHaveBeenCalledTimes(1);
         visibility.setState('visible');
         expect(refresh).toHaveBeenCalledTimes(1);
     });
 
-    it('coalesces a visibility resume that occurs while a request is active', () => {
-        const { coordinator, visibility } = createCoordinator();
-        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
-        coordinator.subscribe('component:resume-busy', 1, () => {
-            handles.push(coordinator.startRequest('component:resume-busy', 'poll'));
-        });
+    it('keeps one refresh when the tab becomes visible during a request', async () => {
+        const { poller, visibility } = createPoller();
+        const runs = watchPolls(poller, 'component:resume-busy');
 
         vi.advanceTimersByTime(1000);
         visibility.setState('hidden');
         visibility.setState('visible');
         visibility.setState('hidden');
         visibility.setState('visible');
-        expect(handles).toHaveLength(1);
+        expect(runs).toHaveLength(1);
 
-        handles[0]!.finish({ status: 'success' });
-        expect(handles).toHaveLength(2);
+        runs[0]!.resolve(1);
+        await vi.waitFor(() => expect(runs).toHaveLength(2));
     });
 
-    it('backs off exponentially after errors and resets after success', () => {
-        const { coordinator } = createCoordinator();
-        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
-        coordinator.subscribe('derived:backoff', 1, () => {
-            handles.push(coordinator.startRequest('derived:backoff', 'poll'));
-        });
+    it('backs off after errors and resets after success', async () => {
+        const { poller } = createPoller();
+        const runs = watchPolls(poller, 'derived:backoff');
 
         vi.advanceTimersByTime(1000);
-        handles[0]!.finish({ status: 'error' });
-        vi.advanceTimersByTime(999);
-        expect(handles).toHaveLength(1);
-        vi.advanceTimersByTime(1);
-        expect(handles).toHaveLength(2);
+        runs[0]!.reject(new Error('first'));
+        await vi.advanceTimersByTimeAsync(999);
+        expect(runs).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runs).toHaveLength(2);
 
-        handles[1]!.finish({ status: 'error' });
-        vi.advanceTimersByTime(1999);
-        expect(handles).toHaveLength(2);
-        vi.advanceTimersByTime(1);
-        expect(handles).toHaveLength(3);
+        runs[1]!.reject(new Error('second'));
+        await vi.advanceTimersByTimeAsync(1999);
+        expect(runs).toHaveLength(2);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runs).toHaveLength(3);
 
-        handles[2]!.finish({ status: 'success' });
-        vi.advanceTimersByTime(999);
-        expect(handles).toHaveLength(3);
-        vi.advanceTimersByTime(1);
-        expect(handles).toHaveLength(4);
+        runs[2]!.resolve(3);
+        await vi.advanceTimersByTimeAsync(999);
+        expect(runs).toHaveLength(3);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runs).toHaveLength(4);
     });
 
-    it('respects Retry-After when it exceeds exponential backoff', () => {
-        const { coordinator } = createCoordinator();
-        const handles: ReturnType<PollingCoordinator['startRequest']>[] = [];
-        coordinator.subscribe('derived:retry-after', 1, () => {
-            handles.push(coordinator.startRequest('derived:retry-after', 'poll'));
-        });
+    it('resets errors when a run succeeds while hidden', async () => {
+        const { poller, visibility } = createPoller();
+        const runs = watchPolls(poller, 'derived:hidden-success');
 
         vi.advanceTimersByTime(1000);
-        handles[0]!.finish({ status: 'error', retryAfterMs: 5000 });
-        vi.advanceTimersByTime(4999);
-        expect(handles).toHaveLength(1);
-        vi.advanceTimersByTime(1);
-        expect(handles).toHaveLength(2);
+        runs[0]!.reject(new Error('first'));
+        await vi.advanceTimersByTimeAsync(1000);
+        visibility.setState('hidden');
+        runs[1]!.resolve(2);
+        await expect(runs[1]!.result).resolves.toBe(2);
+        visibility.setState('visible');
+        await vi.waitFor(() => expect(runs).toHaveLength(3));
+
+        runs[2]!.reject(new Error('after success'));
+        await vi.advanceTimersByTimeAsync(999);
+        expect(runs).toHaveLength(3);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runs).toHaveLength(4);
     });
 
-    it('keeps ordinary jitter inside the configured bound', () => {
-        const early = createCoordinator(undefined, { jitterRatio: 0.1, random: () => 0 }).coordinator;
-        const late = createCoordinator(undefined, { jitterRatio: 0.1, random: () => 1 }).coordinator;
+    it('keeps Retry-After when an error finishes while hidden', async () => {
+        const { poller, visibility } = createPoller();
+        const runs = watchPolls(poller, 'derived:hidden-retry-after');
+
+        vi.advanceTimersByTime(1000);
+        visibility.setState('hidden');
+        runs[0]!.reject(
+            markRetryAfter(
+                new Error('busy'),
+                new Response(null, {
+                    headers: { 'Retry-After': '5' },
+                })
+            )
+        );
+        await Promise.resolve();
+        visibility.setState('visible');
+        await vi.advanceTimersByTimeAsync(4999);
+        expect(runs).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runs).toHaveLength(2);
+    });
+
+    it('keeps jitter inside the configured bound', () => {
+        const early = createPoller(undefined, { jitterRatio: 0.1, random: () => 0 }).poller;
+        const late = createPoller(undefined, { jitterRatio: 0.1, random: () => 1 }).poller;
         const earlyRefresh = vi.fn();
         const lateRefresh = vi.fn();
 
@@ -177,33 +216,102 @@ describe('PollingCoordinator', () => {
         expect(earlyRefresh).not.toHaveBeenCalled();
         vi.advanceTimersByTime(1);
         expect(earlyRefresh).toHaveBeenCalledTimes(1);
-        expect(lateRefresh).not.toHaveBeenCalled();
         vi.advanceTimersByTime(199);
         expect(lateRefresh).not.toHaveBeenCalled();
         vi.advanceTimersByTime(1);
         expect(lateRefresh).toHaveBeenCalledTimes(1);
     });
 
-    it('aborts the owned request when its final rendered consumer unmounts', () => {
-        const { coordinator } = createCoordinator();
-        let request: ReturnType<PollingCoordinator['startRequest']> | undefined;
-        const unsubscribe = coordinator.subscribe('component:unmount', 1, () => {
-            request = coordinator.startRequest('component:unmount', 'poll');
+    it('caps jittered error backoff at one minute', async () => {
+        const { poller } = createPoller(undefined, { jitterRatio: 0.1, random: () => 1 });
+        const runs = watchPolls(poller, 'derived:max-backoff', 60);
+
+        vi.advanceTimersByTime(66_000);
+        runs[0]!.reject(new Error('failed'));
+        await vi.advanceTimersByTimeAsync(59_999);
+        expect(runs).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runs).toHaveLength(2);
+    });
+
+    it('shortens the timer when a faster consumer starts watching', () => {
+        const { poller } = createPoller();
+        const slow = vi.fn();
+        const fast = vi.fn();
+
+        poller.subscribe('shared', 60, slow);
+        vi.advanceTimersByTime(100);
+        poller.subscribe('shared', 1, fast);
+        vi.advanceTimersByTime(999);
+        expect(fast).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(1);
+        expect(fast).toHaveBeenCalledTimes(1);
+        expect(slow).not.toHaveBeenCalled();
+    });
+
+    it('does not let an old cleanup delete a new entry', async () => {
+        const { poller } = createPoller();
+        const firstCleanup = poller.subscribe('component:owned', 1, () => {});
+
+        vi.advanceTimersByTime(1000);
+        const old = defer<number>();
+        const oldRun = poller.run({
+            cause: 'poll',
+            key: 'component:owned',
+            read: () => ({ found: true, value: 0 }),
+            work: (signal) => waitOrAbort(old.promise, signal),
+            write: () => {},
+        });
+        firstCleanup();
+        old.resolve(1);
+        await oldRun;
+
+        const refresh = vi.fn();
+        poller.subscribe('component:owned', 1, refresh);
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts the run when its final consumer unmounts', () => {
+        const { poller } = createPoller();
+        let signal: AbortSignal | undefined;
+        const never = defer<number>();
+        const unsubscribe = poller.subscribe('component:unmount', 1, () => {
+            void poller.run({
+                cause: 'poll',
+                key: 'component:unmount',
+                read: () => ({ found: true, value: 0 }),
+                work: (runSignal) => {
+                    signal = runSignal;
+                    return never.promise;
+                },
+                write: () => {},
+            });
         });
 
         vi.advanceTimersByTime(1000);
         unsubscribe();
         vi.advanceTimersByTime(0);
-
-        expect(request?.signal.aborted).toBe(true);
+        expect(signal?.aborted).toBe(true);
     });
 
-    it('does not abort an immediately reacquired StrictMode subscription', () => {
-        const { coordinator } = createCoordinator();
-        let request: ReturnType<PollingCoordinator['startRequest']> | undefined;
+    it('keeps a run through an immediate StrictMode resubscribe', () => {
+        const { poller } = createPoller();
+        let signal: AbortSignal | undefined;
+        const never = defer<number>();
         const subscribe = (): (() => void) =>
-            coordinator.subscribe('component:strict-mode', 1, () => {
-                request = coordinator.startRequest('component:strict-mode', 'poll');
+            poller.subscribe('component:strict-mode', 1, () => {
+                void poller.run({
+                    cause: 'poll',
+                    key: 'component:strict-mode',
+                    read: () => ({ found: true, value: 0 }),
+                    work: (runSignal) => {
+                        signal = runSignal;
+                        return never.promise;
+                    },
+                    write: () => {},
+                });
             });
 
         const firstCleanup = subscribe();
@@ -211,50 +319,167 @@ describe('PollingCoordinator', () => {
         firstCleanup();
         const secondCleanup = subscribe();
         vi.advanceTimersByTime(0);
-        expect(request?.signal.aborted).toBe(false);
+        expect(signal?.aborted).toBe(false);
 
         secondCleanup();
         vi.advanceTimersByTime(0);
-        expect(request?.signal.aborted).toBe(true);
+        expect(signal?.aborted).toBe(true);
     });
 
-    it('aborts and makes a slow poll stale when a dependency request supersedes it', () => {
-        const { coordinator } = createCoordinator();
-        coordinator.subscribe('derived:freshness', 1, () => {});
+    it('aborts an initial suspended run when its rendered owner unmounts', () => {
+        const { poller } = createPoller();
+        const owner = Symbol('component');
+        let signal: AbortSignal | undefined;
 
-        const poll = coordinator.startRequest('derived:freshness', 'poll');
-        const dependency = coordinator.startRequest('derived:freshness', 'dependency');
+        poller.own(owner, 'derived:first-load');
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:first-load',
+            work: (runSignal) => {
+                signal = runSignal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
+        poller.keepOwner(owner);
+        poller.releaseOwner(owner);
+        vi.advanceTimersByTime(0);
 
-        expect(poll.signal.aborted).toBe(true);
-        expect(() => assertCurrentRequest(poll)).toThrowError(/superseded/);
-        expect(dependency.signal.aborted).toBe(false);
-
-        poll.finish({ status: 'aborted' });
-        dependency.finish({ status: 'success' });
+        expect(signal?.aborted).toBe(true);
     });
 
-    it('deduplicates shared consumers while keeping request-extras identities independent', () => {
-        const { coordinator } = createCoordinator();
-        const sharedRefresh = vi.fn(() => coordinator.startRequest('dv:headers-a', 'poll'));
-        const otherExtrasRefresh = vi.fn(() => coordinator.startRequest('dv:headers-b', 'poll'));
+    it('keeps an initial run through a StrictMode owner remount', () => {
+        const { poller } = createPoller();
+        const owner = Symbol('component');
+        let signal: AbortSignal | undefined;
 
-        coordinator.subscribe('dv:headers-a', 1, sharedRefresh);
-        coordinator.subscribe('dv:headers-a', 1, sharedRefresh);
-        coordinator.subscribe('dv:headers-b', 1, otherExtrasRefresh);
+        poller.own(owner, 'derived:first-load');
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:first-load',
+            work: (runSignal) => {
+                signal = runSignal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
+        poller.keepOwner(owner);
+        poller.releaseOwner(owner);
+        poller.keepOwner(owner);
+        vi.advanceTimersByTime(0);
+
+        expect(signal?.aborted).toBe(false);
+    });
+
+    it('aborts work dropped by the next committed owner render', () => {
+        const { poller } = createPoller();
+        const owner = Symbol('component');
+        let oldSignal: AbortSignal | undefined;
+
+        poller.beginOwner(owner);
+        poller.own(owner, 'derived:old');
+        poller.keepOwner(owner);
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:old',
+            work: (signal) => {
+                oldSignal = signal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
+
+        poller.beginOwner(owner);
+        poller.own(owner, 'derived:new');
+        poller.keepOwner(owner);
+
+        expect(oldSignal?.aborted).toBe(true);
+    });
+
+    it('waits through every newer dependency run before returning', async () => {
+        const { poller } = createPoller();
+        let saved = 'old';
+        const a = defer<string>();
+        const b = defer<string>();
+        const c = defer<string>();
+        const start = (inputKey: string, work: Deferred<string>): Promise<string> =>
+            poller.run({
+                cause: 'dependency',
+                inputKey,
+                key: 'derived:freshness',
+                read: () => ({ found: true, value: saved }),
+                work: (signal) => waitOrAbort(work.promise, signal),
+                write: (value) => {
+                    saved = value;
+                },
+            });
+
+        const runA = start('a', a);
+        const runB = start('b', b);
+        const runC = start('c', c);
+        c.resolve('new');
+
+        await expect(runC).resolves.toBe('new');
+        await expect(runB).resolves.toBe('new');
+        await expect(runA).resolves.toBe('new');
+        expect(saved).toBe('new');
+    });
+
+    it('shares one promise and one fetch for matching input', async () => {
+        const { poller } = createPoller();
+        const result = defer<number>();
+        const work = vi.fn(() => result.promise);
+        const write = vi.fn();
+        const options = {
+            cause: 'dependency' as const,
+            inputKey: 'same',
+            key: 'derived:shared',
+            work,
+            write,
+        };
+
+        const first = poller.run(options);
+        const second = poller.run(options);
+        expect(second).toBe(first);
+        expect(work).toHaveBeenCalledTimes(1);
+
+        result.resolve(42);
+        await expect(first).resolves.toBe(42);
+        expect(write).toHaveBeenCalledTimes(1);
+    });
+
+    it('shares matching extras and keeps different extras apart', () => {
+        const { poller } = createPoller();
+        const sharedRefresh = vi.fn();
+        const otherExtrasRefresh = vi.fn();
+
+        poller.subscribe('dv:headers-a', 1, sharedRefresh);
+        poller.subscribe('dv:headers-a', 1, sharedRefresh);
+        poller.subscribe('dv:headers-b', 1, otherExtrasRefresh);
         vi.advanceTimersByTime(1000);
 
         expect(sharedRefresh).toHaveBeenCalledTimes(1);
         expect(otherExtrasRefresh).toHaveBeenCalledTimes(1);
     });
 
-    it('propagates external cancellation into the coordinator-owned signal', () => {
-        const { coordinator } = createCoordinator();
+    it('passes an outer abort to the run', () => {
+        const { poller } = createPoller();
         const navigation = new AbortController();
-        const request = coordinator.startRequest('derived:navigation', 'dependency', navigation.signal);
+        let signal: AbortSignal | undefined;
 
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:navigation',
+            signal: navigation.signal,
+            work: (runSignal) => {
+                signal = runSignal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
         navigation.abort();
 
-        expect(request.signal.aborted).toBe(true);
+        expect(signal?.aborted).toBe(true);
     });
 });
 

--- a/packages/dara-core/tests/js/polling.spec.tsx
+++ b/packages/dara-core/tests/js/polling.spec.tsx
@@ -64,13 +64,13 @@ describe('Poller', () => {
         poller: Poller,
         key: string,
         interval = 1
-    ): Array<Deferred<number> & { result?: Promise<number>; signal?: AbortSignal }> {
-        const runs: Array<Deferred<number> & { result?: Promise<number>; signal?: AbortSignal }> = [];
+    ): Array<Deferred<number> & { run?: Promise<number>; signal?: AbortSignal }> {
+        const runs: Array<Deferred<number> & { run?: Promise<number>; signal?: AbortSignal }> = [];
         let saved = 0;
         poller.subscribe(key, interval, () => {
-            const next: Deferred<number> & { result?: Promise<number>; signal?: AbortSignal } = defer<number>();
+            const next: Deferred<number> & { run?: Promise<number>; signal?: AbortSignal } = defer<number>();
             runs.push(next);
-            next.result = poller.run({
+            next.run = poller.run({
                 cause: 'poll',
                 key,
                 read: () => ({ found: true, value: saved }),
@@ -99,7 +99,7 @@ describe('Poller', () => {
         runs[0]!.resolve(1);
         await vi.waitFor(() => expect(runs).toHaveLength(2));
         runs[1]!.resolve(2);
-        await expect(runs[1]!.result).resolves.toBe(2);
+        await expect(runs[1]!.run).resolves.toBe(2);
         expect(runs).toHaveLength(2);
     });
 
@@ -180,7 +180,7 @@ describe('Poller', () => {
         await vi.advanceTimersByTimeAsync(1000);
         visibility.setState('hidden');
         runs[1]!.resolve(2);
-        await expect(runs[1]!.result).resolves.toBe(2);
+        await expect(runs[1]!.run).resolves.toBe(2);
         visibility.setState('visible');
         await vi.waitFor(() => expect(runs).toHaveLength(3));
 
@@ -257,6 +257,23 @@ describe('Poller', () => {
         vi.advanceTimersByTime(1);
         expect(fast).toHaveBeenCalledTimes(1);
         expect(slow).not.toHaveBeenCalled();
+    });
+
+    it('lengthens the timer when the fastest consumer stops watching', () => {
+        const { poller } = createPoller();
+        const slow = vi.fn();
+        const fast = vi.fn();
+
+        poller.subscribe('shared', 60, slow);
+        const stopFast = poller.subscribe('shared', 1, fast);
+        vi.advanceTimersByTime(500);
+        stopFast();
+
+        vi.advanceTimersByTime(500);
+        expect(slow).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(59_500);
+        expect(slow).toHaveBeenCalledTimes(1);
+        expect(fast).not.toHaveBeenCalled();
     });
 
     it('uses the latest refresh callback without restarting its timer', () => {
@@ -358,7 +375,7 @@ describe('Poller', () => {
         const owner = 'component';
         let signal: AbortSignal | undefined;
 
-        poller.commitOwner(owner, new Set(['derived:first-load']));
+        poller.commitOwner(owner, new Map([['first-hook', 'derived:first-load']]));
         void poller.run({
             cause: 'dependency',
             key: 'derived:first-load',
@@ -379,7 +396,7 @@ describe('Poller', () => {
         const owner = 'component';
         let signal: AbortSignal | undefined;
 
-        poller.commitOwner(owner, new Set(['derived:first-load']));
+        poller.commitOwner(owner, new Map([['first-hook', 'derived:first-load']]));
         void poller.run({
             cause: 'dependency',
             key: 'derived:first-load',
@@ -390,7 +407,7 @@ describe('Poller', () => {
             write: () => {},
         });
         poller.releaseOwner(owner);
-        poller.commitOwner(owner, new Set(['derived:first-load']));
+        poller.commitOwner(owner, new Map([['first-hook', 'derived:first-load']]));
         vi.advanceTimersByTime(0);
 
         expect(signal?.aborted).toBe(false);
@@ -401,7 +418,7 @@ describe('Poller', () => {
         const owner = 'component';
         let oldSignal: AbortSignal | undefined;
 
-        poller.commitOwner(owner, new Set(['derived:old']));
+        poller.commitOwner(owner, new Map([['old-hook', 'derived:old']]));
         void poller.run({
             cause: 'dependency',
             key: 'derived:old',
@@ -412,9 +429,80 @@ describe('Poller', () => {
             write: () => {},
         });
 
-        poller.commitOwner(owner, new Set(['derived:new']));
+        poller.commitOwner(owner, new Map([['new-hook', 'derived:new']]));
 
         expect(oldSignal?.aborted).toBe(true);
+    });
+
+    it('drops a suspended render claim when the owner commits without it', () => {
+        const { poller } = createPoller();
+        const owner = 'component';
+        let signal: AbortSignal | undefined;
+
+        poller.claimKey(owner, 'late-hook', 'derived:abandoned');
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:abandoned',
+            work: (runSignal) => {
+                signal = runSignal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
+
+        poller.commitOwner(owner, new Map());
+
+        expect(signal?.aborted).toBe(true);
+    });
+
+    it('does not keep a render claim after its committed hook unmounts', () => {
+        const { poller } = createPoller();
+        const owner = 'component';
+        const hook = 'hook';
+        let signal: AbortSignal | undefined;
+
+        poller.claimKey(owner, hook, 'derived:committed');
+        poller.mountKey(owner, hook, 'derived:committed');
+        poller.claimKey(owner, hook, 'derived:committed');
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:committed',
+            work: (runSignal) => {
+                signal = runSignal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
+
+        poller.unmountKey(owner, hook, 'derived:committed');
+        vi.advanceTimersByTime(0);
+
+        expect(signal?.aborted).toBe(true);
+    });
+
+    it('prunes an abandoned hook that shares a key with a committed hook', () => {
+        const { poller } = createPoller();
+        const owner = 'component';
+        let signal: AbortSignal | undefined;
+
+        poller.claimKey(owner, 'abandoned-hook', 'derived:shared');
+        poller.claimKey(owner, 'live-hook', 'derived:shared');
+        poller.mountKey(owner, 'live-hook', 'derived:shared');
+        poller.commitOwner(owner, new Map([['live-hook', 'derived:shared']]));
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:shared',
+            work: (runSignal) => {
+                signal = runSignal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
+
+        poller.unmountKey(owner, 'live-hook', 'derived:shared');
+        vi.advanceTimersByTime(0);
+
+        expect(signal?.aborted).toBe(true);
     });
 
     it('keeps a shared key until its last committed hook unmounts', () => {

--- a/packages/dara-core/tests/js/polling.spec.tsx
+++ b/packages/dara-core/tests/js/polling.spec.tsx
@@ -1,4 +1,13 @@
-import { Poller, markRetryAfter, parseRetryAfter, waitOrAbort } from '@/shared/interactivity/polling';
+import { act, renderHook } from '@testing-library/react';
+
+import {
+    Poller,
+    clearPolling_TEST,
+    markRetryAfter,
+    parseRetryAfter,
+    usePolling,
+    waitOrAbort,
+} from '@/shared/interactivity/polling';
 
 class VisibilityTarget extends EventTarget {
     state: DocumentVisibilityState = 'visible';
@@ -31,6 +40,7 @@ describe('Poller', () => {
     });
 
     afterEach(() => {
+        clearPolling_TEST();
         vi.clearAllTimers();
         vi.useRealTimers();
     });
@@ -249,6 +259,23 @@ describe('Poller', () => {
         expect(slow).not.toHaveBeenCalled();
     });
 
+    it('uses the latest refresh callback without restarting its timer', () => {
+        const firstRefresh = vi.fn();
+        const latestRefresh = vi.fn();
+        const rendered = renderHook(
+            ({ refresh }) => {
+                usePolling('derived:latest-refresh', 1, refresh);
+            },
+            { initialProps: { refresh: firstRefresh } }
+        );
+
+        rendered.rerender({ refresh: latestRefresh });
+        act(() => vi.advanceTimersByTime(1200));
+
+        expect(firstRefresh).not.toHaveBeenCalled();
+        expect(latestRefresh).toHaveBeenCalledTimes(1);
+    });
+
     it('does not let an old cleanup delete a new entry', async () => {
         const { poller } = createPoller();
         const firstCleanup = poller.subscribe('component:owned', 1, () => {});
@@ -328,10 +355,10 @@ describe('Poller', () => {
 
     it('aborts an initial suspended run when its rendered owner unmounts', () => {
         const { poller } = createPoller();
-        const owner = Symbol('component');
+        const owner = 'component';
         let signal: AbortSignal | undefined;
 
-        poller.own(owner, 'derived:first-load');
+        poller.commitOwner(owner, new Set(['derived:first-load']));
         void poller.run({
             cause: 'dependency',
             key: 'derived:first-load',
@@ -341,7 +368,6 @@ describe('Poller', () => {
             },
             write: () => {},
         });
-        poller.keepOwner(owner);
         poller.releaseOwner(owner);
         vi.advanceTimersByTime(0);
 
@@ -350,10 +376,10 @@ describe('Poller', () => {
 
     it('keeps an initial run through a StrictMode owner remount', () => {
         const { poller } = createPoller();
-        const owner = Symbol('component');
+        const owner = 'component';
         let signal: AbortSignal | undefined;
 
-        poller.own(owner, 'derived:first-load');
+        poller.commitOwner(owner, new Set(['derived:first-load']));
         void poller.run({
             cause: 'dependency',
             key: 'derived:first-load',
@@ -363,9 +389,8 @@ describe('Poller', () => {
             },
             write: () => {},
         });
-        poller.keepOwner(owner);
         poller.releaseOwner(owner);
-        poller.keepOwner(owner);
+        poller.commitOwner(owner, new Set(['derived:first-load']));
         vi.advanceTimersByTime(0);
 
         expect(signal?.aborted).toBe(false);
@@ -373,12 +398,10 @@ describe('Poller', () => {
 
     it('aborts work dropped by the next committed owner render', () => {
         const { poller } = createPoller();
-        const owner = Symbol('component');
+        const owner = 'component';
         let oldSignal: AbortSignal | undefined;
 
-        poller.beginOwner(owner);
-        poller.own(owner, 'derived:old');
-        poller.keepOwner(owner);
+        poller.commitOwner(owner, new Set(['derived:old']));
         void poller.run({
             cause: 'dependency',
             key: 'derived:old',
@@ -389,11 +412,37 @@ describe('Poller', () => {
             write: () => {},
         });
 
-        poller.beginOwner(owner);
-        poller.own(owner, 'derived:new');
-        poller.keepOwner(owner);
+        poller.commitOwner(owner, new Set(['derived:new']));
 
         expect(oldSignal?.aborted).toBe(true);
+    });
+
+    it('keeps a shared key until its last committed hook unmounts', () => {
+        const { poller } = createPoller();
+        const owner = 'component';
+        const firstHook = 'first';
+        const secondHook = 'second';
+        let signal: AbortSignal | undefined;
+
+        poller.mountKey(owner, firstHook, 'derived:shared');
+        poller.mountKey(owner, secondHook, 'derived:shared');
+        void poller.run({
+            cause: 'dependency',
+            key: 'derived:shared',
+            work: (runSignal) => {
+                signal = runSignal;
+                return new Promise(() => {});
+            },
+            write: () => {},
+        });
+
+        poller.unmountKey(owner, firstHook, 'derived:shared');
+        vi.advanceTimersByTime(0);
+        expect(signal?.aborted).toBe(false);
+
+        poller.unmountKey(owner, secondHook, 'derived:shared');
+        vi.advanceTimersByTime(0);
+        expect(signal?.aborted).toBe(true);
     });
 
     it('waits through every newer dependency run before returning', async () => {

--- a/packages/dara-core/tests/js/route-loader.spec.tsx
+++ b/packages/dara-core/tests/js/route-loader.spec.tsx
@@ -2,12 +2,13 @@ import { act, render, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import * as React from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router';
-import { useRecoilCallback } from 'recoil';
+import { snapshot_UNSTABLE, useRecoilCallback } from 'recoil';
 
+import { type WebSocketClientInterface } from '@/api';
 import { setSessionIdentifier } from '@/auth';
 import { createRoute } from '@/router/create-router';
-import { ResponseChunk } from '@/router/fetching';
-import { clearRegistries_TEST, useVariable } from '@/shared';
+import { ResponseChunk, fetchRouteData } from '@/router/fetching';
+import { clearRegistries_TEST, deferred, useVariable } from '@/shared';
 import DynamicComponent, { clearCaches_TEST, preloadComponents } from '@/shared/dynamic-component/dynamic-component';
 import { clearStreamUsage_TEST } from '@/shared/interactivity/stream-usage-tracker';
 import { preloadActions } from '@/shared/interactivity/use-action';
@@ -26,7 +27,7 @@ import {
 
 import { Wrapper, server } from './utils';
 import { mockActions, mockComponents } from './utils/test-server-handlers';
-import { importers } from './utils/wrapped-render';
+import { importers, wsClient } from './utils/wrapped-render';
 
 const TEST_TOKEN = 'TEST_TOKEN';
 
@@ -126,6 +127,167 @@ describe('Route Loader', () => {
                 })
             ).toBeVisible()
         );
+    });
+
+    it('keeps settled route chunks and cancels only pending work when an old navigation aborts', async () => {
+        const firstDv: DerivedVariable = {
+            __typename: 'DerivedVariable',
+            deps: [],
+            nested: [],
+            uid: 'first-route-dv',
+            variables: [],
+        };
+        const pendingDv: DerivedVariable = {
+            __typename: 'DerivedVariable',
+            deps: [],
+            nested: [],
+            uid: 'pending-route-dv',
+            variables: [],
+        };
+        const pendingPy = {
+            name: 'PendingRouteComponent',
+            props: {
+                dynamic_kwargs: {},
+                polling_interval: null,
+                js_module: 'test',
+                func_name: 'pending_route',
+            },
+            uid: 'pending-route-py',
+        } satisfies PyComponentInstance;
+        const route = {
+            id: 'streaming-route',
+            case_sensitive: false,
+            index: true,
+            full_path: '/streaming-route',
+            __typename: 'IndexRoute',
+            dependency_graph: {
+                derived_variables: {
+                    [firstDv.uid]: firstDv,
+                    [pendingDv.uid]: pendingDv,
+                },
+                py_components: {
+                    [pendingPy.uid]: pendingPy,
+                },
+            },
+        } satisfies RouteDefinition;
+        const encoder = new TextEncoder();
+        let requestCount = 0;
+        const firstBodyCancel = vi.fn();
+        const send = (controller: ReadableStreamDefaultController<Uint8Array>, chunk: ResponseChunk): void => {
+            controller.enqueue(encoder.encode(`${JSON.stringify(chunk)}\n`));
+        };
+
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+            requestCount++;
+            const currentRequest = requestCount;
+            const stream = new ReadableStream<Uint8Array>({
+                cancel: currentRequest === 1 ? firstBodyCancel : undefined,
+                start(controller) {
+                    send(controller, {
+                        type: 'template',
+                        template: {
+                            data: {
+                                name: 'TestPropsComponent',
+                                props: { text: currentRequest === 1 ? 'old' : 'latest' },
+                                uid: `template-${currentRequest}`,
+                            },
+                            lookup: {},
+                        },
+                    });
+                    send(controller, { type: 'actions', actions: {} });
+                    send(controller, {
+                        type: 'derived_variable',
+                        uid: firstDv.uid,
+                        result: { ok: true, value: currentRequest === 1 ? 'old-dv' : 'latest-dv' },
+                    });
+                    if (currentRequest === 2) {
+                        send(controller, {
+                            type: 'derived_variable',
+                            uid: pendingDv.uid,
+                            result: { ok: true, value: 'latest-pending-dv' },
+                        });
+                        send(controller, {
+                            type: 'py_component',
+                            uid: pendingPy.uid,
+                            result: { ok: true, value: 'latest-py' },
+                        });
+                        controller.close();
+                    }
+                },
+            });
+            return new Response(stream, {
+                headers: { 'content-type': 'application/x-ndjson' },
+            });
+        });
+
+        if (!window.dara) {
+            const ws = deferred<WebSocketClientInterface>();
+            ws.resolve(wsClient);
+            window.dara = { base_url: '', ws };
+        }
+        const snapshot = snapshot_UNSTABLE();
+        const oldNavigation = new AbortController();
+        const oldData = await fetchRouteData(route, {}, snapshot, oldNavigation.signal);
+        const latestData = await fetchRouteData(route, {}, snapshot, new AbortController().signal);
+
+        const oldResolvedDv = oldData.derived_variables.find((handle) => handle.dv.uid === firstDv.uid)!;
+        const oldPendingDv = oldData.derived_variables.find((handle) => handle.dv.uid === pendingDv.uid)!;
+        const oldPendingPy = oldData.py_components.find((handle) => handle.py.uid === pendingPy.uid)!;
+        const pendingDvResult = oldPendingDv.handle.getValue();
+        const pendingPyResult = oldPendingPy.handle.getValue();
+
+        oldNavigation.abort();
+
+        await expect(pendingDvResult).rejects.toMatchObject({ name: 'AbortError' });
+        await expect(pendingPyResult).rejects.toMatchObject({ name: 'AbortError' });
+        await vi.waitFor(() => expect(firstBodyCancel).toHaveBeenCalledTimes(1));
+        expect(oldResolvedDv.handle.status).toBe('resolved');
+        await expect(oldResolvedDv.handle.getValue()).resolves.toEqual({ ok: true, value: 'old-dv' });
+        expect(oldData.template).toMatchObject({ props: { text: 'old' } });
+        expect(oldData.on_load).toEqual([]);
+
+        expect(latestData.template).toMatchObject({ props: { text: 'latest' } });
+        await expect(latestData.derived_variables[0]!.handle.getValue()).resolves.toMatchObject({ ok: true });
+        await expect(latestData.derived_variables[1]!.handle.getValue()).resolves.toMatchObject({ ok: true });
+        await expect(latestData.py_components[0]!.handle.getValue()).resolves.toMatchObject({ ok: true });
+    });
+
+    it('rejects the route load and cancels the body when navigation aborts before any chunks', async () => {
+        const route = {
+            id: 'empty-streaming-route',
+            case_sensitive: false,
+            index: true,
+            full_path: '/empty-streaming-route',
+            __typename: 'IndexRoute',
+        } satisfies RouteDefinition;
+        const bodyCancel = vi.fn();
+        const readerStarted = deferred<void>();
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+            const stream = new ReadableStream<Uint8Array>({
+                cancel: bodyCancel,
+                pull() {
+                    if (readerStarted.status === 'pending') {
+                        readerStarted.resolve();
+                    }
+                },
+            });
+            return new Response(stream, {
+                headers: { 'content-type': 'application/x-ndjson' },
+            });
+        });
+
+        if (!window.dara) {
+            const ws = deferred<WebSocketClientInterface>();
+            ws.resolve(wsClient);
+            window.dara = { base_url: '', ws };
+        }
+        const navigation = new AbortController();
+        const result = fetchRouteData(route, {}, snapshot_UNSTABLE(), navigation.signal);
+        await readerStarted.getValue();
+        navigation.abort();
+
+        await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+        await vi.waitFor(() => expect(bodyCancel).toHaveBeenCalledTimes(1));
     });
 
     it('executes on_load actions', async () => {

--- a/packages/dara-core/tests/js/route-loader.spec.tsx
+++ b/packages/dara-core/tests/js/route-loader.spec.tsx
@@ -37,6 +37,7 @@ describe('Route Loader', () => {
     });
 
     beforeEach(async () => {
+        window.history.replaceState({}, '', '/');
         window.localStorage.clear();
         clearRegistries_TEST();
         clearCaches_TEST();
@@ -252,6 +253,82 @@ describe('Route Loader', () => {
         await expect(latestData.py_components[0]!.handle.getValue()).resolves.toMatchObject({ ok: true });
     });
 
+    it('keeps the latest route when an older partial stream aborts', async () => {
+        const route = {
+            id: 'latest-route',
+            case_sensitive: false,
+            children: [],
+            full_path: '/latest-route/:page',
+            path: '/latest-route/:page',
+            __typename: 'PageRoute',
+        } satisfies RouteDefinition;
+        const encoder = new TextEncoder();
+        let requestCount = 0;
+        const oldBodyCancel = vi.fn();
+        const oldTemplateSent = deferred<void>();
+        const send = (controller: ReadableStreamDefaultController<Uint8Array>, text: string): void => {
+            controller.enqueue(
+                encoder.encode(
+                    `${JSON.stringify({
+                        type: 'template',
+                        template: {
+                            data: {
+                                name: 'TestPropsComponent',
+                                props: { text },
+                                uid: `template-${text}`,
+                            },
+                            lookup: {},
+                        },
+                    } satisfies ResponseChunk)}\n`
+                )
+            );
+        };
+
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+            const currentRequest = ++requestCount;
+            const stream = new ReadableStream<Uint8Array>({
+                cancel: currentRequest === 2 ? oldBodyCancel : undefined,
+                start(controller) {
+                    const text = currentRequest === 1 ? 'initial' : currentRequest === 2 ? 'old' : 'latest';
+                    send(controller, text);
+                    if (currentRequest === 2) {
+                        oldTemplateSent.resolve();
+                        return;
+                    }
+                    controller.enqueue(encoder.encode(`${JSON.stringify({ type: 'actions', actions: {} })}\n`));
+                    controller.close();
+                },
+            });
+            return new Response(stream, {
+                headers: { 'content-type': 'application/x-ndjson' },
+            });
+        });
+
+        if (!window.dara) {
+            const ws = deferred<WebSocketClientInterface>();
+            ws.resolve(wsClient);
+            window.dara = { base_url: '', ws };
+        }
+        window.history.pushState({}, '', '/latest-route/initial');
+        const router = createBrowserRouter([createRoute(route, () => snapshot_UNSTABLE(), new Map())]);
+        const rendered = render(<RouterProvider router={router} />, {
+            wrapper: (props: { children: React.ReactNode }) => <Wrapper withRouter={false}>{props.children}</Wrapper>,
+        });
+        await waitFor(() => expect(rendered.getByText('initial', { exact: false })).toBeVisible());
+
+        const oldNavigation = router.navigate('/latest-route/old');
+        await oldTemplateSent.getValue();
+        const latestNavigation = router.navigate('/latest-route/latest');
+
+        await latestNavigation;
+        await oldNavigation;
+        await waitFor(() => expect(rendered.getByText('latest', { exact: false })).toBeVisible());
+        expect(rendered.queryByText('old', { exact: false })).not.toBeInTheDocument();
+        await vi.waitFor(() => expect(oldBodyCancel).toHaveBeenCalledTimes(1));
+
+        router.dispose();
+    });
+
     it('rejects the route load and cancels the body when navigation aborts before any chunks', async () => {
         const route = {
             id: 'empty-streaming-route',
@@ -284,6 +361,59 @@ describe('Route Loader', () => {
         const navigation = new AbortController();
         const result = fetchRouteData(route, {}, snapshot_UNSTABLE(), navigation.signal);
         await readerStarted.getValue();
+        navigation.abort();
+
+        await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+        await vi.waitFor(() => expect(bodyCancel).toHaveBeenCalledTimes(1));
+    });
+
+    it('keeps an early template settled when navigation aborts before actions', async () => {
+        const route = {
+            id: 'partial-streaming-route',
+            case_sensitive: false,
+            index: true,
+            full_path: '/partial-streaming-route',
+            __typename: 'IndexRoute',
+        } satisfies RouteDefinition;
+        const bodyCancel = vi.fn();
+        const templateSent = deferred<void>();
+        vi.spyOn(globalThis, 'fetch').mockImplementation(async () => {
+            const stream = new ReadableStream<Uint8Array>({
+                cancel: bodyCancel,
+                start(controller) {
+                    const encoder = new TextEncoder();
+                    controller.enqueue(
+                        encoder.encode(
+                            `${JSON.stringify({
+                                type: 'template',
+                                template: {
+                                    data: {
+                                        name: 'TestPropsComponent',
+                                        props: { text: 'early' },
+                                        uid: 'early-template',
+                                    },
+                                    lookup: {},
+                                },
+                            } satisfies ResponseChunk)}\n`
+                        )
+                    );
+                    templateSent.resolve();
+                },
+            });
+            return new Response(stream, {
+                headers: { 'content-type': 'application/x-ndjson' },
+            });
+        });
+
+        if (!window.dara) {
+            const ws = deferred<WebSocketClientInterface>();
+            ws.resolve(wsClient);
+            window.dara = { base_url: '', ws };
+        }
+        const navigation = new AbortController();
+        const result = fetchRouteData(route, {}, snapshot_UNSTABLE(), navigation.signal);
+        await templateSent.getValue();
+        await new Promise((resolve) => setTimeout(resolve, 0));
         navigation.abort();
 
         await expect(result).rejects.toMatchObject({ name: 'AbortError' });

--- a/packages/dara-core/tests/js/use-variable.spec.tsx
+++ b/packages/dara-core/tests/js/use-variable.spec.tsx
@@ -931,6 +931,62 @@ describe('useVariable', () => {
             expect(firstSignal?.aborted).toBe(true);
         });
 
+        it('keeps a dependency request owned while Suspense hides its consumer', async () => {
+            vi.useFakeTimers();
+            const dependency: Variable<number> = {
+                __typename: 'Variable',
+                default: 1,
+                nested: [],
+                uid: 'suspended-refresh-dependency',
+            };
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [dependency],
+                nested: [],
+                uid: 'suspended-refresh-derived',
+                variables: [dependency],
+            };
+            let finishRequest!: () => void;
+            const requestGate = new Promise<void>((resolve) => {
+                finishRequest = resolve;
+            });
+            let requestCount = 0;
+            let refreshSignal: AbortSignal | undefined;
+
+            server.use(
+                http.post('/api/core/derived-variable/suspended-refresh-derived', async ({ request }) => {
+                    requestCount++;
+                    if (requestCount === 2) {
+                        refreshSignal = request.signal;
+                        await requestGate;
+                    }
+                    return HttpResponse.json({
+                        cache_key: String(requestCount),
+                        value: requestCount,
+                    });
+                })
+            );
+
+            const rendered = renderHook(
+                () => {
+                    const [value] = useVariable<number>(variable);
+                    const [, setDependency] = useVariable<number>(dependency);
+                    return { setDependency, value };
+                },
+                { wrapper: Wrapper }
+            );
+
+            await waitFor(() => expect(rendered.result.current.value).toBe(1));
+            act(() => rendered.result.current.setDependency(2));
+            await vi.waitFor(() => expect(refreshSignal).toBeDefined());
+
+            act(() => vi.advanceTimersByTime(0));
+            expect(refreshSignal?.aborted).toBe(false);
+
+            finishRequest();
+            await vi.waitFor(() => expect(rendered.result.current.value).toBe(2));
+        });
+
         it('aborts a slow poll for a dependency change and does not publish its stale result', async () => {
             vi.useFakeTimers();
             const dependency: Variable<number> = {

--- a/packages/dara-core/tests/js/use-variable.spec.tsx
+++ b/packages/dara-core/tests/js/use-variable.spec.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-restricted-globals */
 import { type Matcher, type MatcherOptions, act, fireEvent, render, renderHook, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
+import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router';
 import { useRecoilCallback } from 'recoil';
 
@@ -30,7 +31,7 @@ import { getIdentifier } from '../../js/shared/utils/normalization';
 import { Wrapper, server, wrappedRender } from './utils';
 import { mockLocalStorage } from './utils/mock-storage';
 import { mockActions } from './utils/test-server-handlers';
-import { importers } from './utils/wrapped-render';
+import { importers, wsClient } from './utils/wrapped-render';
 
 // Mock lodash debounce out so it doesn't cause timing issues in the tests
 vi.mock('lodash/debounce', () => ({ default: vi.fn((fn) => fn) }));
@@ -931,6 +932,59 @@ describe('useVariable', () => {
             expect(firstSignal?.aborted).toBe(true);
         });
 
+        it('aborts a later mounted suspended request when its owner unmounts', async () => {
+            vi.useFakeTimers();
+            let finishRequest!: () => void;
+            const requestGate = new Promise<void>((resolve) => {
+                finishRequest = resolve;
+            });
+            let requestSignal: AbortSignal | undefined;
+            server.use(
+                http.post('/api/core/derived-variable/later-suspended-derived', async ({ request }) => {
+                    requestSignal = request.signal;
+                    await requestGate;
+                    return HttpResponse.json({ cache_key: 'late', value: 'late' });
+                })
+            );
+
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [],
+                nested: [],
+                uid: 'later-suspended-derived',
+                variables: [],
+            };
+
+            function Consumer(): JSX.Element {
+                const [value] = useVariable<string>(variable);
+                return <span>{value}</span>;
+            }
+
+            function Host(): JSX.Element {
+                const [shown, setShown] = useState(false);
+                return (
+                    <>
+                        <button onClick={() => setShown(true)} type="button">
+                            show
+                        </button>
+                        {shown && <Consumer />}
+                    </>
+                );
+            }
+
+            const rendered = render(<Host />, { wrapper: Wrapper });
+            fireEvent.click(rendered.getByText('show'));
+            await act(async () => vi.advanceTimersByTimeAsync(20));
+            await vi.waitFor(() => expect(requestSignal).toBeDefined());
+
+            rendered.unmount();
+            act(() => vi.advanceTimersByTime(0));
+            const aborted = requestSignal?.aborted;
+            finishRequest();
+
+            expect(aborted).toBe(true);
+        });
+
         it('keeps a dependency request owned while Suspense hides its consumer', async () => {
             vi.useFakeTimers();
             const dependency: Variable<number> = {
@@ -1044,6 +1098,71 @@ describe('useVariable', () => {
             expect(rendered.result.current.value).not.toBe('stale-poll');
         });
 
+        it('does not let a superseded debounced read handle the current task', async () => {
+            vi.useFakeTimers();
+            const dependency: Variable<number> = {
+                __typename: 'Variable',
+                default: 1,
+                nested: [],
+                uid: 'debounced-task-dependency',
+            };
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [dependency],
+                nested: [],
+                uid: 'debounced-task-derived',
+                variables: [dependency],
+            };
+            let requestCount = 0;
+            let finishTask!: () => void;
+            const taskDone = new Promise<void>((resolve) => {
+                finishTask = resolve;
+            });
+            const waitForTask = vi.spyOn(wsClient, 'waitForTask').mockReturnValue(taskDone);
+            const cancelTask = vi.fn(() => new HttpResponse(null, { status: 200 }));
+
+            server.use(
+                http.post('/api/core/derived-variable/debounced-task-derived', () => {
+                    requestCount++;
+                    if (requestCount === 1) {
+                        return HttpResponse.json({ cache_key: 'initial', value: 'initial' });
+                    }
+                    if (requestCount === 2) {
+                        return HttpResponse.json({ cache_key: 'latest-task', task_id: 'latest-task' });
+                    }
+                    return HttpResponse.json({ cache_key: 'latest', value: 'latest' });
+                }),
+                http.delete('/api/core/tasks/latest-task', cancelTask),
+                http.get('/api/core/tasks/latest-task', () => HttpResponse.json('latest'))
+            );
+
+            const rendered = renderHook(
+                () => {
+                    const [value] = useVariable<string>(variable);
+                    const [, setDependency] = useVariable<number>(dependency);
+                    return { setDependency, value };
+                },
+                { wrapper: Wrapper }
+            );
+
+            await act(async () => vi.advanceTimersByTimeAsync(20));
+            await vi.waitFor(() => expect(rendered.result.current.value).toBe('initial'));
+            act(() => rendered.result.current.setDependency(2));
+            await act(async () => Promise.resolve());
+            act(() => rendered.result.current.setDependency(3));
+            await act(async () => vi.advanceTimersByTimeAsync(20));
+            await vi.waitFor(() => expect(waitForTask).toHaveBeenCalled());
+
+            expect(waitForTask).toHaveBeenCalledTimes(1);
+            expect(cancelTask).not.toHaveBeenCalled();
+
+            await act(async () => finishTask());
+            await vi.waitFor(() => expect(rendered.result.current.value).toBe('latest'));
+
+            rendered.unmount();
+            await act(async () => vi.advanceTimersByTimeAsync(0));
+        });
+
         it('deduplicates shared polling consumers within each RequestExtras identity', async () => {
             vi.useFakeTimers();
             const variable: DerivedVariable = {
@@ -1093,6 +1212,170 @@ describe('useVariable', () => {
                 expect(requestsByExtras.get('shared')).toBe(2);
                 expect(requestsByExtras.get('other')).toBe(2);
             });
+        });
+
+        it('keeps requests with different external signals independent', async () => {
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [],
+                nested: [],
+                uid: 'signal-scoped-derived',
+                variables: [],
+            };
+            const firstNavigation = new AbortController();
+            const secondNavigation = new AbortController();
+            const requestSignals: AbortSignal[] = [];
+            const releases: Array<() => void> = [];
+
+            server.use(
+                http.post('/api/core/derived-variable/signal-scoped-derived', async ({ request }) => {
+                    const requestNumber = requestSignals.push(request.signal);
+                    await new Promise<void>((resolve) => releases.push(resolve));
+                    return HttpResponse.json({
+                        cache_key: String(requestNumber),
+                        value: `value-${requestNumber}`,
+                    });
+                })
+            );
+
+            function Consumer({ testId }: { testId: string }): JSX.Element {
+                const [value] = useVariable<string>(variable);
+                return <span data-testid={testId}>{value}</span>;
+            }
+
+            function Consumers({ showFirst }: { showFirst: boolean }): JSX.Element {
+                return (
+                    <>
+                        {showFirst && (
+                            <RequestExtrasProvider options={{ signal: firstNavigation.signal }}>
+                                <Consumer testId="first" />
+                            </RequestExtrasProvider>
+                        )}
+                        <RequestExtrasProvider options={{ signal: secondNavigation.signal }}>
+                            <Consumer testId="second" />
+                        </RequestExtrasProvider>
+                    </>
+                );
+            }
+
+            const rendered = wrappedRender(<Consumers showFirst />);
+            await vi.waitFor(() => expect(requestSignals).toHaveLength(2));
+            act(() => {
+                firstNavigation.abort();
+                rendered.rerender(<Consumers showFirst={false} />);
+            });
+
+            await vi.waitFor(() => expect(requestSignals.filter((signal) => signal.aborted)).toHaveLength(1));
+            expect(requestSignals.filter((signal) => !signal.aborted)).toHaveLength(1);
+
+            await act(async () => {
+                for (const release of releases) {
+                    release();
+                }
+            });
+            await vi.waitFor(() => expect(rendered.getByTestId('second')).toHaveTextContent(/^value-/));
+        });
+
+        it('keeps a shared nested poll alive until its last consumer unmounts', async () => {
+            vi.useFakeTimers();
+            const firstView: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [],
+                nested: ['first'],
+                polling_interval: 1,
+                uid: 'shared-nested-poll',
+                variables: [],
+            };
+            const secondView: DerivedVariable = {
+                ...firstView,
+                nested: ['second'],
+            };
+            let requestCount = 0;
+            let pollSignal: AbortSignal | undefined;
+            server.use(
+                http.post('/api/core/derived-variable/shared-nested-poll', async ({ request }) => {
+                    requestCount++;
+                    if (requestCount === 2) {
+                        pollSignal = request.signal;
+                        await new Promise<void>((resolve) => {
+                            request.signal.addEventListener('abort', () => resolve(), { once: true });
+                        });
+                    }
+                    return HttpResponse.json({
+                        cache_key: String(requestCount),
+                        value: {
+                            first: `first-${requestCount}`,
+                            second: `second-${requestCount}`,
+                        },
+                    });
+                })
+            );
+
+            function NestedConsumer({ testId, variable }: { testId: string; variable: DerivedVariable }): JSX.Element {
+                const [value] = useVariable<string>(variable);
+                return <span data-testid={testId}>{value}</span>;
+            }
+
+            function Consumers({ showFirst, showSecond }: { showFirst: boolean; showSecond: boolean }): JSX.Element {
+                return (
+                    <>
+                        {showFirst && <NestedConsumer testId="first" variable={firstView} />}
+                        {showSecond && <NestedConsumer testId="second" variable={secondView} />}
+                    </>
+                );
+            }
+
+            const rendered = wrappedRender(<Consumers showFirst showSecond />);
+            await act(async () => vi.advanceTimersByTimeAsync(20));
+            await vi.waitFor(() => expect(rendered.getByTestId('first')).toHaveTextContent('first-1'));
+            expect(rendered.getByTestId('second')).toHaveTextContent('second-1');
+
+            act(() => vi.advanceTimersByTime(1200));
+            await vi.waitFor(() => expect(pollSignal).toBeDefined());
+
+            rendered.rerender(<Consumers showFirst={false} showSecond />);
+            act(() => vi.advanceTimersByTime(0));
+            expect(pollSignal?.aborted).toBe(false);
+
+            rendered.rerender(<Consumers showFirst={false} showSecond={false} />);
+            act(() => vi.advanceTimersByTime(0));
+            expect(pollSignal?.aborted).toBe(true);
+        });
+
+        it('honors Retry-After returned by a DerivedVariable poll', async () => {
+            vi.useFakeTimers();
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [],
+                nested: [],
+                polling_interval: 1,
+                uid: 'retry-after-derived',
+                variables: [],
+            };
+            let requestCount = 0;
+            server.use(
+                http.post('/api/core/derived-variable/retry-after-derived', () => {
+                    requestCount++;
+                    if (requestCount === 2) {
+                        return new HttpResponse(null, {
+                            headers: { 'Retry-After': '5' },
+                            status: 503,
+                        });
+                    }
+                    return HttpResponse.json({ cache_key: String(requestCount), value: requestCount });
+                })
+            );
+
+            const rendered = renderHook(() => useVariable<number>(variable), { wrapper: Wrapper });
+            await act(async () => vi.advanceTimersByTimeAsync(20));
+            await vi.waitFor(() => expect(rendered.result.current[0]).toBe(1));
+
+            act(() => vi.advanceTimersByTime(1200));
+            await vi.waitFor(() => expect(requestCount).toBe(2));
+            await act(async () => vi.advanceTimersByTimeAsync(4800));
+            expect(requestCount).toBe(2);
+            await act(async () => vi.advanceTimersByTimeAsync(500));
+            await vi.waitFor(() => expect(requestCount).toBe(3));
         });
 
         it('should support SwitchVariable as polling_interval and stop polling when disabled', async () => {

--- a/packages/dara-core/tests/js/use-variable.spec.tsx
+++ b/packages/dara-core/tests/js/use-variable.spec.tsx
@@ -845,6 +845,165 @@ describe('useVariable', () => {
             });
         });
 
+        it('keeps slow DerivedVariable polling at one request in flight and aborts on unmount', async () => {
+            vi.useFakeTimers();
+            let requestCount = 0;
+            let activeRequests = 0;
+            let peakRequests = 0;
+            let slowPollSignal: AbortSignal | undefined;
+
+            server.use(
+                http.post('/api/core/derived-variable/slow-polling-derived', async ({ request }) => {
+                    requestCount++;
+                    activeRequests++;
+                    peakRequests = Math.max(peakRequests, activeRequests);
+
+                    if (requestCount > 1) {
+                        slowPollSignal = request.signal;
+                        await new Promise<void>((resolve) => {
+                            request.signal.addEventListener('abort', () => resolve(), { once: true });
+                        });
+                    }
+
+                    activeRequests--;
+                    return HttpResponse.json({
+                        cache_key: String(requestCount),
+                        value: requestCount,
+                    });
+                })
+            );
+
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [],
+                nested: [],
+                polling_interval: 1,
+                uid: 'slow-polling-derived',
+                variables: [],
+            };
+            const rendered = renderHook(() => useVariable<number>(variable), { wrapper: Wrapper });
+
+            await waitFor(() => expect(rendered.result.current[0]).toBe(1));
+            act(() => vi.advanceTimersByTime(1200));
+            await vi.waitFor(() => expect(requestCount).toBe(2));
+
+            act(() => vi.advanceTimersByTime(10_000));
+            expect(requestCount).toBe(2);
+            expect(peakRequests).toBe(1);
+
+            rendered.unmount();
+            act(() => vi.advanceTimersByTime(0));
+            expect(slowPollSignal?.aborted).toBe(true);
+        });
+
+        it('aborts a slow poll for a dependency change and does not publish its stale result', async () => {
+            vi.useFakeTimers();
+            const dependency: Variable<number> = {
+                __typename: 'Variable',
+                default: 1,
+                nested: [],
+                uid: 'poll-freshness-dependency',
+            };
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [dependency],
+                nested: [],
+                polling_interval: 1,
+                uid: 'poll-freshness-derived',
+                variables: [dependency],
+            };
+
+            let requestCount = 0;
+            let stalePollSignal: AbortSignal | undefined;
+            server.use(
+                http.post('/api/core/derived-variable/poll-freshness-derived', async ({ request }) => {
+                    requestCount++;
+                    if (requestCount === 2) {
+                        stalePollSignal = request.signal;
+                        await new Promise<void>((resolve) => {
+                            request.signal.addEventListener('abort', () => resolve(), { once: true });
+                        });
+                        return HttpResponse.json({ cache_key: 'stale', value: 'stale-poll' });
+                    }
+                    return HttpResponse.json({
+                        cache_key: String(requestCount),
+                        value: requestCount === 1 ? 'initial' : 'fresh-dependency',
+                    });
+                })
+            );
+
+            const rendered = renderHook(
+                () => {
+                    const [value] = useVariable<string>(variable);
+                    const [, setDependency] = useVariable<number>(dependency);
+                    return { setDependency, value };
+                },
+                { wrapper: Wrapper }
+            );
+
+            await waitFor(() => expect(rendered.result.current.value).toBe('initial'));
+            act(() => vi.advanceTimersByTime(1200));
+            await vi.waitFor(() => expect(requestCount).toBe(2));
+
+            act(() => rendered.result.current.setDependency(2));
+            await vi.waitFor(() => expect(requestCount).toBe(3));
+            await vi.waitFor(() => expect(rendered.result.current.value).toBe('fresh-dependency'));
+
+            expect(stalePollSignal?.aborted).toBe(true);
+            expect(rendered.result.current.value).not.toBe('stale-poll');
+        });
+
+        it('deduplicates shared polling consumers within each RequestExtras identity', async () => {
+            vi.useFakeTimers();
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [],
+                nested: [],
+                polling_interval: 1,
+                uid: 'polling-extras-derived',
+                variables: [],
+            };
+            const requestsByExtras = new Map<string, number>();
+            server.use(
+                http.post('/api/core/derived-variable/polling-extras-derived', ({ request }) => {
+                    const extras = request.headers.get('X-Dara-Test')!;
+                    requestsByExtras.set(extras, (requestsByExtras.get(extras) ?? 0) + 1);
+                    return HttpResponse.json({
+                        cache_key: extras,
+                        value: requestsByExtras.get(extras),
+                    });
+                })
+            );
+
+            function Consumer({ testId }: { testId: string }): JSX.Element {
+                const [value] = useVariable<number>(variable);
+                return <span data-testid={testId}>{value}</span>;
+            }
+
+            wrappedRender(
+                <>
+                    <RequestExtrasProvider options={{ headers: { 'X-Dara-Test': 'shared' } }}>
+                        <Consumer testId="shared-a" />
+                        <Consumer testId="shared-b" />
+                    </RequestExtrasProvider>
+                    <RequestExtrasProvider options={{ headers: { 'X-Dara-Test': 'other' } }}>
+                        <Consumer testId="other" />
+                    </RequestExtrasProvider>
+                </>
+            );
+
+            await vi.waitFor(() => {
+                expect(requestsByExtras.get('shared')).toBe(1);
+                expect(requestsByExtras.get('other')).toBe(1);
+            });
+
+            act(() => vi.advanceTimersByTime(1200));
+            await vi.waitFor(() => {
+                expect(requestsByExtras.get('shared')).toBe(2);
+                expect(requestsByExtras.get('other')).toBe(2);
+            });
+        });
+
         it('should support SwitchVariable as polling_interval and stop polling when disabled', async () => {
             vi.useFakeTimers();
             const pollingEnabled: Variable<boolean> = {

--- a/packages/dara-core/tests/js/use-variable.spec.tsx
+++ b/packages/dara-core/tests/js/use-variable.spec.tsx
@@ -896,6 +896,41 @@ describe('useVariable', () => {
             expect(slowPollSignal?.aborted).toBe(true);
         });
 
+        it('aborts the first DerivedVariable request when its suspended owner unmounts', async () => {
+            vi.useFakeTimers();
+            let firstSignal: AbortSignal | undefined;
+            server.use(
+                http.post('/api/core/derived-variable/suspended-derived', async ({ request }) => {
+                    firstSignal = request.signal;
+                    await new Promise<void>((resolve) => {
+                        if (request.signal.aborted) {
+                            resolve();
+                        } else {
+                            request.signal.addEventListener('abort', () => resolve(), { once: true });
+                        }
+                    });
+                    return HttpResponse.json({ cache_key: 'aborted', value: 'old' });
+                })
+            );
+
+            const variable: DerivedVariable = {
+                __typename: 'DerivedVariable',
+                deps: [],
+                nested: [],
+                polling_interval: 1,
+                uid: 'suspended-derived',
+                variables: [],
+            };
+            const rendered = renderHook(() => useVariable<string>(variable), { wrapper: Wrapper });
+
+            await act(async () => vi.advanceTimersByTimeAsync(20));
+            await vi.waitFor(() => expect(firstSignal).toBeDefined());
+            rendered.unmount();
+            act(() => vi.advanceTimersByTime(0));
+
+            expect(firstSignal?.aborted).toBe(true);
+        });
+
         it('aborts a slow poll for a dependency change and does not publish its stale result', async () => {
             vi.useFakeTimers();
             const dependency: Variable<number> = {

--- a/packages/dara-core/tests/js/utils/wrapped-render.tsx
+++ b/packages/dara-core/tests/js/utils/wrapped-render.tsx
@@ -15,6 +15,7 @@ import { ThemeProvider, theme } from '@darajs/styled-components';
 
 import { preloadComponents } from '@/shared/dynamic-component/dynamic-component';
 import { PathParamSync, StoreProviders } from '@/shared/interactivity/persistence';
+import { beginPollOwner, keepPollOwner, releasePollOwner } from '@/shared/interactivity/polling';
 import { type Deferred, deferred, useUrlSync } from '@/shared/utils';
 
 import { NavigateTo, ResetVariables, TriggerVariable, UpdateVariable } from '../../../js/actions';
@@ -133,6 +134,12 @@ export const Wrapper = ({ children, client, withRouter = true, withTaskCtx = tru
     const queryClient = new QueryClient();
 
     const variables = useRef<Set<string>>(new Set());
+    const [pollingOwner] = useState(() => Symbol('test-wrapper'));
+    beginPollOwner(pollingOwner);
+    useEffect(() => {
+        keepPollOwner(pollingOwner);
+    });
+    useEffect(() => () => releasePollOwner(pollingOwner), [pollingOwner]);
 
     let child = children;
 
@@ -154,7 +161,7 @@ export const Wrapper = ({ children, client, withRouter = true, withTaskCtx = tru
     if (withTaskCtx) {
         child = (
             <GlobalTaskProvider>
-                <VariableCtx.Provider value={{ variables }}>{child}</VariableCtx.Provider>
+                <VariableCtx.Provider value={{ pollingOwner, variables }}>{child}</VariableCtx.Provider>
             </GlobalTaskProvider>
         );
     }

--- a/packages/dara-core/tests/js/utils/wrapped-render.tsx
+++ b/packages/dara-core/tests/js/utils/wrapped-render.tsx
@@ -5,8 +5,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { type RenderOptions, type RenderResult, render } from '@testing-library/react';
-import React, { type ComponentType, type ReactElement, type ReactNode, useEffect, useRef } from 'react';
-import { useState } from 'react';
+import React, { type ComponentType, type ReactElement, type ReactNode, useRef } from 'react';
 import { RouterProvider, createBrowserRouter } from 'react-router';
 import { RecoilRoot } from 'recoil';
 import { RecoilURLSync } from 'recoil-sync';
@@ -15,7 +14,7 @@ import { ThemeProvider, theme } from '@darajs/styled-components';
 
 import { preloadComponents } from '@/shared/dynamic-component/dynamic-component';
 import { PathParamSync, StoreProviders } from '@/shared/interactivity/persistence';
-import { beginPollOwner, keepPollOwner, releasePollOwner } from '@/shared/interactivity/polling';
+import { usePollScope } from '@/shared/interactivity/polling';
 import { type Deferred, deferred, useUrlSync } from '@/shared/utils';
 
 import { NavigateTo, ResetVariables, TriggerVariable, UpdateVariable } from '../../../js/actions';
@@ -134,12 +133,7 @@ export const Wrapper = ({ children, client, withRouter = true, withTaskCtx = tru
     const queryClient = new QueryClient();
 
     const variables = useRef<Set<string>>(new Set());
-    const [pollingOwner] = useState(() => Symbol('test-wrapper'));
-    beginPollOwner(pollingOwner);
-    useEffect(() => {
-        keepPollOwner(pollingOwner);
-    });
-    useEffect(() => () => releasePollOwner(pollingOwner), [pollingOwner]);
+    const pollScope = usePollScope();
 
     let child = children;
 
@@ -161,7 +155,7 @@ export const Wrapper = ({ children, client, withRouter = true, withTaskCtx = tru
     if (withTaskCtx) {
         child = (
             <GlobalTaskProvider>
-                <VariableCtx.Provider value={{ pollingOwner, variables }}>{child}</VariableCtx.Provider>
+                <VariableCtx.Provider value={{ pollScope, variables }}>{child}</VariableCtx.Provider>
             </GlobalTaskProvider>
         );
     }


### PR DESCRIPTION
## Motivation and Context

This is the top PR in the native GitHub stack:

1. #674 — StreamVariable reconnect/transport reliability
2. #677 — this polling-backpressure and route-cancellation change

This draft intentionally targets `codex/fix-stream-variable-reconnect` and depends on #674.

DerivedVariable and Python-component polling previously used fixed-rate `setInterval` invalidation. A new selector execution could start while the prior request was still pending, and the DerivedVariable RxJS `switchMap` only unsubscribed from the old Promise—it could not cancel the underlying fetch. When response latency exceeded the polling interval, browser requests and backend computations piled up and could later arrive in bursts.

Rapid navigation exposed a related ownership bug in the route loader. If its NDJSON stream had already resolved the template or actions, aborting the stream tried to reject those handles again and raised `Deferred already resolved`.

## Implementation Description

- Add one `Poller` shared by DerivedVariable and Python-component polling, keyed by rendered identity and request extras.
- Keep one poll request in flight per key. Busy ticks request at most one trailing run, and ordinary polls use fixed delay from request completion.
- Pause timers while the document is hidden and run once when it becomes visible.
- Apply bounded ±10% client jitter, exponential error backoff capped at 60 seconds, success reset, and `Retry-After` support.
- Give each request generation an owned `AbortController`; pass its signal through fetches and task-result requests, abort on final unmount/navigation, and allow React StrictMode to reacquire ownership for one macrotask.
- Let real dependency changes supersede slow polling at once. Generation checks block stale writes, while an older selector evaluation adopts the newest completed result.
- Replace the uncancellable RxJS Promise switch with a small per-selector startup delay that keeps started request generations separate.
- Make route-handle settlement status-aware. Abort now rejects only pending handles, cancels the NDJSON reader explicitly, and leaves already-settled template, action, DerivedVariable, and Python-component data intact.
- Keep manual refresh behavior unchanged and leave unrelated fixed-rate `useInterval` consumers alone.

## Before/After Evidence and Impact

The old path emitted every second regardless of request lifetime. Holding a response open for more than ten intervals could start work on every tick.

The deterministic regression harness uses a one-second interval and holds the first poll response open:

- DerivedVariable: after ten more simulated seconds, total requests stayed at `2` (initial load plus the active poll) and peak poll concurrency stayed at `1`.
- Python component: the same case stayed at `2` total requests and peak poll concurrency `1`.
- Repeated ticks while busy lead to exactly one trailing run.
- Hidden tabs stop polling and run once after becoming visible.
- Active slow requests receive an aborted signal on final unmount.
- Rapid route changes can abort a partly read stream without double-settling resolved handles; the reader is canceled and the latest navigation wins.

Slow upstreams now apply backpressure instead of building browser, proxy, and backend queues. The UI keeps the last good value during a failed poll, refreshes promptly after visibility or input changes, and cannot be rolled back by a stale response. Normal navigation aborts no longer leak an uncaught `Deferred already resolved` error.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- Focused deterministic suites: 4 files, 82 tests passed.
- Poller tests cover one active request and one trailing run, fixed delay, hidden-tab pause/resume, error backoff, success reset, `Retry-After`, bounded jitter, unmount/navigation abort, chained input changes, StrictMode ownership, shared-consumer reuse, and request-extras isolation.
- DerivedVariable and Python-component integration tests cover slow-request concurrency, suspended initial-request abort, input changes during a poll, stale-result protection, shared/nested consumers, and distinct request-extras.
- Route-loader tests cover abort after template/actions and some preload handles settle, abort before any chunks, pending-handle rejection, body cancellation, and latest-navigation wins.
- Complete Dara Core JS suite: 33 files, 383 tests passed.
- Dara Core type checking and touched-file type-aware lint passed.
- Full repository JS lint and repository-wide JS formatting checks passed.
- Dara Core production build completed successfully.
- `git diff --check` passed.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

N/A — request scheduling and lifecycle behavior only.
