### PR TITLE
fix: DO-12796 - retain OIDC logout ownership until document unload

### DIFF
--- a/packages/dara-core/js/auth/oidc/oidc-logout.tsx
+++ b/packages/dara-core/js/auth/oidc/oidc-logout.tsx
@@ -8,6 +8,18 @@ import { revokeSession } from '../auth';
 import { runLogout } from '../session-state';
 
 /**
+ * Navigate to a new document and resolve when the current document starts to unload.
+ *
+ * @param url target document URL
+ */
+function navigateDocument(url: string): Promise<void> {
+    return new Promise((resolve) => {
+        window.addEventListener('pagehide', () => resolve(), { once: true });
+        window.location.href = url;
+    });
+}
+
+/**
  * Auth component that handles OIDC logout.
  *
  * If the IDP supports RP-Initiated Logout, redirects to the IDP's end_session_endpoint
@@ -27,7 +39,7 @@ function OIDCAuthLogout(): JSX.Element {
                 const loginUrl = new URL('/login', window.location.origin);
                 const finalRedirectUrl = new URL(responseData.redirect_uri);
                 finalRedirectUrl.searchParams.append('post_logout_redirect_uri', loginUrl.toString());
-                window.location.href = finalRedirectUrl.toString();
+                await navigateDocument(finalRedirectUrl.toString());
                 return;
             }
 

--- a/packages/dara-core/tests/js/auth.spec.tsx
+++ b/packages/dara-core/tests/js/auth.spec.tsx
@@ -1,5 +1,10 @@
+import { render, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
+import { MemoryRouter } from 'react-router';
+import { RecoilRoot } from 'recoil';
+
+import { ThemeProvider, theme } from '@darajs/styled-components';
 
 import {
     getSessionIdentifier,
@@ -12,7 +17,9 @@ import {
     setSessionIdentifier,
     verifySessionToken,
 } from '@/auth';
+import OIDCAuthLogout from '@/auth/oidc/oidc-logout';
 import { getAuthOriginRecommendation, shouldWarnAboutInsecureAuthContext } from '@/auth/origin-security';
+import GlobalTaskProvider from '@/shared/context/global-task-context';
 
 const server = setupServer();
 
@@ -319,6 +326,48 @@ describe('handleAuthErrors', () => {
         finishNavigation();
         await logout;
         expect(isLoggingOut()).toBe(false);
+    });
+
+    it('keeps logout navigation ownership until an external OIDC navigation starts unloading', async () => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            enumerable: true,
+            value: new URL('https://test.com/custom-auth/logOUT'),
+        });
+        server.use(
+            http.post('/api/auth/revoke-session', () => {
+                return HttpResponse.json({ redirect_uri: 'https://idp.test/logout' });
+            })
+        );
+
+        render(
+            <ThemeProvider theme={theme}>
+                <RecoilRoot>
+                    <GlobalTaskProvider>
+                        <MemoryRouter>
+                            <OIDCAuthLogout />
+                        </MemoryRouter>
+                    </GlobalTaskProvider>
+                </RecoilRoot>
+            </ThemeProvider>
+        );
+
+        const externalLogoutUrl = 'https://idp.test/logout?post_logout_redirect_uri=https%3A%2F%2Ftest.com%2Flogin';
+        await waitFor(() => {
+            expect(window.location.href).toBe(externalLogoutUrl);
+        });
+        expect(isLoggingOut()).toBe(true);
+
+        const handled = await handleAuthError('expired', 401);
+
+        expect(handled).toBe(true);
+        expect(window.location.href).toBe(externalLogoutUrl);
+        expect(isLoggingOut()).toBe(true);
+
+        window.dispatchEvent(new Event('pagehide'));
+        await waitFor(() => {
+            expect(isLoggingOut()).toBe(false);
+        });
     });
 
     it('still redirects authorization failures during logout to the error page', async () => {


### PR DESCRIPTION
## Motivation and Context

External OIDC logout navigation can leave the browser on the logout document for a short time after assigning `window.location.href`.

The logout callback previously completed as soon as it assigned the URL. This released logout ownership before document unload started. A delayed authentication failure could then start a competing login redirect.

## Implementation Description

- Add `navigateDocument()` for external OIDC navigation.
- Register a one-time `pagehide` listener before assigning `window.location.href`.
- Keep logout ownership active until the current document starts to unload.
- Preserve the route-independent logout transition design.
- Add a component-level regression test for the external OIDC branch.
- Verify that a stale authentication failure cannot replace the external logout URL before `pagehide`.
- Verify that logout ownership ends after `pagehide`.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

- Ran `./node_modules/.bin/vitest --run tests/js/auth.spec.tsx` from `packages/dara-core`. All 23 tests passed.
- Ran type-aware Oxlint on the changed implementation and test files.
- Ran `pnpm lerna run format:check`. All workspace formatting checks passed.
- Ran `git diff --check`.
- Ran `make lint-js`. It reported existing type errors in unrelated files outside this change.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.

## Screenshots (if appropriate):

Not applicable.
