### PR TITLE
Security: DO-12947 escape bootstrap JSON in HTML

### DIFF
--- a/packages/dara-core/changelog.md
+++ b/packages/dara-core/changelog.md
@@ -2,6 +2,10 @@
 title: Changelog
 ---
 
+## NEXT
+
+- Fixed bootstrap JSON strings escaping their HTML script element.
+
 ## 1.29.9
 
 - Fixed stale authentication requests interrupting logout and sending users back through a login/logout loop.

--- a/packages/dara-core/dara/core/main.py
+++ b/packages/dara-core/dara/core/main.py
@@ -544,7 +544,11 @@ def _start_application(config: Configuration):
             'build_mode': build_cache.build_config.mode,
             'build_dev': build_cache.build_config.dev,
         }
-        json_template_data = json.dumps(jsonable_encoder(template_data))
+        # HTML parsers recognize closing script tags even inside JSON strings. Escape
+        # HTML delimiters after serialization so bootstrap data cannot end its element.
+        json_template_data = json.dumps(jsonable_encoder(template_data)).translate(
+            str.maketrans({'<': r'\u003c', '>': r'\u003e', '&': r'\u0026', '\u2028': r'\u2028', '\u2029': r'\u2029'})
+        )
 
         # For any unmatched route then serve the app to the user if we have any pages to serve
         # (Required for the chosen routing system in the UI)

--- a/packages/dara-core/tests/python/test_main.py
+++ b/packages/dara-core/tests/python/test_main.py
@@ -262,6 +262,37 @@ async def test_dara_data_properjs(monkeypatch: pytest.MonkeyPatch, config: Confi
                     await _check_dara_data(client)
 
 
+@pytest.mark.parametrize('deploy', [False, True])
+async def test_bootstrap_data_cannot_escape_script(
+    config: Configuration, monkeypatch: pytest.MonkeyPatch, deploy: bool
+):
+    """Untrusted bootstrap strings survive HTML parsing without creating executable markup."""
+    from fastapi_vite_dara.loader import ViteLoader
+
+    value = '</ScRiPt><script id="injected">alert(1)</script><!-- & > \u2028\u2029'
+    config.title = value
+    if deploy:
+        monkeypatch.setenv('DARA_DOCKER_MODE', 'TRUE')
+    else:
+        monkeypatch.delenv('DARA_DOCKER_MODE', raising=False)
+
+    loader = Mock()
+    loader.generate_vite_ws_client.return_value = ''
+    loader.generate_vite_asset.return_value = ''
+    loader.generate_vite_react_hmr.return_value = ''
+    with patch('dara.core.main.rebuild_js'), patch.object(ViteLoader, '__new__', return_value=loader):
+        async with AsyncClient(_start_application(config)) as client:
+            response = await client.get('/')
+
+    assert response.status_code == 200
+    parser = DaraDataParser()
+    parser.feed(response.text)
+    assert parser.dara_data['title'] == value
+    assert '<script id="injected">' not in response.text
+    script = response.text.split('id="__DARA_DATA__"', 1)[1].split('>', 1)[1].split('</script>', 1)[0]
+    assert not any(char in script for char in '<>&\u2028\u2029')
+
+
 async def test_dev_server_handshake_renders_one_mismatch_page(
     monkeypatch: pytest.MonkeyPatch,
     config: Configuration,


### PR DESCRIPTION
## Motivation and Context

The bootstrap data is serialized with `json.dumps` into an inline `<script id="__DARA_DATA__">` element. The HTML parser tokenizes the page before JavaScript runs and ends a script element at the first `</script` it meets, even inside a JSON string. Any bootstrap string containing `</script>` therefore closed the element early and the rest was parsed as new markup. `U+2028` and `U+2029` are valid in JSON but are line terminators in older JavaScript, so they could also break the inline script.

The payload (title, theme, router, context components, project name and build flags) is written by the app developer, so this is not a request-driven XSS today. It is still worth fixing at the serialization boundary: theme and router values may come from environment or configuration at startup, and a legitimate title such as `A <b> tag & more` should render rather than break the page.

## Implementation Description

After JSON serialization, `<`, `>`, `&`, `U+2028` and `U+2029` are replaced with their JSON unicode escapes. The JSON stays valid and the browser decodes the escapes, so the original values reach the application unchanged and no embedded string can terminate the script element. This is the same approach as Django's `json_script`.

Regression tests request HTML in both rendering modes with a title containing `</ScRiPt>`, an injected script tag, `&`, `>` and both line separators, and assert the parsed bootstrap data round-trips while the response contains no injected element and no unescaped delimiters inside the data script.

## Any new dependencies Introduced

None.

## How Has This Been Tested?

Bootstrap and embedded-data tests pass, along with Python lint and format checks.

## PR Checklist:

- [x] I have implemented all requirements? (see JIRA, project documentation).
- [x] I am not affecting someone else's work, If I am, they are included as a reviewer.
- [x] I have added relevant tests (unit, integration or regression).
- [x] I have added comments to all the bits that are hard to follow.
- [x] I have added/updated Documentation.
- [x] I have updated the appropriate changelog with a line for my changes.
